### PR TITLE
Fix CI static analysis

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -171,8 +171,10 @@ static int opt_parse_serialize(const struct option *opt, const char *arg, int un
 	if (unset || !arg)
 		*value = STATUS_FORMAT_SERIALIZE_V1;
 
-	if (arg)
+	if (arg) {
+		free(serialize_path);
 		serialize_path = xstrdup(arg);
+	}
 
 	if (do_explicit_deserialize)
 		die("cannot mix --serialize and --deserialize");
@@ -200,8 +202,11 @@ static int opt_parse_deserialize(const struct option *opt, const char *arg, int 
 	} else {
 		if (do_serialize)
 			die("cannot mix --serialize and --deserialize");
-		if (arg) /* override config or stdin */
+		if (arg) {
+			/* override config or stdin */
+			free(deserialize_path);
 			deserialize_path = xstrdup(arg);
+		}
 		if (deserialize_path && *deserialize_path
 		    && (wt_status_deserialize_access(deserialize_path, R_OK) != 0))
 			die("cannot find serialization file '%s'",

--- a/wt-status-deserialize.c
+++ b/wt-status-deserialize.c
@@ -677,7 +677,7 @@ static int wt_deserialize_fd(const struct wt_status *cmd_s, struct wt_status *de
 		return DESERIALIZE_ERR;
 	}
 	/* status_format */
-	if (hashcmp(cmd_s->sha1_commit, des_s->sha1_commit)) {
+	if (!hasheq(cmd_s->sha1_commit, des_s->sha1_commit)) {
 		set_deserialize_reject_reason("args/commit-changed");
 		trace_printf_key(&trace_deserialize, "reject: sha1_commit");
 		return DESERIALIZE_ERR;


### PR DESCRIPTION
Some syntactic changes to get Coccinelle to stop complaining
during the Static Analysis job in the CI build.

WRT the "if (e) v = xstrdup(e)" suggestion, I don't agree with the cocci
expression because the replacement always assigns to v and that may
not always be correct.  I'm avoiding that larger discussion for later.