### PR TITLE
core.txt: fixup typo in gitlink for check-docs

### DIFF
--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -74,7 +74,7 @@ core.virtualFilesystem::
 	the working directory.  Git will only track and update files
 	listed in the virtual file system.  Using the virtual file system
 	will supersede the sparse-checkout settings which will be ignored.
-	See the "virtual file system" section of linkgit:githooks[6].
+	See the "virtual file system" section of linkgit:githooks[5].
 
 core.trustctime::
 	If false, the ctime differences between the index and the


### PR DESCRIPTION
A recent change to add core.virtualFilesystem to config/core.txt included
a linkgit reference that "make check-docs" did not like.  This was causing
the "Documentation Job" in the CI build fail.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>

