### PR TITLE
fixup! pager: fix order of atexit() calls

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -1669,7 +1669,6 @@ extern void write_file(const char *path, const char *fmt, ...);
 
 /* pager.c */
 extern void setup_pager(void);
-extern void wait_for_pager_atexit(void);
 extern int pager_in_use(void);
 extern int pager_use_color;
 extern int term_columns(void);

--- a/git.c
+++ b/git.c
@@ -893,12 +893,6 @@ int cmd_main(int argc, const char **argv)
 			cmd = slash + 1;
 	}
 
-	/*
-	 * wait_for_pager_atexit will close stdout/stderr so it needs to be
-	 * registered first so that it will execute last and not close the
-	 * handles until all other atexit handlers have finished
-	 */
-	atexit(wait_for_pager_atexit);
 	trace_command_performance(argv);
 	atexit(post_command_hook_atexit);
 

--- a/pager.c
+++ b/pager.c
@@ -26,12 +26,9 @@ static void wait_for_pager(int in_signal)
 		finish_command(&pager_process);
 }
 
-
-static int run_wait_for_pager_atexit = 0;
-void wait_for_pager_atexit(void)
+static void wait_for_pager_atexit(void)
 {
-	if (run_wait_for_pager_atexit)
-		wait_for_pager(0);
+	wait_for_pager(0);
 }
 
 static void wait_for_pager_signal(int signo)
@@ -141,7 +138,7 @@ void setup_pager(void)
 
 	/* this makes sure that the parent terminates after the pager */
 	sigchain_push_common(wait_for_pager_signal);
-	run_wait_for_pager_atexit = 1;
+	atexit(wait_for_pager_atexit);
 }
 
 int pager_in_use(void)


### PR DESCRIPTION
A bit of housekeeping to reduce the number of patches in our fork.  This reverts commit 3f588065b0 as it no longer fixes the underlying issue so there is no reason to keep hauling it along with every release.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
