### PR TITLE
[Do NOT merge] unpack-trees: delete files that exists even when skip worktree bit is on

### DIFF
--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -477,9 +477,8 @@ static int apply_sparse_checkout(struct index_state *istate,
 		 */
 		if (!(ce->ce_flags & CE_UPDATE) && verify_uptodate_sparse(ce, o))
 			return -1;
-		if (!gvfs_config_is_set(GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT))
-			ce->ce_flags |= CE_WT_REMOVE;
 
+		ce->ce_flags |= CE_WT_REMOVE;
 		ce->ce_flags &= ~CE_UPDATE;
 	}
 	if (was_skip_worktree && !ce_skip_worktree(ce)) {
@@ -2058,26 +2057,6 @@ static int deleted_entry(const struct cache_entry *ce,
 	}
 	if (!(old->ce_flags & CE_CONFLICTED) && verify_uptodate(old, o))
 		return -1;
-
-	/*
-	 * When marking entries to remove from the index and the working
-	 * directory this option will take into account what the
-	 * skip-worktree bit was set to so that if the entry has the
-	 * skip-worktree bit set it will not be removed from the working
-	 * directory.  This will allow virtualized working directories to
-	 * detect the change to HEAD and use the new commit tree to show
-	 * the files that are in the working directory.
-	 *
-	 * old is the cache_entry that will have the skip-worktree bit set
-	 * which will need to be preserved when the CE_REMOVE entry is added
-	 */
-	if (gvfs_config_is_set(GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT) &&
-		old &&
-		old->ce_flags & CE_SKIP_WORKTREE) {
-		add_entry(o, old, CE_REMOVE, 0);
-		invalidate_ce_path(old, o);
-		return 1;
-	}
 
 	add_entry(o, ce, CE_REMOVE, 0);
 	invalidate_ce_path(ce, o);


### PR DESCRIPTION
When marking entries in the index for deletion and the skip worktree
bit is on, we still want to check if the file is on disk and delete
it so that the file will not be left and show as an untracked file
when the next status is ran.