### PR TITLE
trace2:gvfs:experiment Add experimental regions and data events to help diagnose checkout and reset perf problems

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -25,6 +25,7 @@
 #include "submodule-config.h"
 #include "submodule.h"
 #include "advice.h"
+#include "packfile.h"
 
 static int checkout_optimize_new_branch;
 
@@ -921,8 +922,13 @@ static void update_refs_for_switch(const struct checkout_opts *opts,
 	strbuf_release(&msg);
 	if (!opts->quiet &&
 	    (new_branch_info->path || (!opts->force_detach && !strcmp(new_branch_info->name, "HEAD")))) {
+		unsigned long nr_unpack_entry_at_start;
+
 		trace2_region_enter("exp", "report_tracking", the_repository);
+		nr_unpack_entry_at_start = get_nr_unpack_entry();
 		report_tracking(new_branch_info);
+		trace2_data_intmax("exp", NULL, "report_tracking/nr_unpack_entries",
+				   (intmax_t)(get_nr_unpack_entry() - nr_unpack_entry_at_start));
 		trace2_region_leave("exp", "report_tracking", the_repository);
 	}
 }

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -221,7 +221,7 @@ static void discard_unused_subtrees(struct cache_tree *it)
 	}
 }
 
-int cache_tree_fully_valid(struct cache_tree *it)
+static int cache_tree_fully_valid_1(struct cache_tree *it)
 {
 	int i;
 	if (!it)
@@ -229,10 +229,21 @@ int cache_tree_fully_valid(struct cache_tree *it)
 	if (it->entry_count < 0 || !has_object_file(&it->oid))
 		return 0;
 	for (i = 0; i < it->subtree_nr; i++) {
-		if (!cache_tree_fully_valid(it->down[i]->cache_tree))
+		if (!cache_tree_fully_valid_1(it->down[i]->cache_tree))
 			return 0;
 	}
 	return 1;
+}
+
+int cache_tree_fully_valid(struct cache_tree *it)
+{
+	int result;
+
+	trace2_region_enter("cache_tree", "fully_valid", NULL);
+	result = cache_tree_fully_valid_1(it);
+	trace2_region_leave("cache_tree", "fully_valid", NULL);
+
+	return result;
 }
 
 static int update_one(struct cache_tree *it,

--- a/packfile.c
+++ b/packfile.c
@@ -1646,6 +1646,13 @@ static void *read_object(struct repository *r,
 	return content;
 }
 
+static unsigned long g_nr_unpack_entry;
+
+unsigned long get_nr_unpack_entry(void)
+{
+	return g_nr_unpack_entry;
+}
+
 void *unpack_entry(struct repository *r, struct packed_git *p, off_t obj_offset,
 		   enum object_type *final_type, unsigned long *final_size)
 {
@@ -1658,6 +1665,8 @@ void *unpack_entry(struct repository *r, struct packed_git *p, off_t obj_offset,
 	struct unpack_entry_stack_ent *delta_stack = small_delta_stack;
 	int delta_stack_nr = 0, delta_stack_alloc = UNPACK_ENTRY_STACK_PREALLOC;
 	int base_from_cache = 0;
+
+	g_nr_unpack_entry++;
 
 	write_pack_access_log(p, obj_offset);
 

--- a/packfile.h
+++ b/packfile.h
@@ -193,4 +193,9 @@ int is_promisor_object(const struct object_id *oid);
 int load_idx(const char *path, const unsigned int hashsz, void *idx_map,
 	     size_t idx_size, struct packed_git *p);
 
+/*
+ * Return the number of objects fetched from a packfile.
+ */
+unsigned long get_nr_unpack_entry(void);
+
 #endif

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1478,6 +1478,8 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	if (len > MAX_UNPACK_TREES)
 		die("unpack_trees takes at most %d trees", MAX_UNPACK_TREES);
 
+	trace2_region_enter("exp", "unpack_trees", NULL);
+
 	trace_performance_enter();
 	memset(&el, 0, sizeof(el));
 	if (!core_apply_sparse_checkout || !o->update)
@@ -1658,6 +1660,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 done:
 	trace_performance_leave("unpack_trees");
 	clear_exclude_list(&el);
+	trace2_region_leave("exp", "unpack_trees", NULL);
 	return ret;
 
 return_failed:

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -19,6 +19,7 @@
 #include "fetch-object.h"
 #include "gvfs.h"
 #include "virtualfilesystem.h"
+#include "packfile.h"
 
 /*
  * Error messages expected by scripts out of plumbing commands such as
@@ -1474,11 +1475,13 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	int i, ret;
 	static struct cache_entry *dfc;
 	struct exclude_list el;
+	unsigned long nr_unpack_entry_at_start;
 
 	if (len > MAX_UNPACK_TREES)
 		die("unpack_trees takes at most %d trees", MAX_UNPACK_TREES);
 
 	trace2_region_enter("exp", "unpack_trees", NULL);
+	nr_unpack_entry_at_start = get_nr_unpack_entry();
 
 	trace_performance_enter();
 	memset(&el, 0, sizeof(el));
@@ -1660,6 +1663,8 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 done:
 	trace_performance_leave("unpack_trees");
 	clear_exclude_list(&el);
+	trace2_data_intmax("exp", NULL, "unpack_trees/nr_unpack_entries",
+			   (intmax_t)(get_nr_unpack_entry() - nr_unpack_entry_at_start));
 	trace2_region_leave("exp", "unpack_trees", NULL);
 	return ret;
 

--- a/virtualfilesystem.c
+++ b/virtualfilesystem.c
@@ -259,6 +259,8 @@ void apply_virtualfilesystem(struct index_state *istate)
 	if (!git_config_get_virtualfilesystem())
 		return;
 
+	trace2_region_enter("vfs", "apply", the_repository);
+
 	if (!virtual_filesystem_data.len)
 		get_virtual_filesystem_data(&virtual_filesystem_data);
 
@@ -329,6 +331,8 @@ void apply_virtualfilesystem(struct index_state *istate)
 		trace2_data_intmax("vfs", the_repository, "apply/nr_bulk_skip", nr_bulk_skip);
 		trace2_data_intmax("vfs", the_repository, "apply/nr_explicit_skip", nr_explicit_skip);
 	}
+
+	trace2_region_leave("vfs", "apply", the_repository);
 }
 
 /*


### PR DESCRIPTION
Add experimental regions and data events to help diagnose
performance problems in checkout and reset.

We may or may not choose to carry these changes forward in the future.
