### PR TITLE
fixup! multi-pack-index: implement 'expire' verb

### DIFF
--- a/t/t5319-multi-pack-index.sh
+++ b/t/t5319-multi-pack-index.sh
@@ -446,4 +446,32 @@ test_expect_success 'expire removes repacked packs' '
 	)
 '
 
+test_expect_success 'expire works when adding new packs' '
+	(
+		cd dup &&
+		git pack-objects --revs .git/objects/pack/pack-combined <<-EOF &&
+		refs/heads/A
+		^refs/heads/B
+		EOF
+		git pack-objects --revs .git/objects/pack/pack-combined <<-EOF &&
+		refs/heads/B
+		^refs/heads/C
+		EOF
+		git pack-objects --revs .git/objects/pack/pack-combined <<-EOF &&
+		refs/heads/C
+		^refs/heads/D
+		EOF
+		git multi-pack-index write &&
+		git pack-objects --revs .git/objects/pack/pack-a <<-EOF &&
+		refs/heads/D
+		^refs/heads/E
+		EOF
+		git multi-pack-index write &&
+		git pack-objects --revs .git/objects/pack/pack-z <<-EOF &&
+		refs/heads/E
+		EOF
+		git multi-pack-index expire &&	
+		git multi-pack-index verify
+	)
+'
 test_done


### PR DESCRIPTION
There is a bug in the 'git multi-pack-index expire' subcommand. When
expiring packs while also adding a pack not previously covered by
the multi-pack-index, the logic around the pack permutations did not
work correctly. It would improperly assign objects to the wrong
pack-int-ids.

Rework the logic around expired packs in the following ways:

1. We track the original order of the packs to delete, but do not
   remove them from the list right away. (This is stored as
   `expire_int_ids`.)

2. We append the new packs to the total list of packs.

3. After sorting the full list of packs, we remove the expired
   packs from the list so we do not write them in the new
   multi-pack-index.

4. Finally, we "puncture" the pack permutation to remove the
   entries that will be deleted. This requires reducing the int-ids
   for the packs that have final int-id larger than the expected
   int-id for the expired pack.