### PR TITLE
unpack-trees: enable fscache for sparse-checkout

### DIFF
--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1437,7 +1437,9 @@ static void mark_new_skip_worktree(struct exclude_list *el,
 	 * 2. Widen worktree according to sparse-checkout file.
 	 * Matched entries will have skip_wt_flag cleared (i.e. "in")
 	 */
+	enable_fscache(istate->cache_nr);
 	clear_ce_flags(istate, select_flag, skip_wt_flag, el);
+	disable_fscache();
 }
 
 static int verify_absent(const struct cache_entry *,


### PR DESCRIPTION
When updating the skip-worktree bits in the index to align with new
values in a sparse-checkout file, Git scans the entire working
directory with lstat() calls. In a sparse-checkout, many of these
lstat() calls are for paths that do not exist.

Enable the fscache feature during this scan.