### PR TITLE
[DO NOT MERGE] prototype push algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -980,6 +980,7 @@ LIB_OBJS += transport-helper.o
 LIB_OBJS += tree-diff.o
 LIB_OBJS += tree.o
 LIB_OBJS += tree-walk.o
+LIB_OBJS += tree-walk-sparse.o
 LIB_OBJS += unpack-trees.o
 LIB_OBJS += upload-pack.o
 LIB_OBJS += url.o

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -18,6 +18,7 @@
 #include "list-objects.h"
 #include "list-objects-filter.h"
 #include "list-objects-filter-options.h"
+#include "tree-walk-sparse.h"
 #include "pack-objects.h"
 #include "progress.h"
 #include "refs.h"
@@ -2988,6 +2989,11 @@ static void get_object_list(int ac, const char **av)
 	struct rev_info revs;
 	char line[1000];
 	int flags = 0;
+<<<<<<< HEAD
+=======
+	int save_warning;
+	int sparse = 1; /* TODO: fix */
+>>>>>>> temp: some of the logic is wired
 
 	init_revisions(&revs, NULL);
 	save_commit_buffer = 0;
@@ -3027,7 +3033,11 @@ static void get_object_list(int ac, const char **av)
 
 	if (prepare_revision_walk(&revs))
 		die(_("revision walk setup failed"));
-	mark_edges_uninteresting(&revs, show_edge);
+
+	if (sparse)
+		mark_edges_uninteresting_sparse(&revs, show_edge);
+	else
+		mark_edges_uninteresting(&revs, show_edge);
 
 	if (!fn_show_object)
 		fn_show_object = show_object;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -81,7 +81,6 @@ static int depth = 50;
 static int delta_search_threads;
 static int pack_to_stdout;
 static int sparse;
-static int thin;
 static int num_preferred_base;
 static struct progress *progress_state;
 
@@ -2995,8 +2994,6 @@ static void get_object_list(int ac, const char **av)
 	struct rev_info revs;
 	char line[1000];
 	int flags = 0;
-	int save_warning;
-	int sparse = 1; /* TODO: fix */
 
 	init_revisions(&revs, NULL);
 	save_commit_buffer = 0;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -80,6 +80,8 @@ static unsigned long pack_size_limit;
 static int depth = 50;
 static int delta_search_threads;
 static int pack_to_stdout;
+static int sparse;
+static int thin;
 static int num_preferred_base;
 static struct progress *progress_state;
 
@@ -2647,6 +2649,10 @@ static int git_pack_config(const char *k, const char *v, void *cb)
 			    pack_idx_opts.version);
 		return 0;
 	}
+	if (!strcmp(k, "pack.sparse")) {
+		sparse = git_config_bool(k, v);
+		return 0;
+	}
 	return git_default_config(k, v, cb);
 }
 
@@ -2989,11 +2995,8 @@ static void get_object_list(int ac, const char **av)
 	struct rev_info revs;
 	char line[1000];
 	int flags = 0;
-<<<<<<< HEAD
-=======
 	int save_warning;
 	int sparse = 1; /* TODO: fix */
->>>>>>> temp: some of the logic is wired
 
 	init_revisions(&revs, NULL);
 	save_commit_buffer = 0;
@@ -3034,7 +3037,7 @@ static void get_object_list(int ac, const char **av)
 	if (prepare_revision_walk(&revs))
 		die(_("revision walk setup failed"));
 
-	if (sparse && thin)
+	if (sparse)
 		mark_edges_uninteresting_sparse(&revs, show_edge);
 	else
 		mark_edges_uninteresting(&revs, show_edge);
@@ -3192,6 +3195,8 @@ int cmd_pack_objects(int argc, const char **argv, const char *prefix)
 		{ OPTION_CALLBACK, 0, "unpack-unreachable", NULL, N_("time"),
 		  N_("unpack unreachable objects newer than <time>"),
 		  PARSE_OPT_OPTARG, option_parse_unpack_unreachable },
