### PR TITLE
send-pack: build list of oids to sent to pack-objects

### DIFF
--- a/send-pack.c
+++ b/send-pack.c
@@ -15,7 +15,6 @@
 #include "sha1-array.h"
 #include "gpg-interface.h"
 #include "cache.h"
-#include "gvfs.h"
 
 int option_parse_push_signed(const struct option *opt,
 			     const char *arg, int unset)
@@ -51,7 +50,7 @@ static int send_pack_config(const char *var, const char *value, void *unused)
 
 static void feed_object(const struct object_id *oid, FILE *fh, int negative)
 {
-	if (negative && !gvfs_config_is_set(GVFS_MISSING_OK) && !has_sha1_file(oid->hash))
+	if (negative && !has_sha1_file(oid->hash))
 		return;
 
 	if (negative)

--- a/send-pack.c
+++ b/send-pack.c
@@ -48,17 +48,6 @@ static int send_pack_config(const char *var, const char *value, void *unused)
 	return 0;
 }
 
-static void feed_object(const struct object_id *oid, FILE *fh, int negative)
-{
-	if (negative && !has_sha1_file(oid->hash))
-		return;
-
-	if (negative)
-		putc('^', fh);
-	fputs(oid_to_hex(oid), fh);
-	putc('\n', fh);
-}
-
 static void add_to_oid_list(const struct object_id *oid, struct string_list *list, int negative)
 {
 	if (negative && !has_sha1_file(oid->hash))


### PR DESCRIPTION
This PR reverts #68 because it was causing issues with pushing to other remotes.

This change builds the list of oids before `pack-objects` is spawned so that if checking for the oid has to download the object via the `read-object` process the stdin and stdout handles will not get handled incorrectly.

The one disadvantage of this change is it will take more memory especially when there are a lot of objects to be pushed since it is building the full list first.

Another possible fix is #79 to fix handle inheritance but that change is a lot more invasive and could affect other commands.  This change will limit the scope to push.
 