### PR TITLE
Add experimental trace2 regions around cache-tree, unpack_trees, and read_index thread operations.

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -100,9 +100,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 
 	if (reset_type == MIXED || reset_type == HARD) {
 		tree = parse_tree_indirect(oid);
-		trace2_region_enter("exp", "prime_cache_tree", the_repository);
 		prime_cache_tree(the_repository, the_repository->index, tree);
-		trace2_region_leave("exp", "prime_cache_tree", the_repository);
 	}
 
 	ret = 0;

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -715,10 +715,14 @@ void prime_cache_tree(struct repository *r,
 		      struct index_state *istate,
 		      struct tree *tree)
 {
+	trace2_region_enter("cache_tree", "prime_cache_tree", r);
+
 	cache_tree_free(&istate->cache_tree);
 	istate->cache_tree = cache_tree();
 	prime_cache_tree_rec(r, istate->cache_tree, tree);
 	istate->cache_changed |= CACHE_TREE_CHANGED;
+
+	trace2_region_leave("cache_tree", "prime_cache_tree", r);
 }
 
 /*

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -463,7 +463,9 @@ int cache_tree_update(struct index_state *istate, int flags)
 	if (i)
 		return i;
 	trace_performance_enter();
+	trace2_region_enter("cache_tree", "update_one", NULL);
 	i = update_one(it, cache, entries, "", 0, &skip, flags);
+	trace2_region_leave("cache_tree", "update_one", NULL);
 	trace_performance_leave("cache_tree_update");
 	if (i < 0)
 		return i;

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -221,7 +221,7 @@ static void discard_unused_subtrees(struct cache_tree *it)
 	}
 }
 
-int cache_tree_fully_valid(struct cache_tree *it)
+static int cache_tree_fully_valid_1(struct cache_tree *it)
 {
 	int i;
 	if (!it)
@@ -229,10 +229,21 @@ int cache_tree_fully_valid(struct cache_tree *it)
 	if (it->entry_count < 0 || !has_object_file(&it->oid))
 		return 0;
 	for (i = 0; i < it->subtree_nr; i++) {
-		if (!cache_tree_fully_valid(it->down[i]->cache_tree))
+		if (!cache_tree_fully_valid_1(it->down[i]->cache_tree))
 			return 0;
 	}
 	return 1;
+}
+
+int cache_tree_fully_valid(struct cache_tree *it)
+{
+	int result;
+
+	trace2_region_enter("cache_tree", "cache_tree_fully_valid", NULL);
+	result = cache_tree_fully_valid_1(it);
+	trace2_region_leave("cache_tree", "cache_tree_fully_valid", NULL);
+
+	return result;
 }
 
 static int update_one(struct cache_tree *it,

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -526,7 +526,12 @@ static void write_one(struct strbuf *buffer, struct cache_tree *it,
 
 void cache_tree_write(struct strbuf *sb, struct cache_tree *root)
 {
+	trace2_region_enter("cache_tree", "write_one", NULL);
+
 	write_one(sb, root, "", 0);
+
+	trace2_data_intmax("cache_tree", NULL, "write_size", (intmax_t)sb->len);
+	trace2_region_leave("cache_tree", "write_one", NULL);
 }
 
 static struct cache_tree *read_one(const char **buffer, unsigned long *size_p)
@@ -615,9 +620,20 @@ static struct cache_tree *read_one(const char **buffer, unsigned long *size_p)
 
 struct cache_tree *cache_tree_read(const char *buffer, unsigned long size)
 {
+	struct cache_tree *p;
+
 	if (buffer[0])
 		return NULL; /* not the whole tree */
-	return read_one(&buffer, &size);
+
+	trace2_region_enter("cache_tree", "read_one", NULL);
+	trace2_data_intmax("cache_tree", NULL, "read_size", (intmax_t)size);
+
+	p = read_one(&buffer, &size);
+
+	trace2_region_leave("cache_tree", "read_one", NULL);
+
+	return p;
+	
 }
 
 static struct cache_tree *cache_tree_find(struct cache_tree *it, const char *path)

--- a/read-cache.c
+++ b/read-cache.c
@@ -2936,8 +2936,12 @@ static int do_write_index(struct index_state *istate, struct tempfile *tempfile,
 		struct strbuf sb = STRBUF_INIT;
 
 		cache_tree_write(&sb, istate->cache_tree);
+
+		trace2_region_enter("cache_tree", "extension/write", NULL);
 		err = write_index_ext_header(&c, &eoie_c, newfd, CACHE_EXT_TREE, sb.len) < 0
 			|| ce_write(&c, newfd, sb.buf, sb.len) < 0;
+		trace2_region_leave("cache_tree", "extension/write", NULL);
+
 		strbuf_release(&sb);
 		if (err)
 			return -1;

--- a/read-cache.c
+++ b/read-cache.c
@@ -1957,6 +1957,17 @@ static void *load_index_extensions(void *_data)
 	return NULL;
 }
 
+static void *load_index_extensions_threadproc(void *_data)
+{
+	void *result;
+
+	trace2_thread_start("load_index_extensions");
+	result = load_index_extensions(_data);
+	trace2_thread_exit();
+
+	return result;
+}
+
 /*
  * A helper function that will load the specified range of cache entries
  * from the memory mapped file and add them to the given index.
@@ -2032,12 +2043,17 @@ static void *load_cache_entries_thread(void *_data)
 	struct load_cache_entries_thread_data *p = _data;
 	int i;
 
+	trace2_thread_start("load_cache_entries");
+
 	/* iterate across all ieot blocks assigned to this thread */
 	for (i = p->ieot_start; i < p->ieot_start + p->ieot_blocks; i++) {
 		p->consumed += load_cache_entry_block(p->istate, p->ce_mem_pool,
 			p->offset, p->ieot->entries[i].nr, p->mmap, p->ieot->entries[i].offset, NULL);
 		p->offset += p->ieot->entries[i].nr;
 	}
+
+	trace2_thread_exit();
+
 	return NULL;
 }
 
@@ -2187,7 +2203,7 @@ int do_read_index(struct index_state *istate, const char *path, int must_exist)
 			int err;
 
 			p.src_offset = extension_offset;
-			err = pthread_create(&p.pthread, NULL, load_index_extensions, &p);
+			err = pthread_create(&p.pthread, NULL, load_index_extensions_threadproc, &p);
 			if (err)
 				die(_("unable to create load_index_extensions thread: %s"), strerror(err));
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1478,6 +1478,8 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	if (len > MAX_UNPACK_TREES)
 		die("unpack_trees takes at most %d trees", MAX_UNPACK_TREES);
 
+	trace2_region_enter("unpack_trees", "unpack_trees", NULL);
+
 	trace_performance_enter();
 	memset(&el, 0, sizeof(el));
 	if (!core_apply_sparse_checkout || !o->update)
@@ -1658,6 +1660,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 done:
 	trace_performance_leave("unpack_trees");
 	clear_exclude_list(&el);
+	trace2_region_leave("unpack_trees", "unpack_trees", NULL);
 	return ret;
 
 return_failed:


### PR DESCRIPTION
Measure time spent in major cache-tree related functions.
Also unpack_trees() and read_index threading.