+		OPT_BOOL(0, "sparse", &sparse,
+			 N_("use sparse algorithm")),
 		OPT_BOOL(0, "thin", &thin,
 			 N_("create thin packs")),
 		OPT_BOOL(0, "shallow", &shallow,

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3034,7 +3034,7 @@ static void get_object_list(int ac, const char **av)
 	if (prepare_revision_walk(&revs))
 		die(_("revision walk setup failed"));
 
-	if (sparse)
+	if (sparse && thin)
 		mark_edges_uninteresting_sparse(&revs, show_edge);
 	else
 		mark_edges_uninteresting(&revs, show_edge);

--- a/list-objects.c
+++ b/list-objects.c
@@ -204,6 +204,7 @@ static void mark_edge_parents_uninteresting(struct commit *commit,
 	}
 }
 
+extern int num_walked;
 void mark_edges_uninteresting(struct rev_info *revs, show_edge_fn show_edge)
 {
 	struct commit_list *list;
@@ -235,6 +236,8 @@ void mark_edges_uninteresting(struct rev_info *revs, show_edge_fn show_edge)
 			}
 		}
 	}
+
+	fprintf(stderr, "num_walked: %d\n", num_walked);
 }
 
 static void add_pending_tree(struct rev_info *revs, struct tree *tree)

--- a/revision.c
+++ b/revision.c
@@ -51,6 +51,7 @@ static void mark_blob_uninteresting(struct blob *blob)
 	blob->object.flags |= UNINTERESTING;
 }
 
