### PR TITLE
DO NOT MERGE: add trace2 tree parse counts to pack-objects

### DIFF
--- a/list-objects.c
+++ b/list-objects.c
@@ -249,13 +249,15 @@ static void add_edge_parents(struct commit *commit,
 	}
 }
 
+extern int num_trees_parsed;
+
 void mark_edges_uninteresting(struct rev_info *revs,
 			      show_edge_fn show_edge,
 			      int sparse)
 {
 	struct commit_list *list;
 	int i;
-
+	num_trees_parsed = 0;
 	if (sparse) {
 		struct oidset set;
 		oidset_init(&set, 16);
@@ -303,6 +305,8 @@ void mark_edges_uninteresting(struct rev_info *revs,
 			}
 		}
 	}
+
+        trace2_data_intmax("pack-objects", revs->repo, "num_trees_parsed", num_trees_parsed);
 }
 
 static void add_pending_tree(struct rev_info *revs, struct tree *tree)

--- a/revision.c
+++ b/revision.c
@@ -34,6 +34,8 @@ volatile show_early_output_fn_t show_early_output;
 static const char *term_bad;
 static const char *term_good;
 
+int num_trees_parsed;
+
 implement_shared_commit_slab(revision_sources, char *);
 
 void show_object_with_name(FILE *out, struct object *obj, const char *name)
@@ -63,6 +65,8 @@ static void mark_tree_contents_uninteresting(struct repository *r,
 
 	if (parse_tree_gently(tree, 1) < 0)
 		return;
+
+	num_trees_parsed++;
 
 	init_tree_desc(&desc, tree->buffer, tree->size);
 	while (tree_entry(&desc, &entry)) {
@@ -171,6 +175,8 @@ static void add_children_by_path(struct repository *r,
 
 	if (parse_tree_gently(tree, 1) < 0)
 		return;
+
+	num_trees_parsed++;
 
 	init_tree_desc(&desc, tree->buffer, tree->size);
 	while (tree_entry(&desc, &entry)) {


### PR DESCRIPTION
This is just for testing.