### PR TITLE
Trace2: A few final fixups from upstream/master targeting 2.22.0-RC

### DIFF
--- a/config.c
+++ b/config.c
@@ -1690,12 +1690,14 @@ static int do_git_config_sequence(const struct config_options *opts,
 
 	current_parsing_scope = CONFIG_SCOPE_SYSTEM;
 	if (git_config_system()) {
+		unsigned flag = opts->system_gently ? ACCESS_EACCES_OK : 0;
+
 		if (git_program_data_config() &&
-		    !access_or_die(git_program_data_config(), R_OK, 0))
+		    !access_or_die(git_program_data_config(), R_OK, flag))
 			ret += git_config_from_file(fn,
 						    git_program_data_config(),
 						    data);
-		if (!access_or_die(git_etc_gitconfig(), R_OK, 0))
+		if (!access_or_die(git_etc_gitconfig(), R_OK, flag))
 			ret += git_config_from_file(fn, git_etc_gitconfig(),
 						    data);
 	}
@@ -1827,6 +1829,7 @@ void read_very_early_config(config_fn_t cb, void *data)
 	opts.ignore_repo = 1;
 	opts.ignore_worktree = 1;
 	opts.ignore_cmdline = 1;
+	opts.system_gently = 1;
 
 	config_with_options(cb, data, NULL, &opts);
 }

--- a/config.h
+++ b/config.h
@@ -58,6 +58,7 @@ struct config_options {
 	unsigned int ignore_repo : 1;
 	unsigned int ignore_worktree : 1;
 	unsigned int ignore_cmdline : 1;
+	unsigned int system_gently : 1;
 	const char *commondir;
 	const char *git_dir;
 	config_parser_event_fn_t event_fn;

--- a/read-cache.c
+++ b/read-cache.c
@@ -3146,7 +3146,7 @@ static int write_shared_index(struct index_state *istate,
 	trace2_region_enter_printf("index", "shared/do_write_index",
 				   the_repository, "%s", (*temp)->filename.buf);
 	ret = do_write_index(si->base, *temp, 1);
-	trace2_region_enter_printf("index", "shared/do_write_index",
+	trace2_region_leave_printf("index", "shared/do_write_index",
 				   the_repository, "%s", (*temp)->filename.buf);
 
 	if (ret)

--- a/trace2.c
+++ b/trace2.c
@@ -565,10 +565,14 @@ void trace2_region_enter_printf_va_fl(const char *file, int line,
 }
 
 void trace2_region_enter_fl(const char *file, int line, const char *category,
-			    const char *label, const struct repository *repo)
+			    const char *label, const struct repository *repo, ...)
 {
+	va_list ap;
+	va_start(ap, repo);
 	trace2_region_enter_printf_va_fl(file, line, category, label, repo,
-					 NULL, NULL);
+					 NULL, ap);
+	va_end(ap);
+
 }
 
 void trace2_region_enter_printf_fl(const char *file, int line,
@@ -638,10 +642,13 @@ void trace2_region_leave_printf_va_fl(const char *file, int line,
 }
 
 void trace2_region_leave_fl(const char *file, int line, const char *category,
-			    const char *label, const struct repository *repo)
+			    const char *label, const struct repository *repo, ...)
 {
+	va_list ap;
+	va_start(ap, repo);
 	trace2_region_leave_printf_va_fl(file, line, category, label, repo,
-					 NULL, NULL);
+					 NULL, ap);
+	va_end(ap);
 }
 
 void trace2_region_leave_printf_fl(const char *file, int line,

--- a/trace2.c
+++ b/trace2.c
@@ -727,7 +727,7 @@ void trace2_data_json_fl(const char *file, int line, const char *category,
 	us_elapsed_region = tr2tls_region_elasped_self(us_now);
 
 	for_each_wanted_builtin (j, tgt_j)
-		if (tgt_j->pfn_data_fl)
+		if (tgt_j->pfn_data_json_fl)
 			tgt_j->pfn_data_json_fl(file, line, us_elapsed_absolute,
 						us_elapsed_region, category,
 						repo, key, value);

--- a/trace2.h
+++ b/trace2.h
@@ -257,7 +257,7 @@ void trace2_def_repo_fl(const char *file, int line, struct repository *repo);
  * on this thread.
  */
 void trace2_region_enter_fl(const char *file, int line, const char *category,
-			    const char *label, const struct repository *repo);
+			    const char *label, const struct repository *repo, ...);
 
 #define trace2_region_enter(category, label, repo) \
 	trace2_region_enter_fl(__FILE__, __LINE__, (category), (label), (repo))
@@ -297,7 +297,7 @@ void trace2_region_enter_printf(const char *category, const char *label,
  * in this nesting level.
  */
 void trace2_region_leave_fl(const char *file, int line, const char *category,
-			    const char *label, const struct repository *repo);
+			    const char *label, const struct repository *repo, ...);
 
 #define trace2_region_leave(category, label, repo) \
 	trace2_region_leave_fl(__FILE__, __LINE__, (category), (label), (repo))

--- a/trace2/tr2_tgt_event.c
+++ b/trace2/tr2_tgt_event.c
@@ -193,7 +193,7 @@ static void fn_atexit(uint64_t us_elapsed_absolute, int code)
 static void maybe_add_string_va(struct json_writer *jw, const char *field_name,
 				const char *fmt, va_list ap)
 {
-	if (fmt && *fmt && ap) {
+	if (fmt && *fmt) {
 		va_list copy_ap;
 		struct strbuf buf = STRBUF_INIT;
 

--- a/trace2/tr2_tgt_normal.c
+++ b/trace2/tr2_tgt_normal.c
@@ -127,7 +127,7 @@ static void fn_atexit(uint64_t us_elapsed_absolute, int code)
 static void maybe_append_string_va(struct strbuf *buf, const char *fmt,
 				   va_list ap)
 {
-	if (fmt && *fmt && ap) {
+	if (fmt && *fmt) {
 		va_list copy_ap;
 
 		va_copy(copy_ap, ap);

--- a/trace2/tr2_tgt_perf.c
+++ b/trace2/tr2_tgt_perf.c
@@ -212,7 +212,7 @@ static void fn_atexit(uint64_t us_elapsed_absolute, int code)
 static void maybe_append_string_va(struct strbuf *buf, const char *fmt,
 				   va_list ap)
 {
-	if (fmt && *fmt && ap) {
+	if (fmt && *fmt) {
 		va_list copy_ap;
 
 		va_copy(copy_ap, ap);


### PR DESCRIPTION
Here are 4 commits that were added to upstream/master after I pulled the last round
of trace2 changes from upstream.  These are not essential, but may prevent a few compiler
or runtime problems.

These were taken from the following gitster branches.

jh/trace2:
22a7338318e3709b578d5c041af0afaf95b8fe21 trace2: fix incorrect function pointer check

jh/trace2 and ab/trace2-typofix:
c173542c84cdf5e71b393e91f9d9664a85f995b2 trace2: fix up a missing "leave" entry point

tb/trace2-va-list-fix:
ad006fe419efda47b0012347c5c2925f9a082101 trace2: NULL is not allowed for va_list

jh/trace2-sid-fix:
f672deec2d56b0d7ae64ce3efd918e02efc58b9c trace2: fixup access problem on /etc/gitconfig in read_very_early_config  (**modified on merge**)

I did not bring over the gitster/js/trace2-to-directory branch because we don't
need it with our usage pattern.

