### PR TITLE
send-pack: do not check for sha1 file when GVFS_MISSING_OK set

### DIFF
--- a/send-pack.c
+++ b/send-pack.c
@@ -15,6 +15,7 @@
 #include "sha1-array.h"
 #include "gpg-interface.h"
 #include "cache.h"
+#include "gvfs.h"
 
 int option_parse_push_signed(const struct option *opt,
 			     const char *arg, int unset)
@@ -50,7 +51,7 @@ static int send_pack_config(const char *var, const char *value, void *unused)
 
 static void feed_object(const struct object_id *oid, FILE *fh, int negative)
 {
-	if (negative && !has_sha1_file(oid->hash))
+	if (negative && !gvfs_config_is_set(GVFS_MISSING_OK) && !has_sha1_file(oid->hash))
 		return;
 
 	if (negative)


### PR DESCRIPTION
This is to fix the issue on Mac where the push will hang because the read-object hook process gets spawned and the pack-object process has also been spawned and something, maybe stdin/stdout, get in a deadlock.  Still need to find the smoking gun.

For this fix, it will check the GVFS flag before checking that an object doesn't exist so that it will not download the object.  @derrickstolee I'm not sure how this will affect push performance since it will be sending more negative oids to the pack-object process.  Still need to dig into the pack-object code to see determine if this is the right change.
