### PR TITLE
status: deserialize with -uno does not print correct hint

### DIFF
--- a/t/t7524-serialized-status.sh
+++ b/t/t7524-serialized-status.sh
@@ -333,4 +333,59 @@ test_expect_success 'renames' '
 	test_i18ncmp output.1 output.2
 '
 
+test_expect_success 'hint message when cached with u=complete' '
+	git init hint &&
+	echo xxx >hint/xxx &&
+	git -C hint add xxx &&
+	git -C hint commit -m xxx &&
+
+	cat >expect.clean <<EOF &&
+On branch master
+nothing to commit, working tree clean
+EOF
+
+	cat >expect.use_u <<EOF &&
+On branch master
+nothing to commit (use -u to show untracked files)
+EOF
+
+	# Capture long format output from "no", "normal", and "all"
+	# (without using status cache) and verify it matches expected
+	# output.
+
+	git -C hint status --untracked-files=normal >hint.output_normal &&
+	test_i18ncmp expect.clean hint.output_normal &&
+
+	git -C hint status --untracked-files=all >hint.output_all &&
+	test_i18ncmp expect.clean hint.output_all &&
+
+	git -C hint status --untracked-files=no >hint.output_no &&
+	test_i18ncmp expect.use_u hint.output_no &&
+
+	# Create long format output for "complete" and create status cache.
+
+	git -C hint status --untracked-files=complete --ignored=matching --serialize=../hint.dat >hint.output_complete &&
+	test_i18ncmp expect.clean hint.output_complete &&
+
+	# Capture long format output using the status cache and verify
+	# that the output matches the non-cached version.  There are 2
+	# ways to specify untracked-files, so do them both.
+
+	git -C hint status --deserialize=../hint.dat -unormal >hint.d1_normal &&
+	test_i18ncmp expect.clean hint.d1_normal &&
+	git -C hint -c status.showuntrackedfiles=normal status --deserialize=../hint.dat >hint.d2_normal &&
+	test_i18ncmp expect.clean hint.d2_normal &&
+
+	git -C hint status --deserialize=../hint.dat -uall >hint.d1_all &&
+	test_i18ncmp expect.clean hint.d1_all &&
+	git -C hint -c status.showuntrackedfiles=all status --deserialize=../hint.dat >hint.d2_all &&
+	test_i18ncmp expect.clean hint.d2_all &&
+
+	git -C hint status --deserialize=../hint.dat -uno >hint.d1_no &&
+	test_i18ncmp expect.use_u hint.d1_no &&
+	git -C hint -c status.showuntrackedfiles=no status --deserialize=../hint.dat >hint.d2_no &&
+	test_i18ncmp expect.use_u hint.d2_no
+
+'
+
 test_done

--- a/wt-status-deserialize.c
+++ b/wt-status-deserialize.c
@@ -442,20 +442,24 @@ static int wt_deserialize_v1_ignored_items(struct wt_status *s,
 }
 
 static int validate_untracked_files_arg(enum untracked_status_type cmd,
-					enum untracked_status_type des,
+					enum untracked_status_type *des,
 					enum deserialize_parse_strategy *strategy)
 {
 	*strategy = DESERIALIZE_STRATEGY_AS_IS;
 
-	if (cmd == des) {
+	if (cmd == *des) {
 		*strategy = DESERIALIZE_STRATEGY_AS_IS;
 	} else if (cmd == SHOW_NO_UNTRACKED_FILES) {
 		*strategy = DESERIALIZE_STRATEGY_SKIP;
-	} else if (des == SHOW_COMPLETE_UNTRACKED_FILES) {
-		if (cmd == SHOW_ALL_UNTRACKED_FILES)
+		*des = cmd;
+	} else if (*des == SHOW_COMPLETE_UNTRACKED_FILES) {
+		if (cmd == SHOW_ALL_UNTRACKED_FILES) {
 			*strategy = DESERIALIZE_STRATEGY_ALL;
-		else if (cmd == SHOW_NORMAL_UNTRACKED_FILES)
+			*des = cmd;
+		} else if (cmd == SHOW_NORMAL_UNTRACKED_FILES) {
 			*strategy = DESERIALIZE_STRATEGY_NORMAL;
+			*des = cmd;
+		}
 	} else {
 		return DESERIALIZE_ERR;
 	}
@@ -497,7 +501,7 @@ static int wt_deserialize_v1(const struct wt_status *cmd_s, struct wt_status *s,
 	 * We now have the header parsed. Look at the command args (as passed in), and see how to parse
 	 * the serialized data
 	*/
-	if (validate_untracked_files_arg(cmd_s->show_untracked_files, s->show_untracked_files, &untracked_strategy)) {
+	if (validate_untracked_files_arg(cmd_s->show_untracked_files, &s->show_untracked_files, &untracked_strategy)) {
 		set_deserialize_reject_reason("args/untracked-files");
 		trace_printf_key(&trace_deserialize, "reject: show_untracked_file: command: %d, serialized : %d",
 				cmd_s->show_untracked_files,


### PR DESCRIPTION
With the "--untracked-files=complete" option status computes a
superset of the untracked files.  We use this when writing the
status cache.  If subsequent deserialize commands ask for either
the complete set or one of the "no", "normal", or "all" subsets,
it can still use the cache file because of filtering in the
deserialize parser.

When running status with the "-uno" option, the long format
status would print a "(use -u to show untracked files)" hint.

When deserializing with the "-uno" option and using a cache computed
with "-ucomplete", the "nothing to commit, working tree clean" message
would be printed instead of the hint.

It was easy to miss because the correct hint message was printed
if the cache was rejected for any reason (and status did the full
fallback).

The "struct wt_status des" structure was initialized with the
content of the status cache (and thus defaulted to "complete").
This change sets "des.show_untracked_files" to the requested
subset from the command-line or config.  This allows the long
format to print the hint.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
