### PR TITLE
Trace2 Part 4: add additional trace regions/data to status

### DIFF
--- a/wt-status-serialize.c
+++ b/wt-status-serialize.c
@@ -297,6 +297,8 @@ void wt_status_serialize_v1(int fd, struct wt_status *s)
 	struct string_list_item *iter;
 	int k;
 
+	trace2_region_enter("status", "serialize", the_repository);
+
 	/*
 	 * version header must be first line.
 	 */
@@ -330,4 +332,6 @@ void wt_status_serialize_v1(int fd, struct wt_status *s)
 		}
 		packet_flush(fd);
 	}
+
+	trace2_region_leave("status", "serialize", the_repository);
 }

--- a/wt-status.c
+++ b/wt-status.c
@@ -2317,6 +2317,12 @@ static void wt_porcelain_v2_print(struct wt_status *s)
 
 void wt_status_print(struct wt_status *s)
 {
+	trace2_data_intmax("status", the_repository, "count/changed", s->change.nr);
+	trace2_data_intmax("status", the_repository, "count/untracked", s->untracked.nr);
+	trace2_data_intmax("status", the_repository, "count/ignored", s->ignored.nr);
+
+	trace2_region_enter("status", "print", the_repository);
+
 	switch (s->status_format) {
 	case STATUS_FORMAT_SHORT:
 		wt_shortstatus_print(s);
@@ -2338,6 +2344,8 @@ void wt_status_print(struct wt_status *s)
 		wt_status_serialize_v1(1, s);
 		break;
 	}
+
+	trace2_region_leave("status", "print", the_repository);
 }
 
 /**


### PR DESCRIPTION
Add trace2 regions around serialize and printing.
Add trace2 data messages giving the number of items changed/untracked/ignored.