### PR TITLE
trace2:gvfs:experiment: add region for prime_cache_tree()

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -100,9 +100,7 @@ static int reset_index(const struct object_id *oid, int reset_type, int quiet)
 
 	if (reset_type == MIXED || reset_type == HARD) {
 		tree = parse_tree_indirect(oid);
-		trace2_region_enter("exp", "prime_cache_tree", the_repository);
 		prime_cache_tree(the_repository, the_repository->index, tree);
-		trace2_region_leave("exp", "prime_cache_tree", the_repository);
 	}
 
 	ret = 0;

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -715,10 +715,14 @@ void prime_cache_tree(struct repository *r,
 		      struct index_state *istate,
 		      struct tree *tree)
 {
+	trace2_region_enter("cache_tree", "prime_cache_tree", r);
+
 	cache_tree_free(&istate->cache_tree);
 	istate->cache_tree = cache_tree();
 	prime_cache_tree_rec(r, istate->cache_tree, tree);
 	istate->cache_changed |= CACHE_TREE_CHANGED;
+
+	trace2_region_leave("cache_tree", "prime_cache_tree", r);
 }
 
 /*


### PR DESCRIPTION
Add a region around prime_cache_tree().

This is an experiment to measure time spent in prime_cache_tree()
which seems to be a major factor during "git reset --hard" on the OS
repo.

This series can probably be dropped at a future point.