### PR TITLE
Revert "gvfs: add a perf test for reading the index"

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -972,9 +972,9 @@ core.gvfs::
 	below can be used to turn on specific features.
 +
 --
-	GVFS_SKIP_SHA_ON_INDEX_READ::
+	GVFS_SKIP_SHA_ON_INDEX::
 		Bit value 1
-		Disables the calculation and validation of the sha when reading the index
+		Disables the calculation of the sha when writing the index
 	GVFS_MISSING_OK::
 		Bit value 4
 		Normally git write-tree ensures that the objects referenced by the

--- a/read-cache.c
+++ b/read-cache.c
@@ -1669,9 +1669,6 @@ static int verify_hdr(struct cache_header *hdr, unsigned long size)
 	if (!verify_index_checksum)
 		return 0;
 
-	if (gvfs_config_is_set(GVFS_SKIP_SHA_ON_INDEX))
-		return 0;
-
 	the_hash_algo->init_fn(&c);
 	the_hash_algo->update_fn(&c, hdr, size - the_hash_algo->rawsz);
 	the_hash_algo->final_fn(hash, &c);

--- a/t/perf/p0002-read-cache.sh
+++ b/t/perf/p0002-read-cache.sh
@@ -11,8 +11,4 @@ test_perf "read_cache/discard_cache $count times" "
 	test-tool read-cache $count
 "
 
-test_perf "read_cache/discard_cache $count times with core.gvfs flag on" "
-	git config core.gvfs 1
-	test-read-cache $count
-"
 test_done


### PR DESCRIPTION
Reverts a stale GVFS specific perf test and removes the GVFS specific optimization to avoid computing the SHA1-1 on index load which is no longer needed.