### PR TITLE
update the reset --quiet path codepath to pass the correct flags to the post-indexchanged hook

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -458,6 +458,7 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 			int flags = quiet ? REFRESH_QUIET : REFRESH_IN_PORCELAIN;
 			if (read_from_tree(&pathspec, &oid, intent_to_add))
 				return 1;
+			the_index.updated_skipworktree = 1;
 			if (!quiet && get_git_work_tree()) {
 				uint64_t t_begin, t_delta_in_ms;
 
@@ -470,7 +471,6 @@ int cmd_reset(int argc, const char **argv, const char *prefix)
 						"use '--quiet' to avoid this.  Set the config setting reset.quiet to true\n"
 						"to make this the default.\n"), t_delta_in_ms / 1000.0);
 				}
-				the_index.updated_skipworktree = 1;
 			}
 		} else {
 			int err = reset_index(&oid, reset_type, quiet);

--- a/t/t7113-post-index-changed-hook.sh
+++ b/t/t7113-post-index-changed-hook.sh
@@ -128,7 +128,7 @@ test_expect_success 'test reset --mixed and update-index triggers the hook' '
 	EOF
 	: force index to be dirty &&
 	test-tool chmtime +60 dir1/file1.txt &&
-	git reset --mixed HEAD~1 &&
+	git reset --mixed --quiet HEAD~1 &&
 	test_path_is_file testsuccess && rm -f testsuccess &&
 	test_path_is_missing testfailure &&
 	git hash-object -w --stdin <dir1/file2.txt >expect &&


### PR DESCRIPTION
In the reset --mixed code path, the index is created from scratch from the given commit by the call to read_from_tree().  Since this is the code that actually modifies the index, make sure we set the the_index.updated_skipworktree flag which is passed to the post-indexchanged hook.

Updated the post-index-changed-hook test script to pass the --quiet flag so that we can prevent future regressions.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
