### PR TITLE
trace2: fixup: remove warning message when opening trace file

### DIFF
--- a/trace2/tr2_dst.c
+++ b/trace2/tr2_dst.c
@@ -34,8 +34,10 @@ int tr2_dst_get_trace_fd(struct tr2_dst *dst)
 	else if (is_absolute_path(trace)) {
 		int fd = open(trace, O_WRONLY | O_APPEND | O_CREAT, 0666);
 		if (fd == -1) {
-			warning("could not open '%s' for tracing: %s",
-				trace, strerror(errno));
+			/*
+			 * Silently eat the error and disable tracing on
+			 * this destination.
+			 */
 			tr2_dst_trace_disable(dst);
 		} else {
 			dst->fd = fd;


### PR DESCRIPTION
Remove warning message when the trace2 destination file could not be opened.
