### PR TITLE
DO NOT MERGE - Update the fscache to improve performance

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1618,6 +1618,7 @@ skip_init:
 	}
 
 	wt_status_print(&s);
+	enable_fscache(0);
 	return 0;
 }
 

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -206,7 +206,8 @@ static struct fsentry *fsentry_create_list(const struct fsentry *dir,
 	pattern[wlen] = 0;
 
 	/* open find handle */
-	h = FindFirstFileW(pattern, &fdata);
+	h = FindFirstFileExW(pattern, FindExInfoBasic, &fdata, FindExSearchNameMatch,
+		NULL, FIND_FIRST_EX_LARGE_FETCH);
 	if (h == INVALID_HANDLE_VALUE) {
 		err = GetLastError();
 		*dir_not_found = 1; /* or empty directory */

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -2,6 +2,7 @@
 #include "../../hashmap.h"
 #include "../win32.h"
 #include "fscache.h"
+#include "config.h"
 
 static int initialized;
 static volatile long enabled;
@@ -397,7 +398,11 @@ int fscache_enable(int enable)
 	int result;
 
 	if (!initialized) {
+		int fscache = git_env_bool("GIT_TEST_FSCACHE", -1);
+
 		/* allow the cache to be disabled entirely */
+		if (fscache != -1)
+			core_fscache = fscache;
 		if (!core_fscache)
 			return 0;
 

--- a/compat/win32/fscache.c
+++ b/compat/win32/fscache.c
@@ -8,6 +8,10 @@ static int initialized;
 static volatile long enabled;
 static struct hashmap map;
 static CRITICAL_SECTION mutex;
+unsigned int lstat_requests;
+unsigned int opendir_requests;
+unsigned int fscache_requests;
+unsigned int fscache_misses;
 static struct trace_key trace_fscache = TRACE_KEY_INIT(FSCACHE);
 
 /*
@@ -262,6 +266,8 @@ static void fscache_clear(void)
 {
 	hashmap_free(&map, 1);
 	hashmap_init(&map, (hashmap_cmp_fn)fsentry_cmp, NULL, 0);
+	lstat_requests = opendir_requests = 0;
+	fscache_misses = fscache_requests = 0;
 }
 
 /*
@@ -308,6 +314,7 @@ static struct fsentry *fscache_get(struct fsentry *key)
 	int dir_not_found;
 
 	EnterCriticalSection(&mutex);
+	fscache_requests++;
 	/* check if entry is in cache */
 	fse = fscache_get_wait(key);
 	if (fse) {
@@ -370,6 +377,7 @@ static struct fsentry *fscache_get(struct fsentry *key)
 	}
 
 	/* add directory listing to the cache */
+	fscache_misses++;
 	fscache_add(fse);
 
 	/* lookup file entry if requested (fse already points to directory) */
@@ -407,6 +415,8 @@ int fscache_enable(int enable)
 			return 0;
 
 		InitializeCriticalSection(&mutex);
+		lstat_requests = opendir_requests = 0;
+		fscache_misses = fscache_requests = 0;
 		hashmap_init(&map, (hashmap_cmp_fn) fsentry_cmp, NULL, 0);
 		initialized = 1;
 	}
@@ -423,6 +433,10 @@ int fscache_enable(int enable)
 		opendir = dirent_opendir;
 		lstat = mingw_lstat;
 		EnterCriticalSection(&mutex);
+		trace_printf_key(&trace_fscache, "fscache: lstat %u, opendir %u, "
+						 "total requests/misses %u/%u\n",
+				lstat_requests, opendir_requests,
+				fscache_requests, fscache_misses);
 		fscache_clear();
 		LeaveCriticalSection(&mutex);
 	}
@@ -454,6 +468,7 @@ int fscache_lstat(const char *filename, struct stat *st)
 	if (!fscache_enabled(filename))
 		return mingw_lstat(filename, st);
 
+	lstat_requests++;
 	/* split filename into path + name */
 	len = strlen(filename);
 	if (len && is_dir_sep(filename[len - 1]))
@@ -534,6 +549,7 @@ DIR *fscache_opendir(const char *dirname)
 	if (!fscache_enabled(dirname))
 		return dirent_opendir(dirname);
 
+	opendir_requests++;
 	/* prepare name (strip trailing '/', replace '.') */
 	len = strlen(dirname);
 	if ((len == 1 && dirname[0] == '.') ||

--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -18,4 +18,10 @@ void fscache_flush(void);
 DIR *fscache_opendir(const char *dir);
 int fscache_lstat(const char *file_name, struct stat *buf);
 
+/* opaque fscache structure */
+struct fscache;
+
+struct fscache *fscache_getcache(void);
+void fscache_mergecache(struct fscache *dest);
+
 #endif

--- a/compat/win32/fscache.h
+++ b/compat/win32/fscache.h
@@ -1,6 +1,11 @@
 #ifndef FSCACHE_H
 #define FSCACHE_H
 
+/*
+ * The fscache is thread specific. enable_fscache() must be called
+ * for each thread where caching is desired.
+ */
+
 int fscache_enable(int enable);
 #define enable_fscache(x) fscache_enable(x)
 

--- a/preload-index.c
+++ b/preload-index.c
@@ -15,6 +15,8 @@ void preload_index(struct index_state *index, const struct pathspec *pathspec)
 
 #include <pthread.h>
 
+struct fscache *fscache;
+
 /*
  * Mostly randomly chosen maximum thread counts: we
  * cap the parallelism to 20 threads, and we want
@@ -70,7 +72,7 @@ static void *preload_thread(void *_data)
 		mark_fsmonitor_valid(ce);
 	} while (--nr > 0);
 	cache_def_clear(&cache);
-	enable_fscache(0);
+	fscache_mergecache(fscache);
 	return NULL;
 }
 
@@ -82,6 +84,7 @@ void preload_index(struct index_state *index, const struct pathspec *pathspec)
 	if (!core_preload_index)
 		return;
 
+	fscache = fscache_getcache();
 	threads = index->cache_nr / THREAD_COST;
 	if ((index->cache_nr > 1) && (threads < 2) && getenv("GIT_FORCE_PRELOAD_TEST"))
 		threads = 2;

--- a/preload-index.c
+++ b/preload-index.c
@@ -43,6 +43,7 @@ static void *preload_thread(void *_data)
 	if (nr + p->offset > index->cache_nr)
 		nr = index->cache_nr - p->offset;
 
+	enable_fscache(1);
 	do {
 		struct cache_entry *ce = *cep++;
 		struct stat st;
@@ -69,6 +70,7 @@ static void *preload_thread(void *_data)
 		mark_fsmonitor_valid(ce);
 	} while (--nr > 0);
 	cache_def_clear(&cache);
+	enable_fscache(0);
 	return NULL;
 }
 
@@ -91,7 +93,6 @@ void preload_index(struct index_state *index, const struct pathspec *pathspec)
 	offset = 0;
 	work = DIV_ROUND_UP(index->cache_nr, threads);
 	memset(&data, 0, sizeof(data));
-	enable_fscache(1);
 	for (i = 0; i < threads; i++) {
 		struct thread_data *p = data+i;
 		p->index = index;
@@ -109,7 +110,6 @@ void preload_index(struct index_state *index, const struct pathspec *pathspec)
 			die("unable to join threaded lstat");
 	}
 	trace_performance_leave("preload index");
-	enable_fscache(0);
 }
 #endif
 

--- a/t/README
+++ b/t/README
@@ -323,6 +323,9 @@ GIT_TEST_VALIDATE_INDEX_CACHE_ENTRIES=<boolean> checks that cache-tree
 records are valid when the index is written out or after a merge. This
 is mostly to catch missing invalidation. Default is true.
 
+GIT_TEST_FSCACHE=<boolean> exercises the uncommon fscache code path
+which adds a cache below mingw's lstat and dirent implementations.
+
 Naming Tests
 ------------
 


### PR DESCRIPTION
Update the fscache to:

1) use FindFirstFileExW to avoid retrieving the short name
2) switch to a larger buffer to minimize round trips to the kernel
3) enable running the test suite with GIT_TEST_FSCACHE
4) track and report cache requests and hit statistics
5) reduce thread contention

Test PR to build installer for NTFS team to review.