### PR TITLE
Mark stdin/out/err pipe fds as close on exec so that forking post start_command would be safe

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -967,18 +967,24 @@ end_of_spawn:
 		return -1;
 	}
 
-	if (need_in)
+	if (need_in) {
 		close(fdin[0]);
+		set_cloexec(fdin[1]);
+	}
 	else if (cmd->in)
 		close(cmd->in);
 
-	if (need_out)
+	if (need_out) {
 		close(fdout[1]);
+		set_cloexec(fdout[0]);
+	}
 	else if (cmd->out)
 		close(cmd->out);
 
-	if (need_err)
+	if (need_err) {
 		close(fderr[1]);
+		set_cloexec(fderr[0]);
+	}
 	else if (cmd->err)
 		close(cmd->err);
 

--- a/send-pack.c
+++ b/send-pack.c
@@ -15,7 +15,6 @@
 #include "sha1-array.h"
 #include "gpg-interface.h"
 #include "cache.h"
-#include "gvfs.h"
 
 int option_parse_push_signed(const struct option *opt,
 			     const char *arg, int unset)
@@ -51,7 +50,7 @@ static int send_pack_config(const char *var, const char *value, void *unused)
 
 static void feed_object(const struct object_id *oid, FILE *fh, int negative)
 {
-	if (negative && !gvfs_config_is_set(GVFS_MISSING_OK) && !has_sha1_file(oid->hash))
+	if (negative && !has_sha1_file(oid->hash))
 		return;
 
 	if (negative)


### PR DESCRIPTION
This fixes https://github.com/Microsoft/VFSForGit/issues/830 by reverting #68 and fixing the underlying issue (which is not closing pipe fds before exec).