### PR TITLE
fixup! gvfs: ensure all filters and EOL conversions are blocked

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -1596,6 +1596,9 @@ static int lf_to_crlf_filter_fn(struct stream_filter *filter,
 	size_t count, o = 0;
 	struct lf_to_crlf_filter *lf_to_crlf = (struct lf_to_crlf_filter *)filter;
 
+	if (gvfs_config_is_set(GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS))
+		die("CRLF conversions not supported when running under GVFS");
+
 	/*
 	 * We may be holding onto the CR to see if it is followed by a
 	 * LF, in which case we would need to go to the main loop.
@@ -1839,6 +1842,9 @@ static int ident_filter_fn(struct stream_filter *filter,
 {
 	struct ident_filter *ident = (struct ident_filter *)filter;
 	static const char head[] = "$Id";
+
+	if (gvfs_config_is_set(GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS))
+		die("ident conversions not supported when running under GVFS");
 
 	if (!input) {
 		/* drain upon eof */

--- a/t/t0021-conversion.sh
+++ b/t/t0021-conversion.sh
@@ -347,9 +347,8 @@ test_expect_success "ident blocked when under GVFS" '
 	git commit -m "added ident.i" &&
 	test_config core.gvfs 64 &&
 	rm ident.i &&
-	git checkout -- ident.i &&
 
-	test_must_fail git status
+	test_must_fail git checkout -- ident.i
 '
 
 test_expect_success 'disable filter with empty override' '


### PR DESCRIPTION
Ensure writing out files properly blocks expanding $Id: when the ident attribute is set for a path under GVFS.

Signed-off-by: Ben Peart <benpeart@microsoft.com>
