### PR TITLE
virtualfilesystem: fix case where directories not handled correctly

### DIFF
--- a/t/t1092-virtualfilesystem.sh
+++ b/t/t1092-virtualfilesystem.sh
@@ -348,4 +348,23 @@ test_expect_success 'on folder renamed' '
 	test_cmp expected actual
 '
 
+test_expect_success 'folder with same prefix as file' '
+	clean_repo &&
+	touch dir1.sln &&
+	write_script .git/hooks/virtualfilesystem <<-\EOF &&
+		printf "dir1/\0"
+		printf "dir1.sln\0"
+	EOF
+	git add dir1.sln &&
+	git ls-files -v > actual &&
+	cat > expected <<-\EOF &&
+		H dir1.sln
+		H dir1/file1.txt
+		H dir1/file2.txt
+		S dir2/file1.txt
+		S dir2/file2.txt
+	EOF
+	test_cmp expected actual
+'
+
 test_done

--- a/virtualfilesystem.c
+++ b/virtualfilesystem.c
@@ -273,7 +273,7 @@ void apply_virtualfilesystem(struct index_state *istate)
 			if (buf[i - 1] == '/') {
 				if (ignore_case)
 					adjust_dirname_case(istate, entry);
-				pos = index_name_pos(istate, entry, len - 1);
+				pos = index_name_pos(istate, entry, len);
 				if (pos < 0) {
 					pos = -pos - 1;
 					while (pos < istate->cache_nr && !fspathncmp(istate->cache[pos]->name, entry, len)) {


### PR DESCRIPTION
The vfs does not correctly handle the case when there is a file
that begins with the same prefix as a directory. For example, the
following setup would encounter this issue:

    A directory contains a file named `dir1.sln` and a directory
    named `dir1/`.

    The directory `dir1` contains other files.

    The directory `dir1` is in the virtual file system list

The contents of `dir1` should be in the virtual file system, but
it is not. The contents of this directory do not have the skip
worktree bit cleared as expected. The problem is in the
`apply_virtualfilesystem(…)` function where it does not include
the trailing slash of the directory name when looking up the
position in the index to start clearing the skip worktree bit.

This fix is it include the trailing slash when finding the first
index entry from `index_name_pos(...)`.