### PR TITLE
Support building with GCC v9.x

### DIFF
--- a/config.c
+++ b/config.c
@@ -870,9 +870,9 @@ static int git_parse_signed(const char *value, intmax_t *ret, intmax_t max)
 			errno = EINVAL;
 			return 0;
 		}
-		uval = labs(val);
+		uval = val < 0 ? -val : val;
 		uval *= factor;
-		if (uval > max || labs(val) > uval) {
+		if (uval > max || (val < 0 ? -val : val) > uval) {
 			errno = ERANGE;
 			return 0;
 		}


### PR DESCRIPTION
This is a companion PR to git-for-windows/git#2258

It is necessary because MSYS2 (and therefore, Git for Windows' SDK) switched to GCC v9.x for the MINGW builds.