### PR TITLE
TEST: Read objects in pack order when writing commit-graph

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -817,7 +817,8 @@ void write_commit_graph(const char *obj_dir,
 				die(_("error adding pack %s"), packname.buf);
 			if (open_pack_index(p))
 				die(_("error opening index for %s"), packname.buf);
-			for_each_object_in_pack(p, add_packed_commits, &oids, 0);
+			for_each_object_in_pack(p, add_packed_commits, &oids,
+						FOR_EACH_OBJECT_PACK_ORDER);
 			close_pack(p);
 			free(p);
 		}


### PR DESCRIPTION
This is adapted from [this patch on the mailing list](https://public-inbox.org/git/20190117132345.29791-1-avarab@gmail.com/T/#u). I'm creating this PR only to generate a Windows installer so I can report performance numbers.