### PR TITLE
GVFS serialize status updates

### DIFF
--- a/t/t7524-serialized-status.sh
+++ b/t/t7524-serialized-status.sh
@@ -269,4 +269,16 @@ EOF
 
 '
 
+test_expect_success 'renames' '
+	git init rename_test &&
+	echo OLDNAME >rename_test/OLDNAME &&
+	git -C rename_test add OLDNAME &&
+	git -C rename_test commit -m OLDNAME &&
+	git -C rename_test mv OLDNAME NEWNAME &&
+	git -C rename_test status --serialize=renamed.dat >output.1 &&
+	echo DIRT >rename_test/DIRT &&
+	git -C rename_test status --deserialize=renamed.dat >output.2 &&
+	test_i18ncmp output.1 output.2
+'
+
 test_done

--- a/wt-status-deserialize.c
+++ b/wt-status-deserialize.c
@@ -200,6 +200,7 @@ static int wt_deserialize_v1_changed_items(const struct wt_status *cmd_s,
 		d->worktree_status = ntohl(sd->fixed.worktree_status);
 		d->index_status = ntohl(sd->fixed.index_status);
 		d->stagemask = ntohl(sd->fixed.stagemask);
+		d->rename_status = ntohl(sd->fixed.rename_status);
 		d->rename_score = ntohl(sd->fixed.rename_score);
 		d->mode_head = ntohl(sd->fixed.mode_head);
 		d->mode_index = ntohl(sd->fixed.mode_index);
@@ -218,10 +219,11 @@ static int wt_deserialize_v1_changed_items(const struct wt_status *cmd_s,
 		
 		trace_printf_key(
 			&trace_deserialize,
-			"change: %d %d %d %d %o %o %o %d %d %s %s '%s' '%s'",
+			"change: %d %d %d %d %d %o %o %o %d %d %s %s '%s' '%s'",
 			d->worktree_status,
 			d->index_status,
 			d->stagemask,
+			d->rename_status,
 			d->rename_score,
 			d->mode_head,
 			d->mode_index,

--- a/wt-status-deserialize.c
+++ b/wt-status-deserialize.c
@@ -536,6 +536,7 @@ static int wt_deserialize_fd(const struct wt_status *cmd_s, struct wt_status *de
 	/* show_branch */
 	/* show_stash */
 	/* hints */
+	/* ahead_behind_flags */
 	if (cmd_s->detect_rename != des_s->detect_rename) {
 		trace_printf_key(&trace_deserialize, "reject: detect_rename");
 		return DESERIALIZE_ERR;

--- a/wt-status-serialize.c
+++ b/wt-status-serialize.c
@@ -48,6 +48,7 @@ static void wt_serialize_v1_header(struct wt_status *s, int fd)
 	/* show_branch */
 	/* show_stash */
 	packet_write_fmt(fd, "hints %d\n", s->hints);
+	/* ahead_behind_flags */
 	packet_write_fmt(fd, "detect_rename %d\n", s->detect_rename);
 	packet_write_fmt(fd, "rename_score %d\n", s->rename_score);
 	packet_write_fmt(fd, "rename_limit %d\n", s->rename_limit);

--- a/wt-status-serialize.c
+++ b/wt-status-serialize.c
@@ -78,10 +78,11 @@ static inline void wt_serialize_v1_changed(struct wt_status *s, int fd,
 	int len_path, len_rename_source;
 
 	trace_printf_key(&trace_serialize,
-		"change: %d %d %d %d %o %o %o %d %d %s %s '%s' '%s'",
+		"change: %d %d %d %d %d %o %o %o %d %d %s %s '%s' '%s'",
 		d->worktree_status,
 		d->index_status,
 		d->stagemask,
+		d->rename_status,
 		d->rename_score,
 		d->mode_head,
 		d->mode_index,
@@ -96,6 +97,7 @@ static inline void wt_serialize_v1_changed(struct wt_status *s, int fd,
 	sd.fixed.worktree_status       = htonl(d->worktree_status);
 	sd.fixed.index_status          = htonl(d->index_status);
 	sd.fixed.stagemask             = htonl(d->stagemask);
+	sd.fixed.rename_status         = htonl(d->rename_status);
 	sd.fixed.rename_score          = htonl(d->rename_score);
 	sd.fixed.mode_head             = htonl(d->mode_head);
 	sd.fixed.mode_index            = htonl(d->mode_index);

--- a/wt-status.h
+++ b/wt-status.h
@@ -158,6 +158,7 @@ struct wt_status_serialize_data_fixed
 	uint32_t worktree_status;
 	uint32_t index_status;
 	uint32_t stagemask;
+	uint32_t rename_status;
 	uint32_t rename_score;
 	uint32_t mode_head;
 	uint32_t mode_index;


### PR DESCRIPTION
Update the status serialization cache to contain the new rename_status field.
This allows "git status --deserialize" to correctly report renames.

Also include minor commit to update comments around the ahead_behind_flags
in the status cache header record.