### PR TITLE
virtualfilesystem: check if directory is included

### DIFF
--- a/t/t1092-virtualfilesystem.sh
+++ b/t/t1092-virtualfilesystem.sh
@@ -221,6 +221,8 @@ test_expect_success 'verify folder entries include all files' '
 	cat > expected <<-\EOF &&
 		?? dir1/a
 		?? dir1/b
+		?? dir1/dir2/a
+		?? dir1/dir2/b
 		?? dir1/untracked.txt
 	EOF
 	test_cmp expected actual

--- a/virtualfilesystem.c
+++ b/virtualfilesystem.c
@@ -228,6 +228,10 @@ int is_excluded_from_virtualfilesystem(const char *pathname, int pathlen, int dt
 	}
 
 	if (dtype == DT_DIR) {
+		int ret = is_included_in_virtualfilesystem(pathname, pathlen);
+		if (ret > 0)
+			return 0;
+
 		if (!parent_directory_hashmap.tablesize && virtual_filesystem_data.len)
 			initialize_parent_directory_hashmap(&parent_directory_hashmap, &virtual_filesystem_data);
 		if (!parent_directory_hashmap.tablesize)


### PR DESCRIPTION
Add check to see if a directory is included in the virtualfilesystem
before checking the directory hashmap.  This allows a directory entry
like foo/ to find all untracked files in subdirectories.