### PR TITLE
run-command: close all parent file descriptors

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -716,6 +716,7 @@ fail_pipe:
 {
 	int notify_pipe[2];
 	int null_fd = -1;
+	int fd;
 	char **childenv;
 	struct argv_array argv = ARGV_ARRAY_INIT;
 	struct child_err cerr;
@@ -794,6 +795,13 @@ fail_pipe:
 
 		if (cmd->dir && chdir(cmd->dir))
 			child_die(CHILD_ERR_CHDIR);
+
+		/*
+		 * Make sure any file descriptors from the parent get closed
+		 */
+		for (fd = 3; fd < 256; ++fd) {
+			set_cloexec(fd);
+		}
 
 		/*
 		 * restore default signal handlers here, in case


### PR DESCRIPTION
Looking for feedback on this way to make sure child doesn't keep
parent file descriptors open.

When starting a child process using fork() all file descriptors of
the parent are inherited by the child process.  This can cause
deadlocks in git when the following happens.

1. Start a child process - this opens pipes in the parent process
   in order for the parent to read/write data to the child. The child
   process dups the end of the pipes to stdin/stdout/stderr.
2. Parent does some work that starts another child process - this
   process will get the open pipes that the parent is using to
   communicate with the first child process.
3. Parent writes to the first child through pipe and closes it.
4. Parent reads from the first child through pipe while the second
   child process is still running.
5. Parent is deadlocked on the read because although the first child
   is done and pipes were closed, the second child has the file
   descriptors to the pipes for the first child which are still open.

Since the parent might not know that it is spawning a child process,
all possible file descriptors need to be closed on exec.
