### PR TITLE
Default to using --no-renames for status when in conflict state

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -36,6 +36,7 @@
 #include "help.h"
 #include "commit-reach.h"
 #include "commit-graph.h"
+#include "gvfs.h"
 
 static const char * const builtin_commit_usage[] = {
 	N_("git commit [<options>] [--] <pathspec>..."),
@@ -1519,6 +1520,9 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 		usage_with_options(builtin_status_usage, builtin_status_options);
 
 	status_init_config(&s, git_status_config);
+	if (gvfs_config_is_set(GVFS_STATUS_NORENAMES_ON_CONFLICT) && s.whence != FROM_COMMIT)
+		no_renames = 1;
+
 	argc = parse_options(argc, argv, prefix,
 			     builtin_status_options,
 			     builtin_status_usage, 0);

--- a/gvfs.h
+++ b/gvfs.h
@@ -16,6 +16,7 @@
 #define GVFS_MISSING_OK                             (1 << 2)
 #define GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT       (1 << 3)
 #define GVFS_FETCH_SKIP_REACHABILITY_AND_UPLOADPACK (1 << 4)
+#define GVFS_STATUS_NORENAMES_ON_CONFLICT           (1 << 5)
 #define GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS      (1 << 6)
 
 void gvfs_load_config_value(const char *value);


### PR DESCRIPTION
I'm actually questioning whether we even need to set the `--no-renames` any more because I was unable to repro a slow status in the conflicted state.  I know that there has been some work done around rename detection and maybe the changes take into account the skip-worktree bit now and don't try to find renames on files with the bit on?  If someone knows that would be great.  I will look through the code and see what the rename detection is doing now as well.

When using a large repo status will take a long time looking for renames
when in a conflict state.

This change will turn off renames for status when there is a conflict file
present to improve the performance.
