### PR TITLE
[DO NOT MERGE] Check push counts for testing

### DIFF
--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3402,6 +3402,9 @@ int cmd_pack_objects(int argc, const char **argv, const char *prefix)
 	stop_progress(&progress_state);
 	trace2_region_leave("pack-objects", "enumerate-objects", the_repository);
 
+	/* BREAK HERE TO AVOID ACTUALLY PUSHING DURING TESTING */
+	exit(1);
+
 	if (non_empty && !nr_result)
 		return 0;
 	if (nr_result) {

--- a/list-objects.c
+++ b/list-objects.c
@@ -242,6 +242,10 @@ static void add_pending_tree(struct rev_info *revs, struct tree *tree)
 	add_pending_object(revs, &tree->object, "");
 }
 
+static int num_commits = 0;
+static int num_trees = 0;
+static int num_blobs = 0;
+
 static void traverse_trees_and_blobs(struct rev_info *revs,
 				     struct strbuf *base,
 				     show_object_fn show_object,
@@ -271,12 +275,14 @@ static void traverse_trees_and_blobs(struct rev_info *revs,
 			process_tree(revs, (struct tree *)obj, show_object,
 				     base, path, show_data,
 				     filter_fn, filter_data);
+			num_trees++;
 			continue;
 		}
 		if (obj->type == OBJ_BLOB) {
 			process_blob(revs, (struct blob *)obj, show_object,
 				     base, path, show_data,
 				     filter_fn, filter_data);
+			num_blobs++;
 			continue;
 		}
 		die("unknown pending object %s (%s)",
@@ -304,6 +310,7 @@ static void do_traverse(struct rev_info *revs,
 		if (get_commit_tree(commit))
 			add_pending_tree(revs, get_commit_tree(commit));
 		show_commit(commit, show_data);
+		num_commits++;
 
 		if (revs->tree_blobs_in_commit_order)
 			/*
@@ -319,6 +326,10 @@ static void do_traverse(struct rev_info *revs,
 				 show_object, show_data,
 				 filter_fn, filter_data);
 	strbuf_release(&csp);
+
+	fprintf(stderr, "num_commits: %d\n", num_commits);
+	fprintf(stderr, "num_trees: %d\n", num_trees);
+	fprintf(stderr, "num_blobs: %d\n", num_blobs);
 }
 
 void traverse_commit_list(struct rev_info *revs,

--- a/midx.c
+++ b/midx.c
@@ -50,6 +50,8 @@ struct multi_pack_index *load_multi_pack_index(const char *object_dir, int local
 	uint32_t i;
 	const char *cur_pack_name;
 
+	fprintf(stderr, "load_multi_pack_index\n");
+
 	fd = git_open(midx_name);
 
 	if (fd < 0)
@@ -336,6 +338,8 @@ int prepare_multi_pack_index_one(struct repository *r, const char *object_dir, i
 	struct multi_pack_index *m_search;
 	int config_value;
 	static int env_value = -1;
+
+	fprintf(stderr, "prepare_multi_pack_index_one\n");
 
 	if (env_value < 0)
 		env_value = git_env_bool(GIT_TEST_MULTI_PACK_INDEX, 0);

--- a/packfile.c
+++ b/packfile.c
@@ -964,6 +964,9 @@ static void prepare_packed_git(struct repository *r)
 
 	if (r->objects->packed_git_initialized)
 		return;
+
+	fprintf(stderr, "prepare_packed_git\n");
+
 	prepare_multi_pack_index_one(r, r->objects->objectdir, 1);
 	prepare_packed_git_one(r, r->objects->objectdir, 1);
 	prepare_alt_odb(r);

--- a/send-pack.c
+++ b/send-pack.c
@@ -74,6 +74,8 @@ static int pack_objects(int fd, struct ref *refs, struct oid_array *extra, struc
 	int i;
 	int rc;
 
+	argv_array_push(&po.args, "-c");
+	argv_array_push(&po.args, "core.warnAmbiguousRefs=false");
 	argv_array_push(&po.args, "pack-objects");
 	argv_array_push(&po.args, "--all-progress-implied");
 	argv_array_push(&po.args, "--revs");


### PR DESCRIPTION
Creating the PR only to generate a Git for Windows installer that I can use on my box for performance testing.

This counts the number of objects walked during a push, then kills the push before actually sending the pack.