### PR TITLE
Fix the Azure Pipeline (e.g. macOS builds after the upgrade to Mojave)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,8 +154,8 @@ jobs:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- job: windows
-  displayName: Windows
+- job: windows_build
+  displayName: Windows Build
   pool: Hosted
   timeoutInMinutes: 240
   steps:
@@ -188,23 +188,100 @@ jobs:
          export MAKEFLAGS=-j10
          export DEVELOPER=1
          export NO_PERL=1
-         export NO_SVN_TESTS=1
-         export GIT_TEST_SKIP_REBASE_P=1
 
-         ci/run-build-and-tests.sh || {
-           ci/print-test-failures.sh
-           exit 1
-         }
+         mkdir -p artifacts &&
+         printf '%s\n%s\n\t%s\n\t%s\n' \
+           'include Makefile' \
+           'a:: `$(ALL_PROGRAMS) `$(SCRIPT_LIB) `$(BUILT_INS) `$(OTHER_PROGRAMS)  GIT-BUILD-OPTIONS `$(TEST_PROGRAMS) `$(test_bindir_programs) `$(NO_INSTALL) `$(MOFILES)' \
+           '`$(MAKE) -C templates' \
+           'tar czf artifacts/artifacts.tar.gz `$^ templates/blt/' >mak &&
+         make -f mak a
        "@
        c
-    displayName: 'Build & Test'
+    displayName: 'Build test artifacts'
     env:
       HOME: $(Build.SourcesDirectory)
       MSYSTEM: MINGW64
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Pipeline Artifact: test artifacts'
+    inputs:
+      artifactName: 'windows-artifacts'
+      targetPath: '$(Build.SourcesDirectory)\artifacts'
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Pipeline Artifact: git-sdk-64-minimal'
+    inputs:
+      artifactName: 'git-sdk-64-minimal'
+      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
   - powershell: |
        if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
          cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
        }
