### PR TITLE
Fix problems with `git difftool` and a large number of files

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -489,7 +489,7 @@ static const char *external_diff(void)
 
 	if (done_preparing)
 		return external_diff_cmd;
-	external_diff_cmd = getenv("GIT_EXTERNAL_DIFF");
+	external_diff_cmd = xstrdup_or_null(getenv("GIT_EXTERNAL_DIFF"));
 	if (!external_diff_cmd)
 		external_diff_cmd = external_diff_cmd_cfg;
 	done_preparing = 1;


### PR DESCRIPTION
Due to some mishandling of the return value of `getenv("GIT_EXTERNAL_DIFF")`, when calling `git difftool` in a worktree with _lots_ of files, Git launched commands with a corrupt command-line.

This was fixed in Git v2.21.0, and here is a backport to vfs-2.20.1.