### PR TITLE
Gvfs trace2 checkout and reset experiment

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -856,8 +856,11 @@ static void update_refs_for_switch(const struct checkout_opts *opts,
 	remove_branch_state(the_repository);
 	strbuf_release(&msg);
 	if (!opts->quiet &&
-	    (new_branch_info->path || (!opts->force_detach && !strcmp(new_branch_info->name, "HEAD"))))
+	    (new_branch_info->path || (!opts->force_detach && !strcmp(new_branch_info->name, "HEAD")))) {
+		trace2_region_enter("exp", "report_tracking", the_repository);
 		report_tracking(new_branch_info);
+		trace2_region_leave("exp", "report_tracking", the_repository);
+	}
 }
 
 static int add_pending_uninteresting_ref(const char *refname,

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -100,7 +100,9 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 
 	if (reset_type == MIXED || reset_type == HARD) {
 		tree = parse_tree_indirect(oid);
+		trace2_region_enter("exp", "prime_cache_tree", the_repository);
 		prime_cache_tree(the_repository, the_repository->index, tree);
+		trace2_region_leave("exp", "prime_cache_tree", the_repository);
 	}
 
 	ret = 0;

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1426,15 +1426,23 @@ static int clear_ce_flags(struct index_state *istate,
 			  struct exclude_list *el)
 {
 	static struct strbuf prefix = STRBUF_INIT;
+	char label[100];
+	int rval;
 
 	strbuf_reset(&prefix);
 
-	return clear_ce_flags_1(istate,
+	xsnprintf(label, sizeof(label), "clear_ce_flags(0x%08lx,0x%08lx)",
+		  (unsigned long)select_mask, (unsigned long)clear_mask);
+	trace2_region_enter("exp", label, the_repository);
+	rval = clear_ce_flags_1(istate,
 				istate->cache,
 				istate->cache_nr,
 				&prefix,
 				select_mask, clear_mask,
 				el, 0);
+	trace2_region_leave("exp", label, the_repository);
+
+	return rval;
 }
 
 /*

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1573,7 +1573,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		}
 
 		trace_performance_enter();
+		trace2_region_enter("exp", "traverse_trees", the_repository);
 		ret = traverse_trees(o->src_index, len, t, &info);
+		trace2_region_leave("exp", "traverse_trees", the_repository);
 		trace_performance_leave("traverse_trees");
 		if (ret < 0)
 			goto return_failed;


### PR DESCRIPTION
Add some temporary telemetry around checkout and reset to help identify performance problems.
These are marked with the "exp" category.