+    displayName: 'Unmount test-cache'
+    condition: true
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+
+- job: windows_test
+  displayName: Windows Test
+  dependsOn: windows_build
+  condition: succeeded()
+  pool: Hosted
+  timeoutInMinutes: 240
+  strategy:
+    parallel: 10
+  steps:
+  - powershell: |
+      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+        net use s: \\gitfileshare.file.core.windows.net\test-cache "$GITFILESHAREPWD" /user:AZURE\gitfileshare /persistent:no
+        cmd /c mklink /d "$(Build.SourcesDirectory)\test-cache" S:\
+      }
+    displayName: 'Mount test-cache'
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download Pipeline Artifact: test artifacts'
+    inputs:
+      artifactName: 'windows-artifacts'
+      targetPath: '$(Build.SourcesDirectory)'
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download Pipeline Artifact: git-sdk-64-minimal'
+    inputs:
+      artifactName: 'git-sdk-64-minimal'
+      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
+  - powershell: |
+      & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
+        test -f artifacts.tar.gz || {
+          echo No test artifacts found\; skipping >&2
+          exit 0
+        }
+        tar xf artifacts.tar.gz || exit 1
+
+        # Let Git ignore the SDK and the test-cache
+        printf '%s\n' /git-sdk-64-minimal/ /test-cache/ >>.git/info/exclude
+
+        cd t &&
+        T=`$(ls -S t[0-9]`*.sh | awk NR%`$SYSTEM_TOTALJOBSINPHASE==`$((`$SYSTEM_JOBPOSITIONINPHASE-1))) &&
+        GIT_TEST_OPTS=\"--verbose-log -x\" GIT_PROVE_OPTS=\"--timer --jobs 10\" eval make -j10 `$T
+        test 0 != `$? || exit 0
+        cd test-results
+        for t in `$(grep -l '^[1-9]' *.exit | sed -n 's/\.exit`$//p')
+        do
+          echo \"##vso[task.logissue type=error]Failed: `$t\"
+          cat `$t.out
+        done
+        exit 1
+      "@
+      if (!$?) { exit(1) }
+    displayName: 'Test (parallel)'
+    env:
+      HOME: $(Build.SourcesDirectory)
+      MSYSTEM: MINGW64
+      NO_SVN_TESTS: 1
+      GIT_TEST_SKIP_REBASE_P: 1
+  - powershell: |
+      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+        cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
+      }
     displayName: 'Unmount test-cache'
     condition: true
     env:
@@ -217,6 +294,12 @@ jobs:
       platform: Windows
       publishRunAttachments: false
     condition: succeededOrFailed()
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish trash directories of failed tests'
+    condition: failed()
+    inputs:
+      PathtoPublish: t/failed-test-artifacts
+      ArtifactName: failed-test-artifacts
 
 - job: linux32
   displayName: Linux32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,11 @@
-resources:
-- repo: self
-  fetchDepth: 1
+variables:
+  Agent.Source.Git.ShallowFetchDepth: 100
 
-phases:
-- phase: linux_clang
+jobs:
+- job: linux_clang
   displayName: linux-clang
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -37,11 +35,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: linux_gcc
+- job: linux_gcc
   displayName: linux-gcc
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -69,11 +66,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: osx_clang
+- job: osx_clang
   displayName: osx-clang
   condition: succeeded()
-  queue:
-    name: Hosted macOS
+  pool: Hosted macOS
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -99,11 +95,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: osx_gcc
+- job: osx_gcc
   displayName: osx-gcc
   condition: succeeded()
-  queue:
-    name: Hosted macOS
+  pool: Hosted macOS
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -127,11 +122,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: gettext_poison
+- job: gettext_poison
   displayName: GETTEXT_POISON
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -160,11 +154,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: windows
+- job: windows
   displayName: Windows
-  queue:
-    name: Hosted
-    timeoutInMinutes: 240
+  pool: Hosted
+  timeoutInMinutes: 240
   steps:
   - powershell: |
        if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
@@ -225,11 +218,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: linux32
+- job: linux32
   displayName: Linux32
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -266,11 +258,10 @@ phases:
       publishRunAttachments: false
     condition: succeededOrFailed()
 
-- phase: static_analysis
+- job: static_analysis
   displayName: StaticAnalysis
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1
@@ -288,11 +279,10 @@ phases:
     env:
       GITFILESHAREPWD: $(gitfileshare.pwd)
 
-- phase: documentation
+- job: documentation
   displayName: Documentation
   condition: succeeded()
-  queue:
-    name: Hosted Ubuntu 1604
+  pool: Hosted Ubuntu 1604
   steps:
   - bash: |
        test "$GITFILESHAREPWD" = '$(gitfileshare.pwd)' || ci/mount-fileshare.sh //gitfileshare.file.core.windows.net/test-cache gitfileshare "$GITFILESHAREPWD" "$HOME/test-cache" || exit 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,53 +175,23 @@ phases:
     env:
       GITFILESHAREPWD: $(gitfileshare.pwd)
   - powershell: |
-       # Helper to check the error level of the latest command (exit with error when appropriate)
-       function c() { if (!$?) { exit(1) } }
+      $urlbase = "https://dev.azure.com/git-for-windows/git/_apis/build/builds"
+      $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=22&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
+      $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[1].resource.downloadUrl
+      (New-Object Net.WebClient).DownloadFile($downloadUrl,"git-sdk-64-minimal.zip")
+      Expand-Archive git-sdk-64-minimal.zip -DestinationPath "$(Build.SourcesDirectory)" -Force
+      Remove-Item git-sdk-64-minimal.zip
 
-       # Add build agent's MinGit to PATH
-       $env:PATH = $env:AGENT_HOMEDIRECTORY +"\externals\\git\cmd;" +$env:PATH
-
-       # Helper to initialize (or update) a Git worktree
-       function init ($path, $url, $set_origin) {
-           if (Test-Path $path) {
-               cd $path; c
-               if (Test-Path .git) {
-                   git init; c
-               } else {
-                   git status
-               }
-           } else {
-               git init $path; c
-               cd $path; c
-           }
-           git config core.autocrlf false; c
-           git config core.untrackedCache true; c
-           if (($set_origin -ne 0) -and !(git config remote.origin.url)) {
-               git remote add origin $url; c
-           }
-           git fetch --depth=1 $url master; c
-           git reset --hard FETCH_HEAD; c
-           git clean -df; c
-       }
-
-       # Initialize Git for Windows' SDK
-       $sdk_path = "$(Build.SourcesDirectory)\git-sdk-64"
-       init "$sdk_path" "https://dev.azure.com/git-for-windows/git-sdk-64/_git/git-sdk-64" 0
-       init usr\src\build-extra https://github.com/git-for-windows/build-extra 1
-
-       # Let Git ignore the SDK and the test-cache
-       "/git-sdk-64/`n/test-cache/`n" | Out-File -NoNewLine -Encoding ascii -Append "$(Build.SourcesDirectory)\.git\info\exclude"
-
-       # Help MSYS2 runtime startup by initializing /etc/passwd
-       & "$sdk_path\git-cmd" --command=usr\\bin\\bash.exe -lc "mkpasswd -c >>/etc/passwd"; c
-    displayName: 'Initialize the Git for Windows SDK'
+      # Let Git ignore the SDK and the test-cache
+      "/git-sdk-64-minimal/`n/test-cache/`n" | Out-File -NoNewLine -Encoding ascii -Append "$(Build.SourcesDirectory)\.git\info\exclude"
+    displayName: 'Download git-sdk-64-minimal'
   - powershell: |
        # Helper to check the error level of the latest command (exit with error when appropriate)
        function c() { if (!$?) { exit(1) } }
 
        cd "$(Build.SourcesDirectory)"; c
 
-       git-sdk-64\git-cmd --command=usr\\bin\\bash.exe -lc @"
+       & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
          export MAKEFLAGS=-j10
          export DEVELOPER=1
          export NO_PERL=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,153 @@ variables:
   Agent.Source.Git.ShallowFetchDepth: 100
 
 jobs:
+- job: windows_build
+  displayName: Windows Build
+  pool: Hosted
+  timeoutInMinutes: 240
+  steps:
+  - powershell: |
+       if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+         net use s: \\gitfileshare.file.core.windows.net\test-cache "$GITFILESHAREPWD" /user:AZURE\gitfileshare /persistent:no
+         cmd /c mklink /d "$(Build.SourcesDirectory)\test-cache" S:\
+       }
+    displayName: 'Mount test-cache'
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+  - powershell: |
+      $urlbase = "https://dev.azure.com/git-for-windows/git/_apis/build/builds"
+      $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=22&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
+      $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[1].resource.downloadUrl
+      (New-Object Net.WebClient).DownloadFile($downloadUrl,"git-sdk-64-minimal.zip")
+      Expand-Archive git-sdk-64-minimal.zip -DestinationPath "$(Build.SourcesDirectory)" -Force
+      Remove-Item git-sdk-64-minimal.zip
+
+      # Let Git ignore the SDK and the test-cache
+      "/git-sdk-64-minimal/`n/test-cache/`n" | Out-File -NoNewLine -Encoding ascii -Append "$(Build.SourcesDirectory)\.git\info\exclude"
+    displayName: 'Download git-sdk-64-minimal'
+  - powershell: |
+       # Helper to check the error level of the latest command (exit with error when appropriate)
+       function c() { if (!$?) { exit(1) } }
+
+       cd "$(Build.SourcesDirectory)"; c
+
+       & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
+         export MAKEFLAGS=-j10
+         export DEVELOPER=1
+         export NO_PERL=1
+
+         mkdir -p artifacts &&
+         printf '%s\n%s\n\t%s\n\t%s\n' \
+           'include Makefile' \
+           'a:: `$(ALL_PROGRAMS) `$(SCRIPT_LIB) `$(BUILT_INS) `$(OTHER_PROGRAMS)  GIT-BUILD-OPTIONS `$(TEST_PROGRAMS) `$(test_bindir_programs) `$(NO_INSTALL) `$(MOFILES)' \
+           '`$(MAKE) -C templates' \
+           'tar czf artifacts/artifacts.tar.gz `$^ templates/blt/' >mak &&
+         make -f mak a
+       "@
+       c
+    displayName: 'Build test artifacts'
+    env:
+      HOME: $(Build.SourcesDirectory)
+      MSYSTEM: MINGW64
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Pipeline Artifact: test artifacts'
+    inputs:
+      artifactName: 'windows-artifacts'
+      targetPath: '$(Build.SourcesDirectory)\artifacts'
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Pipeline Artifact: git-sdk-64-minimal'
+    inputs:
+      artifactName: 'git-sdk-64-minimal'
+      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
+  - powershell: |
+       if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+         cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
+       }
+    displayName: 'Unmount test-cache'
+    condition: true
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+
+- job: windows_test
+  displayName: Windows Test
+  dependsOn: windows_build
+  condition: succeeded()
+  pool: Hosted
+  timeoutInMinutes: 240
+  strategy:
+    parallel: 10
+  steps:
+  - powershell: |
+      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+        net use s: \\gitfileshare.file.core.windows.net\test-cache "$GITFILESHAREPWD" /user:AZURE\gitfileshare /persistent:no
+        cmd /c mklink /d "$(Build.SourcesDirectory)\test-cache" S:\
+      }
+    displayName: 'Mount test-cache'
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download Pipeline Artifact: test artifacts'
+    inputs:
+      artifactName: 'windows-artifacts'
+      targetPath: '$(Build.SourcesDirectory)'
+  - task: DownloadPipelineArtifact@0
+    displayName: 'Download Pipeline Artifact: git-sdk-64-minimal'
+    inputs:
+      artifactName: 'git-sdk-64-minimal'
+      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
+  - powershell: |
+      & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
+        test -f artifacts.tar.gz || {
+          echo No test artifacts found\; skipping >&2
+          exit 0
+        }
+        tar xf artifacts.tar.gz || exit 1
+
+        # Let Git ignore the SDK and the test-cache
+        printf '%s\n' /git-sdk-64-minimal/ /test-cache/ >>.git/info/exclude
+
+        cd t &&
+        T=`$(ls -S t[0-9]`*.sh | awk NR%`$SYSTEM_TOTALJOBSINPHASE==`$((`$SYSTEM_JOBPOSITIONINPHASE-1))) &&
+        GIT_TEST_OPTS=\"--verbose-log -x\" GIT_PROVE_OPTS=\"--timer --jobs 10\" eval make -j10 `$T
+        test 0 != `$? || exit 0
+        cd test-results
+        for t in `$(grep -l '^[1-9]' *.exit | sed -n 's/\.exit`$//p')
+        do
+          echo \"##vso[task.logissue type=error]Failed: `$t\"
+          cat `$t.out
+        done
+        exit 1
+      "@
+      if (!$?) { exit(1) }
+    displayName: 'Test (parallel)'
+    env:
+      HOME: $(Build.SourcesDirectory)
+      MSYSTEM: MINGW64
+      NO_SVN_TESTS: 1
+      GIT_TEST_SKIP_REBASE_P: 1
+  - powershell: |
+      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
+        cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
+      }
+    displayName: 'Unmount test-cache'
+    condition: true
+    env:
+      GITFILESHAREPWD: $(gitfileshare.pwd)
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/TEST-*.xml'
+    inputs:
+      mergeTestResults: true
+      testRunTitle: 'windows'
+      platform: Windows
+      publishRunAttachments: false
+    condition: succeededOrFailed()
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish trash directories of failed tests'
+    condition: failed()
+    inputs:
+      PathtoPublish: t/failed-test-artifacts
+      ArtifactName: failed-test-artifacts
+
 - job: linux_clang
   displayName: linux-clang
   condition: succeeded()
@@ -153,153 +300,6 @@ jobs:
       platform: Linux
       publishRunAttachments: false
     condition: succeededOrFailed()
-
-- job: windows_build
-  displayName: Windows Build
-  pool: Hosted
-  timeoutInMinutes: 240
-  steps:
-  - powershell: |
-       if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
-         net use s: \\gitfileshare.file.core.windows.net\test-cache "$GITFILESHAREPWD" /user:AZURE\gitfileshare /persistent:no
-         cmd /c mklink /d "$(Build.SourcesDirectory)\test-cache" S:\
-       }
-    displayName: 'Mount test-cache'
-    env:
-      GITFILESHAREPWD: $(gitfileshare.pwd)
-  - powershell: |
-      $urlbase = "https://dev.azure.com/git-for-windows/git/_apis/build/builds"
-      $id = ((Invoke-WebRequest -UseBasicParsing "${urlbase}?definitions=22&statusFilter=completed&resultFilter=succeeded&`$top=1").content | ConvertFrom-JSON).value[0].id
-      $downloadUrl = ((Invoke-WebRequest -UseBasicParsing "${urlbase}/$id/artifacts").content | ConvertFrom-JSON).value[1].resource.downloadUrl
-      (New-Object Net.WebClient).DownloadFile($downloadUrl,"git-sdk-64-minimal.zip")
-      Expand-Archive git-sdk-64-minimal.zip -DestinationPath "$(Build.SourcesDirectory)" -Force
-      Remove-Item git-sdk-64-minimal.zip
-
-      # Let Git ignore the SDK and the test-cache
-      "/git-sdk-64-minimal/`n/test-cache/`n" | Out-File -NoNewLine -Encoding ascii -Append "$(Build.SourcesDirectory)\.git\info\exclude"
-    displayName: 'Download git-sdk-64-minimal'
-  - powershell: |
-       # Helper to check the error level of the latest command (exit with error when appropriate)
-       function c() { if (!$?) { exit(1) } }
-
-       cd "$(Build.SourcesDirectory)"; c
-
-       & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
-         export MAKEFLAGS=-j10
-         export DEVELOPER=1
-         export NO_PERL=1
-
-         mkdir -p artifacts &&
-         printf '%s\n%s\n\t%s\n\t%s\n' \
-           'include Makefile' \
-           'a:: `$(ALL_PROGRAMS) `$(SCRIPT_LIB) `$(BUILT_INS) `$(OTHER_PROGRAMS)  GIT-BUILD-OPTIONS `$(TEST_PROGRAMS) `$(test_bindir_programs) `$(NO_INSTALL) `$(MOFILES)' \
-           '`$(MAKE) -C templates' \
-           'tar czf artifacts/artifacts.tar.gz `$^ templates/blt/' >mak &&
-         make -f mak a
-       "@
-       c
-    displayName: 'Build test artifacts'
-    env:
-      HOME: $(Build.SourcesDirectory)
-      MSYSTEM: MINGW64
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Pipeline Artifact: test artifacts'
-    inputs:
-      artifactName: 'windows-artifacts'
-      targetPath: '$(Build.SourcesDirectory)\artifacts'
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Pipeline Artifact: git-sdk-64-minimal'
-    inputs:
-      artifactName: 'git-sdk-64-minimal'
-      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
-  - powershell: |
-       if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
-         cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
-       }
-    displayName: 'Unmount test-cache'
-    condition: true
-    env:
-      GITFILESHAREPWD: $(gitfileshare.pwd)
-
-- job: windows_test
-  displayName: Windows Test
-  dependsOn: windows_build
-  condition: succeeded()
-  pool: Hosted
-  timeoutInMinutes: 240
-  strategy:
-    parallel: 10
-  steps:
-  - powershell: |
-      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
-        net use s: \\gitfileshare.file.core.windows.net\test-cache "$GITFILESHAREPWD" /user:AZURE\gitfileshare /persistent:no
-        cmd /c mklink /d "$(Build.SourcesDirectory)\test-cache" S:\
-      }
-    displayName: 'Mount test-cache'
-    env:
-      GITFILESHAREPWD: $(gitfileshare.pwd)
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact: test artifacts'
-    inputs:
-      artifactName: 'windows-artifacts'
-      targetPath: '$(Build.SourcesDirectory)'
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact: git-sdk-64-minimal'
-    inputs:
-      artifactName: 'git-sdk-64-minimal'
-      targetPath: '$(Build.SourcesDirectory)\git-sdk-64-minimal'
-  - powershell: |
-      & git-sdk-64-minimal\usr\bin\bash.exe -lc @"
-        test -f artifacts.tar.gz || {
-          echo No test artifacts found\; skipping >&2
-          exit 0
-        }
-        tar xf artifacts.tar.gz || exit 1
-
-        # Let Git ignore the SDK and the test-cache
-        printf '%s\n' /git-sdk-64-minimal/ /test-cache/ >>.git/info/exclude
-
-        cd t &&
-        T=`$(ls -S t[0-9]`*.sh | awk NR%`$SYSTEM_TOTALJOBSINPHASE==`$((`$SYSTEM_JOBPOSITIONINPHASE-1))) &&
-        GIT_TEST_OPTS=\"--verbose-log -x\" GIT_PROVE_OPTS=\"--timer --jobs 10\" eval make -j10 `$T
-        test 0 != `$? || exit 0
-        cd test-results
-        for t in `$(grep -l '^[1-9]' *.exit | sed -n 's/\.exit`$//p')
-        do
-          echo \"##vso[task.logissue type=error]Failed: `$t\"
-          cat `$t.out
-        done
-        exit 1
-      "@
-      if (!$?) { exit(1) }
-    displayName: 'Test (parallel)'
-    env:
-      HOME: $(Build.SourcesDirectory)
-      MSYSTEM: MINGW64
-      NO_SVN_TESTS: 1
-      GIT_TEST_SKIP_REBASE_P: 1
-  - powershell: |
-      if ("$GITFILESHAREPWD" -ne "" -and "$GITFILESHAREPWD" -ne "`$`(gitfileshare.pwd)") {
-        cmd /c rmdir "$(Build.SourcesDirectory)\test-cache"
-      }
-    displayName: 'Unmount test-cache'
-    condition: true
-    env:
-      GITFILESHAREPWD: $(gitfileshare.pwd)
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results **/TEST-*.xml'
-    inputs:
-      mergeTestResults: true
-      testRunTitle: 'windows'
-      platform: Windows
-      publishRunAttachments: false
-    condition: succeededOrFailed()
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish trash directories of failed tests'
-    condition: failed()
-    inputs:
-      PathtoPublish: t/failed-test-artifacts
-      ArtifactName: failed-test-artifacts
 
 - job: linux32
   displayName: Linux32

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -1588,7 +1588,9 @@ static int fetch_one(struct remote *remote, int argc, const char **argv, int pru
 
 	sigchain_push_common(unlock_pack_on_signal);
 	atexit(unlock_pack);
+	sigchain_push(SIGPIPE, SIG_IGN);
 	exit_code = do_fetch(gtransport, &rs);
+	sigchain_pop(SIGPIPE);
 	refspec_clear(&rs);
 	transport_disconnect(gtransport);
 	gtransport = NULL;

--- a/compat/obstack.c
+++ b/compat/obstack.c
@@ -112,15 +112,15 @@ compat_symbol (libc, _obstack_compat, _obstack, GLIBC_2_0);
 
 # define CALL_CHUNKFUN(h, size) \
   (((h) -> use_extra_arg) \
-   ? (*(h)->chunkfun) ((h)->extra_arg, (size)) \
-   : (*(struct _obstack_chunk *(*) (long)) (h)->chunkfun) ((size)))
+   ? (*(h)->chunkfun.extra) ((h)->extra_arg, (size)) \
+   : (*(h)->chunkfun.plain) ((size)))
 
 # define CALL_FREEFUN(h, old_chunk) \
   do { \
     if ((h) -> use_extra_arg) \
-      (*(h)->freefun) ((h)->extra_arg, (old_chunk)); \
+      (*(h)->freefun.extra) ((h)->extra_arg, (old_chunk)); \
     else \
-      (*(void (*) (void *)) (h)->freefun) ((old_chunk)); \
+      (*(h)->freefun.plain) ((old_chunk)); \
   } while (0)
 
 
@@ -159,8 +159,8 @@ _obstack_begin (struct obstack *h,
       size = 4096 - extra;
     }
 
-  h->chunkfun = (struct _obstack_chunk * (*)(void *, long)) chunkfun;
-  h->freefun = (void (*) (void *, struct _obstack_chunk *)) freefun;
+  h->chunkfun.plain = chunkfun;
+  h->freefun.plain = freefun;
   h->chunk_size = size;
   h->alignment_mask = alignment - 1;
   h->use_extra_arg = 0;
@@ -206,8 +206,9 @@ _obstack_begin_1 (struct obstack *h, int size, int alignment,
       size = 4096 - extra;
     }
 
-  h->chunkfun = (struct _obstack_chunk * (*)(void *,long)) chunkfun;
-  h->freefun = (void (*) (void *, struct _obstack_chunk *)) freefun;
+  h->chunkfun.extra = (struct _obstack_chunk * (*)(void *,long)) chunkfun;
+  h->freefun.extra = (void (*) (void *, struct _obstack_chunk *)) freefun;
+
   h->chunk_size = size;
   h->alignment_mask = alignment - 1;
   h->extra_arg = arg;

--- a/compat/obstack.h
+++ b/compat/obstack.h
@@ -160,11 +160,15 @@ struct obstack		/* control current object in current chunk */
     void *tempptr;
   } temp;			/* Temporary for some macros.  */
   int   alignment_mask;		/* Mask of alignment for each object. */
-  /* These prototypes vary based on `use_extra_arg', and we use
-     casts to the prototypeless function type in all assignments,
-     but having prototypes here quiets -Wstrict-prototypes.  */
-  struct _obstack_chunk *(*chunkfun) (void *, long);
-  void (*freefun) (void *, struct _obstack_chunk *);
+  /* These prototypes vary based on `use_extra_arg'. */
+  union {
+    void *(*plain) (long);
+    struct _obstack_chunk *(*extra) (void *, long);
+  } chunkfun;
+  union {
+    void (*plain) (void *);
+    void (*extra) (void *, struct _obstack_chunk *);
+  } freefun;
   void *extra_arg;		/* first arg for chunk alloc/dealloc funcs */
   unsigned use_extra_arg:1;	/* chunk alloc/dealloc funcs take extra arg */
   unsigned maybe_empty_object:1;/* There is a possibility that the current
@@ -235,10 +239,10 @@ extern void (*obstack_alloc_failed_handler) (void);
 		    (void (*) (void *, void *)) (freefun), (arg))
 
 #define obstack_chunkfun(h, newchunkfun) \
-  ((h) -> chunkfun = (struct _obstack_chunk *(*)(void *, long)) (newchunkfun))
+  ((h)->chunkfun.extra = (struct _obstack_chunk *(*)(void *, long)) (newchunkfun))
 
 #define obstack_freefun(h, newfreefun) \
-  ((h) -> freefun = (void (*)(void *, struct _obstack_chunk *)) (newfreefun))
+  ((h)->freefun.extra = (void (*)(void *, struct _obstack_chunk *)) (newfreefun))
 
 #define obstack_1grow_fast(h,achar) (*((h)->next_free)++ = (achar))
 

--- a/compat/poll/poll.c
+++ b/compat/poll/poll.c
@@ -149,7 +149,7 @@ win32_compute_revents (HANDLE h, int *p_sought)
     case FILE_TYPE_PIPE:
       if (!once_only)
 	{
-	  NtQueryInformationFile = (PNtQueryInformationFile)
+	  NtQueryInformationFile = (PNtQueryInformationFile)(void (*)(void))
 	    GetProcAddress (GetModuleHandleA ("ntdll.dll"),
 			    "NtQueryInformationFile");
 	  once_only = TRUE;

--- a/compat/win32/exit-process.h
+++ b/compat/win32/exit-process.h
@@ -130,7 +130,8 @@ static int exit_process(HANDLE process, int exit_code)
 			HINSTANCE kernel32 = GetModuleHandleA("kernel32");
 			if (!kernel32)
 				die("BUG: cannot find kernel32");
-			exit_process_address = (LPTHREAD_START_ROUTINE)
+			exit_process_address =
+				(LPTHREAD_START_ROUTINE)(void (*)(void))
 				GetProcAddress(kernel32, "ExitProcess");
 			initialized = 1;
 		}

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -133,6 +133,8 @@ ifeq ($(uname_S),Darwin)
 	HAVE_BSD_SYSCTL = YesPlease
 	FREAD_READS_DIRECTORIES = UnfortunatelyYes
 	HAVE_NS_GET_EXECUTABLE_PATH = YesPlease
+	BASIC_CFLAGS += -I/usr/local/include
+	BASIC_LDFLAGS += -L/usr/local/lib
 endif
 ifeq ($(uname_S),SunOS)
 	NEEDS_SOCKET = YesPlease

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -610,7 +610,7 @@ ifneq (,$(wildcard ../THIS_IS_MSYSGIT))
 	NO_GETTEXT = YesPlease
 	COMPAT_CLFAGS += -D__USE_MINGW_ACCESS
 else
-	ifeq ($(shell expr "$(uname_R)" : '2\.'),2)
+	ifneq ($(shell expr "$(uname_R)" : '1\.'),2)
 		# MSys2
 		prefix = /usr/
 		# Enable DEP

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -189,8 +189,10 @@ static void send_request(struct fetch_pack_args *args,
 	if (args->stateless_rpc) {
 		send_sideband(fd, -1, buf->buf, buf->len, LARGE_PACKET_MAX);
 		packet_flush(fd);
-	} else
-		write_or_die(fd, buf->buf, buf->len);
+	} else {
+		if (write_in_full(fd, buf->buf, buf->len) < 0)
+			die_errno(_("unable to write to remote"));
+	}
 }
 
 static void insert_one_alternate_object(struct fetch_negotiator *negotiator,
@@ -1181,7 +1183,8 @@ static int send_fetch_request(struct fetch_negotiator *negotiator, int fd_out,
 
 	/* Send request */
 	packet_buf_flush(&req_buf);
-	write_or_die(fd_out, req_buf.buf, req_buf.len);
+	if (write_in_full(fd_out, req_buf.buf, req_buf.len) < 0)
+		die_errno(_("unable to write request to remote"));
 
 	strbuf_release(&req_buf);
 	return ret;

--- a/kwset.c
+++ b/kwset.c
@@ -38,7 +38,13 @@
 #include "compat/obstack.h"
 
 #define NCHAR (UCHAR_MAX + 1)
-#define obstack_chunk_alloc xmalloc
+/* adapter for `xmalloc()`, which takes `size_t`, not `long` */
+static void *obstack_chunk_alloc(long size)
+{
+	if (size < 0)
+		BUG("Cannot allocate a negative amount: %ld", size);
+	return xmalloc(size);
+}
 #define obstack_chunk_free free
 
 #define U(c) ((unsigned char) (c))

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -88,13 +88,15 @@ static void packet_trace(const char *buf, unsigned int len, int write)
 void packet_flush(int fd)
 {
 	packet_trace("0000", 4, 1);
-	write_or_die(fd, "0000", 4);
+	if (write_in_full(fd, "0000", 4) < 0)
+		die_errno(_("unable to write flush packet"));
 }
 
 void packet_delim(int fd)
 {
 	packet_trace("0001", 4, 1);
-	write_or_die(fd, "0001", 4);
+	if (write_in_full(fd, "0001", 4) < 0)
+		die_errno(_("unable to write delim packet"));
 }
 
 int packet_flush_gently(int fd)

--- a/t/t6500-gc.sh
+++ b/t/t6500-gc.sh
@@ -162,7 +162,15 @@ test_expect_success 'background auto gc respects lock for all operations' '
 	# now fake a concurrent gc that holds the lock; we can use our
 	# shell pid so that it looks valid.
 	hostname=$(hostname || echo unknown) &&
-	printf "$$ %s" "$hostname" >.git/gc.pid &&
+	shell_pid=$$ &&
+	if test_have_prereq MINGW && test -f /proc/$shell_pid/winpid
+	then
+		# In Git for Windows, Bash (actually, the MSYS2 runtime) has a
+		# different idea of PIDs than git.exe (actually Windows). Use
+		# the Windows PID in this case.
+		shell_pid=$(cat /proc/$shell_pid/winpid)
+	fi &&
+	printf "%d %s" "$shell_pid" "$hostname" >.git/gc.pid &&
 
 	# our gc should exit zero without doing anything
 	run_and_wait_for_auto_gc &&

--- a/t/t9822-git-p4-path-encoding.sh
+++ b/t/t9822-git-p4-path-encoding.sh
@@ -7,6 +7,13 @@ test_description='Clone repositories with non ASCII paths'
 UTF8_ESCAPED="a-\303\244_o-\303\266_u-\303\274.txt"
 ISO8859_ESCAPED="a-\344_o-\366_u-\374.txt"
 
+ISO8859="$(printf "$ISO8859_ESCAPED")" &&
+echo content123 >"$ISO8859" &&
+rm "$ISO8859" || {
+	skip_all="fs does not accept ISO-8859-1 filenames"
+	test_done
+}
+
 test_expect_success 'start p4d' '
 	start_p4d
 '

--- a/t/t9833-errors.sh
+++ b/t/t9833-errors.sh
@@ -45,33 +45,6 @@ test_expect_success 'ticket logged out' '
 	)
 '
 
-test_expect_success 'create group with short ticket expiry' '
-	P4TICKETS="$cli/tickets" &&
-	echo "newpassword" | p4 login &&
-	p4_add_user short_expiry_user &&
-	p4 -u short_expiry_user passwd -P password &&
-	p4 group -i <<-EOF &&
-	Group: testgroup
-	Timeout: 3
-	Users: short_expiry_user
-	EOF
-
-	p4 users | grep short_expiry_user
-'
-
-test_expect_success 'git operation with expired ticket' '
-	P4TICKETS="$cli/tickets" &&
-	P4USER=short_expiry_user &&
-	echo "password" | p4 login &&
-	(
-		cd "$git" &&
-		git p4 sync &&
-		sleep 5 &&
-		test_must_fail git p4 sync 2>errmsg &&
-		grep "failure accessing depot" errmsg
-	)
-'
-
 test_expect_success 'kill p4d' '
 	kill_p4d
 '


### PR DESCRIPTION
This backports:

* Two fixes needed to build on the macOS agents of Azure Pipelines, as they are upgraded to macOS Mojave now.
* A fix to allow building on Windows in the presence of v3.x of the MSYS2 runtime.
* A fix (two commits) to fix the flakiness of `t5570-git-daemon.sh` on macOS.
* Speedups to the Azure Pipeline (runs the tests in parallel now).