### PR TITLE
status: deserialization wait

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -3378,6 +3378,22 @@ status.deserializePath::
 	`--deserialize=<path>` on the command line.  If the cache file is
 	invalid or stale, git will fall-back and compute status normally.
 
+status.deserializeWait::
+	EXPERIMENTAL, Specifies what `git status --deserialize` should do
+	if the serialization cache file is stale and whether it should
+	fall-back and compute status normally.  This will be overridden by
+	`--deserialize-wait=<value>` on the command line.
++
+--
+* `fail` - cause git to exit with an error when the status cache file
+is stale; this is intended for testing and debugging.
+* `block` - cause git to spin and periodically retry the cache file
+every 100 ms; this is intended to help coordinate with another git
+instance concurrently computing the cache file.
+* `no` - to immediately fall-back if cache file is stale.  This is the default.
+* `<timeout>` - time (in tenths of a second) to spin and retry.
+--
+
 stash.showPatch::
 	If this is set to true, the `git stash show` command without an
 	option will show the stash entry in patch form.  Defaults to false.

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -134,6 +134,9 @@ static int do_implicit_deserialize = 0;
 static int do_explicit_deserialize = 0;
 static char *deserialize_path = NULL;
 
+static enum wt_status_deserialize_wait implicit_deserialize_wait = DESERIALIZE_WAIT__UNSET;
+static enum wt_status_deserialize_wait explicit_deserialize_wait = DESERIALIZE_WAIT__UNSET;
+
 /*
  * --serialize | --serialize=<path>
  *
@@ -190,6 +193,40 @@ static int opt_parse_deserialize(const struct option *opt, const char *arg, int 
 
 		do_explicit_deserialize = 1;
 	}
+
+	return 0;
+}
+
+static enum wt_status_deserialize_wait parse_dw(const char *arg)
+{
+	int tenths;
+
+	if (!strcmp(arg, "fail"))
+		return DESERIALIZE_WAIT__FAIL;
+	else if (!strcmp(arg, "block"))
+		return DESERIALIZE_WAIT__BLOCK;
+	else if (!strcmp(arg, "no"))
+		return DESERIALIZE_WAIT__NO;
+
+	/*
+	 * Otherwise, assume it is a timeout in tenths of a second.
+	 * If it contains a bogus value, atol() will return zero
+	 * which is OK.
+	 */
+	tenths = atol(arg);
+	if (tenths < 0)
+		tenths = DESERIALIZE_WAIT__NO;
+	return tenths;
+}
+
+static int opt_parse_deserialize_wait(const struct option *opt,
+				      const char *arg,
+				      int unset)
+{
+	if (unset)
+		explicit_deserialize_wait = DESERIALIZE_WAIT__UNSET;
+	else
+		explicit_deserialize_wait = parse_dw(arg);
 
 	return 0;
 }
@@ -1355,6 +1392,13 @@ static int git_status_config(const char *k, const char *v, void *cb)
 		}
 		return 0;
 	}
+	if (!strcmp(k, "status.deserializewait")) {
+		if (!v || !*v)
+			implicit_deserialize_wait = DESERIALIZE_WAIT__UNSET;
+		else
+			implicit_deserialize_wait = parse_dw(v);
+		return 0;
+	}
 	if (!strcmp(k, "status.showuntrackedfiles")) {
 		if (!v)
 			return config_error_nonbool(k);
@@ -1418,6 +1462,9 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 		{ OPTION_CALLBACK, 0, "deserialize", NULL,
 		  N_("path"), N_("deserialize raw status data from file"),
 		  PARSE_OPT_OPTARG, opt_parse_deserialize },
+		{ OPTION_CALLBACK, 0, "deserialize-wait", NULL,
+		  N_("fail|block|no"), N_("how to wait if status cache file is invalid"),
+		  PARSE_OPT_OPTARG, opt_parse_deserialize_wait },
 		OPT_SET_INT(0, "long", &status_format,
 			    N_("show status in long format (default)"),
 			    STATUS_FORMAT_LONG),
@@ -1525,11 +1572,21 @@ skip_init:
 	}
 
 	if (try_deserialize) {
+		int result;
+		enum wt_status_deserialize_wait dw = implicit_deserialize_wait;
+		if (explicit_deserialize_wait != DESERIALIZE_WAIT__UNSET)
+			dw = explicit_deserialize_wait;
+		if (dw == DESERIALIZE_WAIT__UNSET)
+			dw = DESERIALIZE_WAIT__NO;
+
 		if (s.relative_paths)
 			s.prefix = prefix;
 
-		if (wt_status_deserialize(&s, deserialize_path) == DESERIALIZE_OK)
+		result = wt_status_deserialize(&s, deserialize_path, dw);
+		if (result == DESERIALIZE_OK)
 			return 0;
+		if (dw == DESERIALIZE_WAIT__FAIL)
+			die(_("Rejected status serialization cache"));
 
 		/* deserialize failed, so force the initialization we skipped above. */
 		enable_fscache(1);

--- a/wt-status.h
+++ b/wt-status.h
@@ -182,6 +182,15 @@ struct wt_status_serialize_data
 		     - sizeof(struct wt_status_serialize_data_fixed)];
 };
 
+enum wt_status_deserialize_wait
+{
+	DESERIALIZE_WAIT__UNSET = -3,
+	DESERIALIZE_WAIT__FAIL = -2, /* return error, do not fallback */
+	DESERIALIZE_WAIT__BLOCK = -1, /* unlimited timeout */
+	DESERIALIZE_WAIT__NO = 0, /* immediately fallback */
+	/* any positive value is a timeout in tenths of a second */
+};
+
 /*
  * Serialize computed status scan results using "version 1" format
  * to the given file.
@@ -196,7 +205,8 @@ void wt_status_serialize_v1(int fd, struct wt_status *s);
  * fields.
  */
 int wt_status_deserialize(const struct wt_status *cmd_s,
-			  const char *path);
+			  const char *path,
+			  enum wt_status_deserialize_wait dw);
 
 /*
  * A helper routine for serialize and deserialize to compute


### PR DESCRIPTION
Extend `git status --deserialize` to better handle stale status cache files.

Add new `--deserialize-wait` command line argument and `status.deserializeWait` config setting.
