### PR TITLE
[DO NOT MERGE] unpack-trees: trace time in last_exclude_matching

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1059,6 +1059,9 @@ int match_pathname(const char *pathname, int pathlen,
 				 WM_PATHNAME) == 0;
 }
 
+long last_exclude_num = 0;
+long last_exclude_ns = 0;
+
 /*
  * Scan the given exclude list in reverse to see whether pathname
  * should be ignored.  The first match (i.e. the last on the list), if
@@ -1074,6 +1077,7 @@ static struct exclude *last_exclude_matching_from_list(const char *pathname,
 {
 	struct exclude *exc = NULL; /* undecided */
 	int i;
+	long starttime = getnanotime();
 
 	if (!el->nr)
 		return NULL;	/* undefined */
@@ -1109,6 +1113,10 @@ static struct exclude *last_exclude_matching_from_list(const char *pathname,
 			break;
 		}
 	}
+
+	last_exclude_num++;
+	last_exclude_ns += getnanotime() - starttime;
+
 	return exc;
 }
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1404,6 +1404,9 @@ static int clear_ce_flags_1(struct index_state *istate,
 	return nr - (cache_end - cache);
 }
 
+extern long last_exclude_num;
+extern long last_exclude_ns;
+
 static int clear_ce_flags(struct index_state *istate,
 			  int select_mask, int clear_mask,
 			  struct exclude_list *el)
@@ -1411,6 +1414,9 @@ static int clear_ce_flags(struct index_state *istate,
 	static struct strbuf prefix = STRBUF_INIT;
 	char label[100];
 	int rval;
+
+	last_exclude_num = 0;
+	last_exclude_ns = 0;
 
 	strbuf_reset(&prefix);
 
@@ -1423,6 +1429,9 @@ static int clear_ce_flags(struct index_state *istate,
 				&prefix,
 				select_mask, clear_mask,
 				el, 0);
+	trace2_data_intmax("exp", the_repository, "last_exclude_num", last_exclude_num);
+	trace2_data_intmax("exp", the_repository, "last_exclude_ns", last_exclude_ns);
+
 	trace2_region_leave("exp", label, the_repository);
 
 	return rval;


### PR DESCRIPTION
This will help identify issues with large sparse-checkout files and
will measure the potential improvement by using a prefix-only model.