### PR TITLE
Region and data events for unpack_trees and cache_tree operations

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -806,7 +806,7 @@ static int merge_working_tree(const struct checkout_opts *opts,
 	if (!active_cache_tree)
 		active_cache_tree = cache_tree();
 
-	if (!cache_tree_fully_valid(active_cache_tree))
+	if (!cache_tree_fully_valid__trace2(active_cache_tree, "merge_working_tree/cache_tree_fully_valid"))
 		cache_tree_update(&the_index, WRITE_TREE_SILENT | WRITE_TREE_REPAIR);
 
 	if (write_locked_index(&the_index, &lock_file, COMMIT_LOCK))

--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -516,7 +516,7 @@ static int reset_tree(struct tree *tree, const struct checkout_opts *o,
 	opts.dst_index = &the_index;
 	parse_tree(tree);
 	init_tree_desc(&tree_desc, tree->buffer, tree->size);
-	switch (unpack_trees(1, &tree_desc, &opts)) {
+	switch (unpack_trees__trace2(1, &tree_desc, &opts, "checkout/reset_tree/unpack_trees")) {
 	case -2:
 		*writeout_error = 1;
 		/*
@@ -717,7 +717,7 @@ static int merge_working_tree(const struct checkout_opts *opts,
 		tree = parse_tree_indirect(&new_branch_info->commit->object.oid);
 		init_tree_desc(&trees[1], tree->buffer, tree->size);
 
-		ret = unpack_trees(2, trees, &topts);
+		ret = unpack_trees__trace2(2, trees, &topts, "checkout/merge_working_tree/unpack_trees");
 		clear_unpack_trees_porcelain(&topts);
 		if (ret == -1) {
 			/*

--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -766,7 +766,7 @@ static int checkout(int submodule_progress)
 	tree = parse_tree_indirect(&oid);
 	parse_tree(tree);
 	init_tree_desc(&t, tree->buffer, tree->size);
-	if (unpack_trees(1, &t, &opts) < 0)
+	if (unpack_trees__trace2(1, &t, &opts, "clone/checkout/unpack_trees") < 0)
 		die(_("unable to checkout working tree"));
 
 	if (write_locked_index(&the_index, &lock_file, COMMIT_LOCK))

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -422,7 +422,7 @@ static void create_base_index(const struct commit *current_head)
 		die(_("failed to unpack HEAD tree object"));
 	parse_tree(tree);
 	init_tree_desc(&t, tree->buffer, tree->size);
-	if (unpack_trees(1, &t, &opts))
+	if (unpack_trees__trace2(1, &t, &opts, "commit/create_base_index/unpack_trees"))
 		exit(128); /* We've already reported the error, finish dying */
 }
 

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -531,7 +531,7 @@ static const char *prepare_index(int argc, const char **argv, const char *prefix
 		hold_locked_index(&index_lock, LOCK_DIE_ON_ERROR);
 		refresh_cache_or_die(refresh_flags);
 		if (active_cache_changed
-		    || !cache_tree_fully_valid(active_cache_tree))
+		    || !cache_tree_fully_valid__trace2(active_cache_tree, "prepare_index/cache_tree_fully_valid"))
 			update_main_cache_tree(WRITE_TREE_SILENT);
 		if (write_locked_index(&the_index, &index_lock,
 				       COMMIT_LOCK | SKIP_IF_UNCHANGED))

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -677,7 +677,7 @@ static int read_tree_trivial(struct object_id *common, struct object_id *head,
 		parse_tree(trees[i]);
 		init_tree_desc(t+i, trees[i]->buffer, trees[i]->size);
 	}
-	if (unpack_trees(nr_trees, t, &opts))
+	if (unpack_trees__trace2(nr_trees, t, &opts, "merge/read_trivial_tree/unpack_trees"))
 		return -1;
 	return 0;
 }

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -247,7 +247,7 @@ int cmd_read_tree(int argc, const char **argv, const char *unused_prefix)
 		parse_tree(tree);
 		init_tree_desc(t+i, tree->buffer, tree->size);
 	}
-	if (unpack_trees(nr_trees, t, &opts))
+	if (unpack_trees__trace2(nr_trees, t, &opts, "read-tree/cmd_read_tree/unpack_trees"))
 		return 128;
 
 	if (opts.debug_unpack || opts.dry_run)

--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -851,7 +851,7 @@ static int reset_head(struct object_id *oid, const char *action,
 		goto leave_reset_head;
 	}
 
-	if (unpack_trees(nr, desc, &unpack_tree_opts)) {
+	if (unpack_trees__trace2(nr, desc, &unpack_tree_opts, "rebase/reset_head/unpack_trees")) {
 		ret = -1;
 		goto leave_reset_head;
 	}

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -95,7 +95,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 	}
 	nr++;
 
-	if (unpack_trees(nr, desc, &opts))
+	if (unpack_trees__trace2(nr, desc, &opts, "reset/reset_index/unpack_trees"))
 		goto out;
 
 	if (reset_type == MIXED || reset_type == HARD) {

--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -100,9 +100,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 
 	if (reset_type == MIXED || reset_type == HARD) {
 		tree = parse_tree_indirect(oid);
-		trace2_region_enter("exp", "prime_cache_tree", the_repository);
 		prime_cache_tree(the_repository, the_repository->index, tree);
-		trace2_region_leave("exp", "prime_cache_tree", the_repository);
 	}
 
 	ret = 0;

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -257,7 +257,7 @@ static int reset_tree(struct object_id *i_tree, int update, int reset)
 	opts.update = update;
 	opts.fn = oneway_merge;
 
-	if (unpack_trees(nr_trees, t, &opts))
+	if (unpack_trees__trace2(nr_trees, t, &opts, "stash/reset_tree/unpack_trees"))
 		return -1;
 
 	if (write_locked_index(&the_index, &lock_file, COMMIT_LOCK))

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -715,10 +715,14 @@ void prime_cache_tree(struct repository *r,
 		      struct index_state *istate,
 		      struct tree *tree)
 {
+	trace2_region_enter("cache_tree", "prime_cache_tree", r);
+
 	cache_tree_free(&istate->cache_tree);
 	istate->cache_tree = cache_tree();
 	prime_cache_tree_rec(r, istate->cache_tree, tree);
 	istate->cache_changed |= CACHE_TREE_CHANGED;
+
+	trace2_region_leave("cache_tree", "prime_cache_tree", r);
 }
 
 /*

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -463,7 +463,11 @@ int cache_tree_update(struct index_state *istate, int flags)
 	if (i)
 		return i;
 	trace_performance_enter();
+	trace2_region_enter("cache_tree", "cache_tree_update/update_one", NULL);
+
 	i = update_one(it, cache, entries, "", 0, &skip, flags);
+
+	trace2_region_leave("cache_tree", "cache_tree_update/update_one", NULL);
 	trace_performance_leave("cache_tree_update");
 	if (i < 0)
 		return i;

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -235,6 +235,17 @@ int cache_tree_fully_valid(struct cache_tree *it)
 	return 1;
 }
 
+int cache_tree_fully_valid__trace2(struct cache_tree *it, const char *label)
+{
+	int result;
+
+	trace2_region_enter("cache_tree", label, NULL);
+	result = cache_tree_fully_valid(it);
+	trace2_region_leave("cache_tree", label, NULL);
+
+	return result;
+}
+
 static int update_one(struct cache_tree *it,
 		      struct cache_entry **cache,
 		      int entries,
@@ -655,7 +666,7 @@ int write_index_as_tree(struct object_id *oid, struct index_state *index_state, 
 	if (!index_state->cache_tree)
 		index_state->cache_tree = cache_tree();
 
-	was_valid = cache_tree_fully_valid(index_state->cache_tree);
+	was_valid = cache_tree_fully_valid__trace2(index_state->cache_tree, "write_index_as_tree/cache_tree_fully_valid");
 	if (!was_valid) {
 		if (cache_tree_update(index_state, flags) < 0) {
 			ret = WRITE_TREE_UNMERGED_INDEX;

--- a/cache-tree.h
+++ b/cache-tree.h
@@ -31,6 +31,7 @@ void cache_tree_write(struct strbuf *, struct cache_tree *root);
 struct cache_tree *cache_tree_read(const char *buffer, unsigned long size);
 
 int cache_tree_fully_valid(struct cache_tree *);
+int cache_tree_fully_valid__trace2(struct cache_tree *it, const char *label);
 int cache_tree_update(struct index_state *, int);
 void cache_tree_verify(struct repository *, struct index_state *);
 

--- a/diff-lib.c
+++ b/diff-lib.c
@@ -515,7 +515,7 @@ static int diff_cache(struct rev_info *revs,
 	opts.pathspec->recursive = 1;
 
 	init_tree_desc(&t, tree->buffer, tree->size);
-	return unpack_trees(1, &t, &opts);
+	return unpack_trees__trace2(1, &t, &opts, "diff-lib/diff_cache/unpack_trees");
 }
 
 int run_diff_index(struct rev_info *revs, int cached)

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -391,7 +391,7 @@ static int unpack_trees_start(struct merge_options *opt,
 	init_tree_desc_from_tree(t+1, head);
 	init_tree_desc_from_tree(t+2, merge);
 
-	rc = unpack_trees(3, t, &opt->unpack_opts);
+	rc = unpack_trees__trace2(3, t, &opt->unpack_opts, "merge-recursive/unpack_trees_start/unpack_trees");
 	cache_tree_free(&opt->repo->index->cache_tree);
 
 	/*

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -433,7 +433,7 @@ struct tree *write_tree_from_memory(struct merge_options *opt)
 	if (!istate->cache_tree)
 		istate->cache_tree = cache_tree();
 
-	if (!cache_tree_fully_valid(istate->cache_tree) &&
+	if (!cache_tree_fully_valid__trace2(istate->cache_tree, "write_tree_from_memory/cache_tree_fully_valid") &&
 	    cache_tree_update(istate, 0) < 0) {
 		err(opt, _("error building trees"));
 		return NULL;

--- a/merge.c
+++ b/merge.c
@@ -96,7 +96,7 @@ int checkout_fast_forward(struct repository *r,
 	opts.fn = twoway_merge;
 	setup_unpack_trees_porcelain(&opts, "merge");
 
-	if (unpack_trees(nr_trees, t, &opts)) {
+	if (unpack_trees__trace2(nr_trees, t, &opts, "merge/checkout_ff/unpack_trees")) {
 		rollback_lock_file(&lock_file);
 		clear_unpack_trees_porcelain(&opts);
 		return -1;

--- a/read-cache.c
+++ b/read-cache.c
@@ -1960,6 +1960,17 @@ static void *load_index_extensions(void *_data)
 	return NULL;
 }
 
+static void *load_index_extensions_threadproc(void *_data)
+{
+	void *result;
+
+	trace2_thread_start("load_index_extensions");
+	result = load_index_extensions(_data);
+	trace2_thread_exit();
+
+	return result;
+}
+
 /*
  * A helper function that will load the specified range of cache entries
  * from the memory mapped file and add them to the given index.
@@ -2035,12 +2046,17 @@ static void *load_cache_entries_thread(void *_data)
 	struct load_cache_entries_thread_data *p = _data;
 	int i;
 
+	trace2_thread_start("load_cache_entries");
+
 	/* iterate across all ieot blocks assigned to this thread */
 	for (i = p->ieot_start; i < p->ieot_start + p->ieot_blocks; i++) {
 		p->consumed += load_cache_entry_block(p->istate, p->ce_mem_pool,
 			p->offset, p->ieot->entries[i].nr, p->mmap, p->ieot->entries[i].offset, NULL);
 		p->offset += p->ieot->entries[i].nr;
 	}
+
+	trace2_thread_exit();
+
 	return NULL;
 }
 
@@ -2190,7 +2206,7 @@ int do_read_index(struct index_state *istate, const char *path, int must_exist)
 			int err;
 
 			p.src_offset = extension_offset;
-			err = pthread_create(&p.pthread, NULL, load_index_extensions, &p);
+			err = pthread_create(&p.pthread, NULL, load_index_extensions_threadproc, &p);
 			if (err)
 				die(_("unable to create load_index_extensions thread: %s"), strerror(err));
 

--- a/run-command.c
+++ b/run-command.c
@@ -1407,6 +1407,17 @@ int run_hook_argv(const char *const *env, const char *name,
 	const char *p;
 
 	p = find_hook(name);
+	/*
+	 * Backwards compatibility hack in VFS for Git: when originally
+	 * introduced (and used!), it was called `post-index-changed`, but this
+	 * name was changed during the review on the Git mailing list.
+	 *
+	 * Therefore, when the `post-index-change` hook is not found, let's
+	 * look for a hook with the old name (which would be found in case of
+	 * already-existing checkouts).
+	 */
+	if (!p && !strcmp(name, "post-index-change"))
+		p = find_hook("post-index-changed");
 	if (!p)
 		return 0;
 

--- a/sequencer.c
+++ b/sequencer.c
@@ -641,7 +641,7 @@ static struct object_id *get_cache_tree_oid(struct index_state *istate)
 	if (!istate->cache_tree)
 		istate->cache_tree = cache_tree();
 
-	if (!cache_tree_fully_valid(istate->cache_tree))
+	if (!cache_tree_fully_valid__trace2(istate->cache_tree, "get_cache_tree_oid/cache_tree_fully_valid"))
 		if (cache_tree_update(istate, 0)) {
 			error(_("unable to update cache tree"));
 			return NULL;

--- a/sequencer.c
+++ b/sequencer.c
@@ -3202,7 +3202,7 @@ static int do_reset(struct repository *r,
 		return -1;
 	}
 
-	if (unpack_trees(1, &desc, &unpack_tree_opts)) {
+	if (unpack_trees__trace2(1, &desc, &unpack_tree_opts, "sequencer/do_reset/unpack_trees")) {
 		rollback_lock_file(&lock);
 		free((void *)desc.buffer);
 		strbuf_release(&ref_name);

--- a/t/t7113-post-index-change-hook.sh
+++ b/t/t7113-post-index-change-hook.sh
@@ -12,6 +12,36 @@ test_expect_success 'setup' '
 	git commit -m "initial"
 '
 
+test_expect_success 'post-index-changed' '
+	mkdir -p .git/hooks &&
+	test_when_finished "rm -f .git/hooks/post-index-changed marker" &&
+	write_script .git/hooks/post-index-changed <<-\EOF &&
+	: >marker
+	EOF
+
+	: make sure -changed is called if -change does not exist &&
+	test_when_finished "echo testing >dir1/file2.txt && git status" &&
+	echo changed >dir1/file2.txt &&
+	: force index to be dirty &&
+	test-tool chmtime -60 .git/index &&
+	git status &&
+	test_path_is_file marker &&
+
+	test_when_finished "rm -f .git/hooks/post-index-change marker2" &&
+	write_script .git/hooks/post-index-change <<-\EOF &&
+	: >marker2
+	EOF
+
+	: make sure -changed is not called if -change exists &&
+	rm -f marker marker2 &&
+	echo testing >dir1/file2.txt &&
+	: force index to be dirty &&
+	test-tool chmtime -60 .git/index &&
+	git status &&
+	test_path_is_missing marker &&
+	test_path_is_file marker2
+'
+
 test_expect_success 'test status, add, commit, others trigger hook without flags set' '
 	mkdir -p .git/hooks &&
 	write_script .git/hooks/post-index-change <<-\EOF &&

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1670,6 +1670,19 @@ return_failed:
 	goto done;
 }
 
+int unpack_trees__trace2(unsigned n, struct tree_desc *t,
+			 struct unpack_trees_options *options,
+			 const char *label)
+{
+	int result;
+
+	trace2_region_enter("unpacktree", label, NULL);
+	result = unpack_trees(n, t, options);
+	trace2_region_leave("unpacktree", label, NULL);
+
+	return result;
+}
+
 /* Here come the merge functions */
 
 static int reject_merge(const struct cache_entry *ce,

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1641,7 +1641,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 				cache_tree_verify(the_repository, &o->result);
 			if (!o->result.cache_tree)
 				o->result.cache_tree = cache_tree();
-			if (!cache_tree_fully_valid(o->result.cache_tree))
+			if (!cache_tree_fully_valid__trace2(o->result.cache_tree, "unpack_trees/cache_tree_fully_valid"))
 				cache_tree_update(&o->result,
 						  WRITE_TREE_SILENT |
 						  WRITE_TREE_REPAIR);

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -88,6 +88,9 @@ struct unpack_trees_options {
 
 int unpack_trees(unsigned n, struct tree_desc *t,
 		 struct unpack_trees_options *options);
+int unpack_trees__trace2(unsigned n, struct tree_desc *t,
+			 struct unpack_trees_options *options,
+			 const char *label);
 
 int verify_uptodate(const struct cache_entry *ce,
 		    struct unpack_trees_options *o);


### PR DESCRIPTION
This series adds regions around calls to unpack_trees() as we've discussed earlier.
And adds regions and a few data events around some of the cache_tree code.
These are marked "trace2:gvfs:experiment" to indicate that we may or may not
want to upstream them.

Finally, the "trace2:read_cache" commit adds thread events around the multi-threading
that Ben added when reading the index.  This commit should go upstream.

The first commit is a revert of a commit from my previous experimental series.

I'd like to consider shipping this in our vfs-2.22.0 release, but it is not urgent.
