### PR TITLE
Avoid `sane_execvp` in `git rebase` and `git stash`

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1068,13 +1068,17 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 	 */
 
 	if (!use_builtin_rebase()) {
-		const char *path = mkpath("%s/git-legacy-rebase",
-					  git_exec_path());
+		struct argv_array args = ARGV_ARRAY_INIT;
+		int code;
 
-		if (sane_execvp(path, (char **)argv) < 0)
-			die_errno(_("could not exec %s"), path);
-		else
-			BUG("sane_execvp() returned???");
+		argv_array_push(&args, mkpath("%s/git-legacy-rebase",
+					      git_exec_path()));
+		argv_array_pushv(&args, argv + 1);
+		code = run_command_v_opt(args.argv, 0);
+		if (code < 0)
+			die_errno(_("could not exec %s"), args.argv[0]);
+		argv_array_clear(&args);
+		exit(code);
 	}
 
 	if (argc == 2 && !strcmp(argv[1], "-h"))

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -1509,13 +1509,17 @@ int cmd_stash(int argc, const char **argv, const char *prefix)
 	};
 
 	if (!use_builtin_stash()) {
-		const char *path = mkpath("%s/git-legacy-stash",
-					  git_exec_path());
+		struct argv_array args = ARGV_ARRAY_INIT;
+		int code;
 
-		if (sane_execvp(path, (char **)argv) < 0)
-			die_errno(_("could not exec %s"), path);
-		else
-			BUG("sane_execvp() returned???");
+		argv_array_push(&args, mkpath("%s/git-legacy-stash",
+					      git_exec_path()));
+		argv_array_pushv(&args, argv + 1);
+		code = run_command_v_opt(args.argv, 0);
+		if (code < 0)
+			die_errno(_("could not exec %s"), args.argv[0]);
+		argv_array_clear(&args);
+		exit(code);
 	}
 
 	prefix = setup_git_directory();


### PR DESCRIPTION
William Baker reported that the non-built-in rebase and stash fail to
run the post-command hook (which is important for VFS for Git, though).

The reason is that an `exec()` will replace the current process by the
newly-exec'ed one (our Windows-specific emulation cannot do that, and
does not even try, so this is only an issue on Linux/macOS). As a
consequence, not even the atexit() handlers are run, including the
one running the post-command hook.

To work around that, let's spawn the legacy rebase/stash and exit with
the reported exit code.