+extern int num_walked;
 static void mark_tree_contents_uninteresting(struct tree *tree)
 {
 	struct tree_desc desc;
@@ -59,6 +60,7 @@ static void mark_tree_contents_uninteresting(struct tree *tree)
 	if (parse_tree_gently(tree, 1) < 0)
 		return;
 
+	num_walked++;
 	init_tree_desc(&desc, tree->buffer, tree->size);
 	while (tree_entry(&desc, &entry)) {
 		switch (object_type(entry.mode)) {

--- a/tree-walk-sparse.c
+++ b/tree-walk-sparse.c
@@ -77,6 +77,7 @@ static void mark_tree_uninteresting_shallow(struct tree *tree)
 	/* don't recurse now! */
 }
 
+int num_walked = 0;
 static void walk_tree_contents(struct repository *r,
 			       struct tree *tree,
 			       struct names_and_oids *no)
@@ -86,6 +87,8 @@ static void walk_tree_contents(struct repository *r,
 
 	if (parse_tree_gently(tree, 1) < 0)
 		return;
+
+	num_walked++;
 
 	init_tree_desc(&desc, tree->buffer, tree->size);
 	while (tree_entry(&desc, &entry)) {
@@ -216,4 +219,6 @@ void mark_edges_uninteresting_sparse(struct rev_info *revs,
 			}
 		}
 	}
+	
+	fprintf(stderr, "num_walked: %d\n", num_walked);
 }

--- a/tree-walk-sparse.c
+++ b/tree-walk-sparse.c
@@ -25,11 +25,11 @@ struct names_and_oids {
 	struct string_list list;
 };
 
-void insert_name_and_oid(struct names_and_oids *no,
+static void insert_name_and_oid(struct names_and_oids *no,
 			 const char *name,
-			 struct tree *tree)
+			 const struct object_id *oid)
 {
-	struct string_list_item *item = string_list_insert(&no->list, name)->util;
+	struct string_list_item *item = string_list_insert(&no->list, name);
 	struct oidset *set; 
 	
 	if (!item->util) {
@@ -40,14 +40,14 @@ void insert_name_and_oid(struct names_and_oids *no,
 		set = item->util;
 	}
 
-	oidset_insert(set, &tree->object.oid);
+	oidset_insert(set, oid);
 }
 
-void init_names_and_oids(struct names_and_oids *no) {
+static  void init_names_and_oids(struct names_and_oids *no) {
 	string_list_init(&no->list, 1);
 }
 
-void free_names_and_oids(struct names_and_oids *no) {
+static void free_names_and_oids(struct names_and_oids *no) {
 	int i; 
 	for (i = 0; i < no->list.nr; i++) {
 		oidset_clear(no->list.items[i].util);
@@ -77,8 +77,9 @@ static void mark_tree_uninteresting_shallow(struct tree *tree)
 	/* don't recurse now! */
 }
 
-static void mark_tree_contents_uninteresting(struct repository *r,
-					     struct tree *tree)
+static void walk_tree_contents(struct repository *r,
+			       struct tree *tree,
+			       struct names_and_oids *no)
 {
 	struct tree_desc desc;
 	struct name_entry entry;
@@ -90,14 +91,17 @@ static void mark_tree_contents_uninteresting(struct repository *r,
 	while (tree_entry(&desc, &entry)) {
 		switch (object_type(entry.mode)) {
 		case OBJ_TREE:
-			/* add to dictionary here! */
-			mark_tree_uninteresting_shallow(lookup_tree(r, entry.oid));
+			insert_name_and_oid(no, entry.path, entry.oid);
+
+			if (tree->object.flags & UNINTERESTING)
+				mark_tree_uninteresting_shallow(lookup_tree(r, entry.oid));
 			break;
 		case OBJ_BLOB:
-			mark_blob_uninteresting(lookup_blob(r, entry.oid));
+			if (tree->object.flags & UNINTERESTING)
+				mark_blob_uninteresting(lookup_blob(r, entry.oid));
 			break;
 		default:
-			/* Subprojct commit - not in this repository */
+			/* Subproject commit - not in this repository */
 			break;
 		}
 	}
@@ -105,18 +109,60 @@ static void mark_tree_contents_uninteresting(struct repository *r,
 	free_tree_buffer(tree);
 }
 
+static void tree_walk_sparse(struct rev_info *revs,
+	       		     struct oidset *set)
+{
+	int i, has_interesting = 0, has_uninteresting = 0;
+	struct names_and_oids no;
+	struct object_id *oid;
+	struct oidset_iter iter;
+	init_names_and_oids(&no);
+
+	/* Check if we need to recurse down these trees */
+	oidset_iter_init(set, &iter);
+	while ((oid = oidset_iter_next(&iter))) {
+		struct tree *tree = lookup_tree(revs->repo, oid);
+		if (tree->object.flags & UNINTERESTING)
+			has_uninteresting = 1;
+		else
+			has_interesting = 1;
+	}
+
+	if (!has_interesting || !has_uninteresting) {
+		return;
+	}
+
+	/* Phase 1: read all trees in the set, add trees to dictionary */
+	oidset_iter_init(set, &iter);
+	while ((oid = oidset_iter_next(&iter))) {
+		struct tree *tree = lookup_tree(revs->repo, oid);
+		walk_tree_contents(revs->repo, tree, &no);
+	}
+
+	/* Phase 2: for each path, recurse on that oidset */
+	for (i = 0; i < no.list.nr; i++)
+		tree_walk_sparse(revs, (struct oidset *)no.list.items[i].util);
+
+	free_names_and_oids(&no);
+}
+
 static void mark_edge_parents_uninteresting(struct commit *commit,
 					    struct rev_info *revs,
-					    show_edge_fn show_edge)
+					    show_edge_fn show_edge,
+					    struct oidset *set)
 {
 	struct commit_list *parents;
 
 	for (parents = commit->parents; parents; parents = parents->next) {
 		struct commit *parent = parents->item;
+		struct tree *tree;
 
 		if (!(parent->object.flags & UNINTERESTING))
 			continue;
-		mark_tree_uninteresting_shallow(get_commit_tree(parent));
+
+		tree = get_commit_tree(parent);
+		oidset_insert(set, &tree->object.oid);
+		mark_tree_uninteresting_shallow(tree);
 
 		if (!(parent->object.flags & SHOWN)) {
 			parent->object.flags |= SHOWN;
@@ -130,14 +176,15 @@ void mark_edges_uninteresting_sparse(struct rev_info *revs,
 {
 	struct commit_list *list;
 	int i;
+	struct oidset set;
+	oidset_init(&set, 16);
 
 	for (list = revs->commits; list; list = list->next) {
 		struct commit *commit = list->item;
+		oidset_insert(&set, get_commit_tree_oid(commit));
 
 		if (commit->object.flags & UNINTERESTING) {
 			mark_tree_uninteresting_shallow(get_commit_tree(commit));
-
-			/* TODO: add tree to list */
 
 			if (revs->edge_hint_aggressive && !(commit->object.flags & SHOWN)) {
 				commit->object.flags |= SHOWN;
@@ -147,10 +194,11 @@ void mark_edges_uninteresting_sparse(struct rev_info *revs,
 		}
 
 		/* send tree list here */
-		mark_edge_parents_uninteresting(commit, revs, show_edge);
+		mark_edge_parents_uninteresting(commit, revs, show_edge, &set);
 	}
 
-	/* TODO: mark the trees uninteresting using the sparse algorithm */
+	tree_walk_sparse(revs, &set);
+	oidset_clear(&set);
 
 	if (revs->edge_hint_aggressive) {
 		for (i = 0; i < revs->cmdline.nr; i++) {

--- a/tree-walk-sparse.c
+++ b/tree-walk-sparse.c
@@ -1,0 +1,171 @@
+#include "git-compat-util.h"
+#include "cache.h"
+#include "tag.h"
+#include "commit.h"
+#include "tree.h"
+#include "blob.h"
+#include "diff.h"
+#include "oidset.h"
+#include "tree-walk.h"
+#include "revision.h"
+#include "object-store.h"
+#include "string-list.h"
+#include "trace.h"
+#include "tree-walk-sparse.h"
+
+/*
+ * At each "level" of the search, we will store a dictionary.
+ *
+ * Key: the entry name from a tree above to a tree in the next level.
+ * Value: An oidset of tree oids that appear at that entry name.
+ *
+ * We use string_list as the dictionary.
+ */
+struct names_and_oids {
+	struct string_list list;
+};
+
+void insert_name_and_oid(struct names_and_oids *no,
+			 const char *name,
+			 struct tree *tree)
+{
+	struct string_list_item *item = string_list_insert(&no->list, name)->util;
+	struct oidset *set; 
+	
+	if (!item->util) {
+		set = xcalloc(1, sizeof(struct oidset));
+		oidset_init(set, 16);
+		item->util = set;
+	} else {
+		set = item->util;
+	}
+
+	oidset_insert(set, &tree->object.oid);
+}
+
+void init_names_and_oids(struct names_and_oids *no) {
+	string_list_init(&no->list, 1);
+}
+
+void free_names_and_oids(struct names_and_oids *no) {
+	int i; 
+	for (i = 0; i < no->list.nr; i++) {
+		oidset_clear(no->list.items[i].util);
+		free(no->list.items[i].util); 
+	}  
+
+	string_list_clear(&no->list, 0);
+}
+
+static void mark_blob_uninteresting(struct blob *obj)
+{
+	obj->object.flags |= UNINTERESTING;
+}
+
+static void mark_tree_uninteresting_shallow(struct tree *tree)
+{
+	struct object *obj;
+
+	if (!tree)
+		return;
+
+	obj = &tree->object;
+	if (obj->flags & UNINTERESTING)
+		return;
+
+	obj->flags |= UNINTERESTING;
+	/* don't recurse now! */
+}
+
+static void mark_tree_contents_uninteresting(struct repository *r,
+					     struct tree *tree)
+{
+	struct tree_desc desc;
+	struct name_entry entry;
+
+	if (parse_tree_gently(tree, 1) < 0)
+		return;
+
+	init_tree_desc(&desc, tree->buffer, tree->size);
+	while (tree_entry(&desc, &entry)) {
+		switch (object_type(entry.mode)) {
+		case OBJ_TREE:
+			/* add to dictionary here! */
+			mark_tree_uninteresting_shallow(lookup_tree(r, entry.oid));
+			break;
+		case OBJ_BLOB:
+			mark_blob_uninteresting(lookup_blob(r, entry.oid));
+			break;
+		default:
+			/* Subprojct commit - not in this repository */
+			break;
+		}
+	}
+
+	free_tree_buffer(tree);
+}
+
+static void mark_edge_parents_uninteresting(struct commit *commit,
+					    struct rev_info *revs,
+					    show_edge_fn show_edge)
+{
+	struct commit_list *parents;
+
+	for (parents = commit->parents; parents; parents = parents->next) {
+		struct commit *parent = parents->item;
+
+		if (!(parent->object.flags & UNINTERESTING))
+			continue;
+		mark_tree_uninteresting_shallow(get_commit_tree(parent));
+
+		if (!(parent->object.flags & SHOWN)) {
+			parent->object.flags |= SHOWN;
+			show_edge(parent);
+		}
+	}
+}
+
+void mark_edges_uninteresting_sparse(struct rev_info *revs,
+				     show_edge_fn show_edge)
+{
+	struct commit_list *list;
+	int i;
+
+	for (list = revs->commits; list; list = list->next) {
+		struct commit *commit = list->item;
+
+		if (commit->object.flags & UNINTERESTING) {
+			mark_tree_uninteresting_shallow(get_commit_tree(commit));
+
+			/* TODO: add tree to list */
+
+			if (revs->edge_hint_aggressive && !(commit->object.flags & SHOWN)) {
+				commit->object.flags |= SHOWN;
+				show_edge(commit);
+			}
+			continue;
+		}
+
+		/* send tree list here */
+		mark_edge_parents_uninteresting(commit, revs, show_edge);
+	}
+
+	/* TODO: mark the trees uninteresting using the sparse algorithm */
+
+	if (revs->edge_hint_aggressive) {
+		for (i = 0; i < revs->cmdline.nr; i++) {
+			struct object *obj = revs->cmdline.rev[i].item;
+			struct commit *commit = (struct commit *)obj;
+			if (obj->type != OBJ_COMMIT || !(obj->flags & UNINTERESTING))
+				continue;
+			
+			/* this will do a full recursion on the trees, stopping only
+			 * at trees that are already marked UNINTERESTING. */
+			mark_tree_uninteresting(revs->repo, get_commit_tree(commit));
+			if (!(obj->flags & SHOWN)) {
+				obj->flags |= SHOWN;
+				show_edge(commit);
+			}
+		}
+	}
+}

--- a/tree-walk-sparse.c
+++ b/tree-walk-sparse.c
@@ -78,8 +78,7 @@ static void mark_tree_uninteresting_shallow(struct tree *tree)
 }
 
 int num_walked = 0;
-static void walk_tree_contents(struct repository *r,
-			       struct tree *tree,
+static void walk_tree_contents(struct tree *tree,
 			       struct names_and_oids *no)
 {
 	struct tree_desc desc;
@@ -97,11 +96,11 @@ static void walk_tree_contents(struct repository *r,
 			insert_name_and_oid(no, entry.path, entry.oid);
 
 			if (tree->object.flags & UNINTERESTING)
-				mark_tree_uninteresting_shallow(lookup_tree(r, entry.oid));
+				mark_tree_uninteresting_shallow(lookup_tree(the_repository, entry.oid));
 			break;
 		case OBJ_BLOB:
 			if (tree->object.flags & UNINTERESTING)
-				mark_blob_uninteresting(lookup_blob(r, entry.oid));
+				mark_blob_uninteresting(lookup_blob(the_repository, entry.oid));
 			break;
 		default:
 			/* Subproject commit - not in this repository */
@@ -124,7 +123,7 @@ static void tree_walk_sparse(struct rev_info *revs,
 	/* Check if we need to recurse down these trees */
 	oidset_iter_init(set, &iter);
 	while ((oid = oidset_iter_next(&iter))) {
-		struct tree *tree = lookup_tree(revs->repo, oid);
+		struct tree *tree = lookup_tree(the_repository, oid);
 		if (tree->object.flags & UNINTERESTING)
 			has_uninteresting = 1;
 		else
@@ -138,8 +137,8 @@ static void tree_walk_sparse(struct rev_info *revs,
 	/* Phase 1: read all trees in the set, add trees to dictionary */
 	oidset_iter_init(set, &iter);
 	while ((oid = oidset_iter_next(&iter))) {
-		struct tree *tree = lookup_tree(revs->repo, oid);
-		walk_tree_contents(revs->repo, tree, &no);
+		struct tree *tree = lookup_tree(the_repository, oid);
+		walk_tree_contents(tree, &no);
 	}
 
 	/* Phase 2: for each path, recurse on that oidset */
@@ -212,7 +211,7 @@ void mark_edges_uninteresting_sparse(struct rev_info *revs,
 			
 			/* this will do a full recursion on the trees, stopping only
 			 * at trees that are already marked UNINTERESTING. */
-			mark_tree_uninteresting(revs->repo, get_commit_tree(commit));
+			mark_tree_uninteresting(get_commit_tree(commit));
 			if (!(obj->flags & SHOWN)) {
 				obj->flags |= SHOWN;
 				show_edge(commit);

--- a/tree-walk-sparse.h
+++ b/tree-walk-sparse.h
@@ -1,0 +1,11 @@
+#ifndef __TREE_WALK_SPARSE__
+#define __TREE_WALK_SPARSE__
+
+struct commit;
+struct rev_info;
+typedef void (*show_edge_fn)(struct commit *);
+
+void mark_edges_uninteresting_sparse(struct rev_info *revs,
+				     show_edge_fn show_edge);
+
+#endif


### PR DESCRIPTION
I'm creating this PR just so I can generate a Windows installer, and will then test performance on a real repo with that data.

The basic idea is here, but it is also thrown together in a terrible way. It will be redone for actual upstreaming. This PR is particularly bad because I rebased it from 2.20.0-rc1 to 2.19.1 so I could create this PR, and that was rather painful due to conflicts.

BUT I do have some data! Running `git pack-objects --thin --revs --stdout [--sparse]` giving the following input over stdin:

```
HEAD
^HEAD~10
```

gives the following numbers of parsed trees:

| Repo  | Walked Before | Walked After |
|-------|---------------|--------------|
| Git   | 352           | 157          |
| Linux | 6789          | 735          |

I'm going to test this with a few deeper repos (these repos are very shallow, so are actually not tailored to work well with this algorithm).

And possibly the best indicator so far: I ran this using one of my old unmerged topic branches in the Azure DevOps repo and got the following data points:

```
$ time ~/git/git pack-objects --stdout --revs --thin <in.txt >/dev/null
num_walked: 22804
Enumerating objects: 220, done.
Counting objects: 100% (220/220), done.
Compressing objects: 100% (41/41), done.
Total 158 (delta 119), reused 155 (delta 116)

real    1m29.762s
user    0m1.225s
sys     0m0.730s

$ time ~/git/git pack-objects --stdout --revs --thin --sparse <in.txt >/dev/null
num_walked: 129
Enumerating objects: 220, done.
Counting objects: 100% (220/220), done.
Compressing objects: 100% (41/41), done.
Total 158 (delta 119), reused 155 (delta 116)

real    0m9.621s
user    0m0.948s
sys     0m0.130s
```