### PR TITLE
gvfs: block unsupported commands when running in a GVFS repo

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -27,6 +27,7 @@
 #include "pack-objects.h"
 #include "blob.h"
 #include "tree.h"
+#include "gvfs.h"
 
 #define FAILED_RUN "failed to run %s"
 
@@ -564,6 +565,9 @@ int cmd_gc(int argc, const char **argv, const char *prefix)
 	}
 	if (quiet)
 		argv_array_push(&repack, "-q");
+
+	if ((!auto_gc || (auto_gc && gc_auto_threshold > 0)) && gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
+		die(_("'git gc' is not supported on a GVFS repo"));
 
 	if (auto_gc) {
 		/*

--- a/builtin/update-index.c
+++ b/builtin/update-index.c
@@ -17,6 +17,7 @@
 #include "dir.h"
 #include "split-index.h"
 #include "fsmonitor.h"
+#include "gvfs.h"
 
 /*
  * Default to not allowing changes to the list of files. The
@@ -1115,7 +1116,13 @@ int cmd_update_index(int argc, const char **argv, const char *prefix)
 	argc = parse_options_end(&ctx);
 
 	getline_fn = nul_term_line ? strbuf_getline_nul : strbuf_getline_lf;
+	if (mark_skip_worktree_only && gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
+		die(_("modifying the skip worktree bit is not supported on a GVFS repo"));
+	
 	if (preferred_index_format) {
+		if (preferred_index_format != 4 && gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
+			die(_("changing the index version is not supported on a GVFS repo"));
+
 		if (preferred_index_format < INDEX_FORMAT_LB ||
 		    INDEX_FORMAT_UB < preferred_index_format)
 			die("index-version %d not in range: %d..%d",
@@ -1151,6 +1158,9 @@ int cmd_update_index(int argc, const char **argv, const char *prefix)
 	}
 
 	if (split_index > 0) {
+		if (gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
+			die(_("split index is not supported on a GVFS repo"));
+
 		if (git_config_get_split_index() == 0)
 			warning(_("core.splitIndex is set to false; "
 				  "remove or change it, if you really want to "

--- a/git.c
+++ b/git.c
@@ -5,6 +5,7 @@
 #include "run-command.h"
 #include "alias.h"
 #include "dir.h"
+#include "gvfs.h"
 
 #define RUN_SETUP		(1<<0)
 #define RUN_SETUP_GENTLY	(1<<1)
@@ -17,6 +18,7 @@
 #define SUPPORT_SUPER_PREFIX	(1<<4)
 #define DELAY_PAGER_CONFIG	(1<<5)
 #define NO_PARSEOPT		(1<<6) /* parse-options is not used */
+#define BLOCK_ON_GVFS_REPO	(1<<7) /* command not allowed in GVFS repos */
 
 struct cmd_struct {
 	const char *cmd;
@@ -487,6 +489,9 @@ static int run_builtin(struct cmd_struct *p, int argc, const char **argv)
 	if (!help && p->option & NEED_WORK_TREE)
 		setup_work_tree();
 
+	if (!help && p->option & BLOCK_ON_GVFS_REPO && gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
+		die("'git %s' is not supported on a GVFS repo", p->cmd);
+
 	if (run_pre_command_hook(argv))
 		die("pre-command hook aborted command");
 
@@ -561,7 +566,7 @@ static struct cmd_struct commands[] = {
 	{ "fmt-merge-msg", cmd_fmt_merge_msg, RUN_SETUP },
 	{ "for-each-ref", cmd_for_each_ref, RUN_SETUP },
 	{ "format-patch", cmd_format_patch, RUN_SETUP },
-	{ "fsck", cmd_fsck, RUN_SETUP },
+	{ "fsck", cmd_fsck, RUN_SETUP | BLOCK_ON_GVFS_REPO},
 	{ "fsck-objects", cmd_fsck, RUN_SETUP },
 	{ "gc", cmd_gc, RUN_SETUP },
 	{ "get-tar-commit-id", cmd_get_tar_commit_id, NO_PARSEOPT },
@@ -599,7 +604,7 @@ static struct cmd_struct commands[] = {
 	{ "pack-refs", cmd_pack_refs, RUN_SETUP },
 	{ "patch-id", cmd_patch_id, RUN_SETUP_GENTLY | NO_PARSEOPT },
 	{ "pickaxe", cmd_blame, RUN_SETUP },
-	{ "prune", cmd_prune, RUN_SETUP },
+	{ "prune", cmd_prune, RUN_SETUP | BLOCK_ON_GVFS_REPO},
 	{ "prune-packed", cmd_prune_packed, RUN_SETUP },
 	{ "pull", cmd_pull, RUN_SETUP | NEED_WORK_TREE },
 	{ "push", cmd_push, RUN_SETUP },
@@ -617,7 +622,7 @@ static struct cmd_struct commands[] = {
 	{ "remote", cmd_remote, RUN_SETUP },
 	{ "remote-ext", cmd_remote_ext, NO_PARSEOPT },
 	{ "remote-fd", cmd_remote_fd, NO_PARSEOPT },
-	{ "repack", cmd_repack, RUN_SETUP },
+	{ "repack", cmd_repack, RUN_SETUP | BLOCK_ON_GVFS_REPO },
 	{ "replace", cmd_replace, RUN_SETUP },
 	{ "rerere", cmd_rerere, RUN_SETUP },
 	{ "reset", cmd_reset, RUN_SETUP },
@@ -641,7 +646,7 @@ static struct cmd_struct commands[] = {
 	{ "stash", cmd_stash },
 	{ "status", cmd_status, RUN_SETUP | NEED_WORK_TREE },
 	{ "stripspace", cmd_stripspace },
-	{ "submodule--helper", cmd_submodule__helper, RUN_SETUP | SUPPORT_SUPER_PREFIX | NO_PARSEOPT },
+	{ "submodule--helper", cmd_submodule__helper, RUN_SETUP | SUPPORT_SUPER_PREFIX | NO_PARSEOPT | BLOCK_ON_GVFS_REPO },
 	{ "symbolic-ref", cmd_symbolic_ref, RUN_SETUP },
 	{ "tag", cmd_tag, RUN_SETUP | DELAY_PAGER_CONFIG },
 	{ "unpack-file", cmd_unpack_file, RUN_SETUP | NO_PARSEOPT },
@@ -658,7 +663,7 @@ static struct cmd_struct commands[] = {
 	{ "verify-tag", cmd_verify_tag, RUN_SETUP },
 	{ "version", cmd_version },
 	{ "whatchanged", cmd_whatchanged, RUN_SETUP },
-	{ "worktree", cmd_worktree, RUN_SETUP | NO_PARSEOPT },
+	{ "worktree", cmd_worktree, RUN_SETUP | NO_PARSEOPT | BLOCK_ON_GVFS_REPO },
 	{ "write-tree", cmd_write_tree, RUN_SETUP },
 };
 

--- a/gvfs.h
+++ b/gvfs.h
@@ -12,6 +12,7 @@
  * The list of bits in the core_gvfs setting
  */
 #define GVFS_SKIP_SHA_ON_INDEX                      (1 << 0)
+#define GVFS_BLOCK_COMMANDS                         (1 << 1)
 #define GVFS_MISSING_OK                             (1 << 2)
 #define GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT       (1 << 3)
 #define GVFS_FETCH_SKIP_REACHABILITY_AND_UPLOADPACK (1 << 4)

--- a/t/t0402-block-command-on-gvfs.sh
+++ b/t/t0402-block-command-on-gvfs.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='block commands in GVFS repo'
+
+. ./test-lib.sh
+
+not_with_gvfs () {
+    command=$1 &&
+    shift &&
+    test_expect_success "test $command $*" "
+        test_config alias.g4rbled $command &&
+        test_config core.gvfs true &&
+        test_must_fail git $command $* &&
+        test_must_fail git g4rbled $* &&
+        test_unconfig core.gvfs &&
+        test_must_fail git -c core.gvfs=true $command $* &&
+        test_must_fail git -c core.gvfs=true g4rbled $*
+    "
+}
+
+not_with_gvfs fsck
+not_with_gvfs gc
+not_with_gvfs gc --auto
+not_with_gvfs prune
+not_with_gvfs repack
+not_with_gvfs submodule status
+not_with_gvfs update-index --index-version 2
+not_with_gvfs update-index --skip-worktree
+not_with_gvfs update-index --no-skip-worktree
+not_with_gvfs update-index --split-index
+not_with_gvfs worktree list
+
+test_expect_success 'test gc --auto succeeds when disabled via config' '
+	test_config core.gvfs true &&
+	test_config gc.auto 0 &&
+	git gc --auto
+'
+
+test_done


### PR DESCRIPTION
The following commands and options are not currently supported when working
in a GVFS repo.  Add code to detect and block these commands from executing.

1) fsck
2) gc
4) prune
5) repack
6) submodule
8) update-index --split-index
9) update-index --index-version (other than 4)
10) update-index --[no-]skip-worktree
11) worktree

Signed-off-by: Ben Peart <benpeart@microsoft.com>