### PR TITLE
[WIP] partial-checkout feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@
 /git-pack-objects
 /git-pack-refs
 /git-parse-remote
+/git-partial-checkout
 /git-patch-id
 /git-prune
 /git-prune-packed

--- a/Documentation/git-partial-checkout.txt
+++ b/Documentation/git-partial-checkout.txt
@@ -24,7 +24,10 @@ the checkout to a set of directories given by a list of prefixes.
 COMMANDS
 --------
 'init'::
-
+	Enable the `core.partialCheckout` setting and clear all folders not
+	included by the partial-checkout file. Typically, no partial-checkout
+	file will exist when this command is run, so all directories in the
+	working directory will be removed.
 
 'add'::
 	Given a list of paths over stdin, add those paths to the

--- a/Documentation/git-partial-checkout.txt
+++ b/Documentation/git-partial-checkout.txt
@@ -1,0 +1,122 @@
+git-partial-checkout(1)
+=======================
+
+NAME
+----
+git-partial-checkout - Initialize and modify the partial-checkout
+configuration, which reduces the checkout to a set of directories
+given by a list of prefixes.
+
+
+SYNOPSIS
+--------
+[verse]
+'git partial-clone [init|add|remove|list]'
+
+
+DESCRIPTION
+-----------
+
+Initialize and modify the partial-checkout configuration, which reduces
+the checkout to a set of directories given by a list of prefixes.
+
+
+COMMANDS
+--------
+'init'::
+
+
+'add'::
+	Given a list of paths over stdin, add those paths to the
+	partial-checkout file. Refresh the index and working directory to
+	place the necessary files on disk.
+
+'remove'::
+	Given a list of paths over stdin, remove those paths from the
+	partial-checkout file. Refresh the index and working directory to
+	remove the unnecessary files on disk.
+
+'list'::
+	Provide a list of the contents in the partial-checkout file.
+
+
+PARTIAL CHECKOUT
+----------------
+
+The partial-checkout feature provides simple way to reduce the "cone" of files
+in the working directory which are populated by Git. The partial-checkout file
+specifies a list of directories from the working directory root, and the list
+of paths included are as follows:
+
+1. Any path that is contained in a folder listed in the partial-checkout file.
+   For example, if `A/B/C` is in the partial-checkout file, then `A/B/C/D/e.txt`
+   will exist in the working directory.
+
+2. Any path whose immediate parent folder is an ancestor of a folder listed in
+   the partial-checkout file. For example, all files in the root directory are
+   included -- even if the partial-checkout file is empty. As another example,
+   if `A/B/C` is in the partial-checkout file, then `A/foo.txt` and `A/B/bar.c`
+   would be included. Note that `A/F/xyz.h` would not be included, as its
+   immediate parent (`A/F`) is not a prefix of `A/B/C`.
+
+Note that the pattern matching in the partial-checkout feature is very restricted,
+unlike the sparse-checkout feature. The partial-checkout and sparse-checkout
+features both use the skip-worktree bits in the index file to interact with
+other features in Git, but otherwise are incompatible. Creating a sparse-checkout
+file to include files according to the rules above is difficult, and the
+pattern matching required by the sparse-checkout feature leads to quadratic
+growth: for N patterns and M index entries, we must check O(N * M) patterns.
+
+Conversely, the partial-checkout feature does not allow negative patterns or
+file-name based patterns. If you want to exclude all files ending in ".exe"
+you could include the line `!*.exe` in the sparse-checkout file. This is not
+available in the partial-checkout feature.
+
+To use the partial-checkout feature, you must enable the `core.partialCheckout`
+config setting. This setting will override the `core.sparseCheckout` setting,
+so any values in the sparse-checkout file will be ignored.
+
+To initialize an existing repo to use the partial-checkout feature, run
+`git partial-checkout init`. This will enable `core.partialCheckout`, remove
+all directories in the root of the working directory, and then update the
+working directory to contain the folders that may already exist in the
+partial-checkout file. In the usual case, the partial-checkout file will be
+empty and you will only see files in the working directory root.
+
+To add folders to the partial-checkout file, run the `add` subcommand, and
+provide the list over standard-in:
+
+```
+$git partial-checkout add
+A/B/C
+Docs
+tests
+^D
+```
+
+Since these folders do not exist in your working directory, you can use
+`git ls-tree HEAD -- <path>` to help discover folders that exist in your
+repo.
+
+After adding the folders to the partial-checkout file, Git will update the index
+and run `git reset --hard` to place the files on disk. Due to the use of
+`git reset --hard`, the command will halt with an error before doing any work
+if you do not have a clean `git status`.
+
+If you wish to reduce your working directory, you can use the
+`git partial-checkout remove` subcommand. It takes a list of folders from
+standard in, removes them from the partial-checkout file and deletes them from
+your working directory, then runs `git reset --hard` to ensure the index is
+up to date.
+
+To check which folders are included in the partial-checkout file, run the
+`git partial-checkout list` subcommand.
+
+SEE ALSO
+--------
+
+linkgit:git-read-tree[1]
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Makefile
+++ b/Makefile
@@ -945,6 +945,7 @@ LIB_OBJS += pack-write.o
 LIB_OBJS += pager.o
 LIB_OBJS += parse-options.o
 LIB_OBJS += parse-options-cb.o
+LIB_OBJS += partial-checkout.o
 LIB_OBJS += patch-delta.o
 LIB_OBJS += patch-ids.o
 LIB_OBJS += path.o

--- a/Makefile
+++ b/Makefile
@@ -1110,6 +1110,7 @@ BUILTIN_OBJS += builtin/notes.o
 BUILTIN_OBJS += builtin/pack-objects.o
 BUILTIN_OBJS += builtin/pack-redundant.o
 BUILTIN_OBJS += builtin/pack-refs.o
+BUILTIN_OBJS += builtin/partial-checkout.o
 BUILTIN_OBJS += builtin/patch-id.o
 BUILTIN_OBJS += builtin/prune-packed.o
 BUILTIN_OBJS += builtin/prune.o

--- a/builtin.h
+++ b/builtin.h
@@ -197,6 +197,7 @@ int cmd_name_rev(int argc, const char **argv, const char *prefix);
 int cmd_notes(int argc, const char **argv, const char *prefix);
 int cmd_pack_objects(int argc, const char **argv, const char *prefix);
 int cmd_pack_redundant(int argc, const char **argv, const char *prefix);
+int cmd_partial_checkout(int argc, const char **argv, const char *prefix);
 int cmd_patch_id(int argc, const char **argv, const char *prefix);
 int cmd_prune(int argc, const char **argv, const char *prefix);
 int cmd_prune_packed(int argc, const char **argv, const char *prefix);

--- a/builtin/partial-checkout.c
+++ b/builtin/partial-checkout.c
@@ -1,0 +1,226 @@
+#include "builtin.h"
+#include "config.h"
+#include "dir.h"
+#include "parse-options.h"
+#include "partial-checkout.h"
+#include "repository.h"
+#include "run-command.h"
+#include "strbuf.h"
+#include "string-list.h"
+
+static char const * const builtin_partial_checkout_usage[] = {
+	N_("git partial-checkout [add|remove|list]"),
+	NULL
+};
+
+struct opts_partial_checkout {
+	const char *subcommand;
+	int read_stdin;
+} opts;
+
+static int check_clean_status(void)
+{
+/*
+	struct strbuf sb = STRBUF_INIT;
+
+	if (repo_index_has_changes(the_repository, NULL, &sb)) {
+		error(_("You have local changes that could be overwritten by a reset:\n %s"),
+		      sb.buf);
+		return 1;
+	}
+*/
+	return 0;
+}
+
+static int pc_read_tree(void)
+{
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	int result = 0;
+	argv_array_pushl(&argv, "read-tree", "-m", "-u", "HEAD", NULL);
+
+	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
+		error(_("failed to update index with new partial-checkout paths"));
+		result = 1;
+	}
+
+	argv_array_clear(&argv);
+	return result;
+}
+
+static int pc_reset_hard(void)
+{
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	int result = 0;
+	argv_array_pushl(&argv, "reset", "--hard", "HEAD", NULL);
+
+	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
+		error(_("failed to reset with new partial-checkout paths"));
+		result = 1;
+	}
+
+	argv_array_clear(&argv);
+	return result;
+}
+
+static int partial_checkout_add(int argc, const char **argv)
+{
+	struct strbuf data = STRBUF_INIT;
+	char line[PATH_MAX + 2];
+	char *fname;
+	FILE *fp;
+	int i, start = 0;
+
+	if (check_clean_status())
+		return 1;
+
+	get_partial_checkout_data(the_repository, &data);
+
+	for (;;) {
+		if (!fgets(line, sizeof(line), stdin)) {
+			if (feof(stdin))
+				break;
+			if (!ferror(stdin))
+				die("BUG: fgets returned NULL, not EOF, not error!");
+			if (errno != EINTR)
+				die_errno("fgets");
+			clearerr(stdin);
+			continue;
+		}
+
+		if (strlen(line)) {
+			strbuf_addstr(&data, line);
+			strbuf_addch(&data, '\n');
+		}
+	}
+
+	fname = get_partial_checkout_filename(the_repository);
+	fp = fopen(fname, "w");
+	free(fname);
+
+	for (i = 0; i < data.len; i++) {
+		if (data.buf[i] == '\n') {
+			if (i > start + 1) {
+				data.buf[i] = '\0';
+				fprintf(fp, "%s\n", data.buf + start);
+			}
+
+			start = i + 1;
+		}
+	}
+
+	fclose(fp);
+	strbuf_release(&data);
+
+	return pc_read_tree() || pc_reset_hard();
+}
+
+static int partial_checkout_remove(int argc, const char **argv)
+{
+	struct strbuf data = STRBUF_INIT;
+	struct string_list to_remove = STRING_LIST_INIT_DUP;
+	char line[PATH_MAX + 2];
+	char *fname;
+	FILE *fp;
+	int i, start = 0;
+	struct strbuf dirname = STRBUF_INIT;
+	size_t dirname_len = dirname.len;
+
+	if (check_clean_status())
+		return 1;
+
+	string_list_init(&to_remove, 0);
+	strbuf_addstr(&dirname, the_repository->worktree);
+
+	for (;;) {
+		int len;
+
+		if (!fgets(line, sizeof(line), stdin)) {
+			if (feof(stdin))
+				break;
+			if (!ferror(stdin))
+				die("BUG: fgets returned NULL, not EOF, not error!");
+			if (errno != EINTR)
+				die_errno("fgets");
+			clearerr(stdin);
+			continue;
+		}
+
+		if ((len = strlen(line)) > 1) {
+			if (line[len - 1] == '\n')
+				line[len - 1] = '\0';
+
+			string_list_insert(&to_remove, line);
+
+			strbuf_addf(&dirname, "/%s", line);
+
+			if (remove_dir_recursively(&dirname, 0))
+				warning(_("failed to remove directory '%s'"), dirname.buf);
+
+			strbuf_setlen(&dirname, dirname_len);
+		}
+	}
+	string_list_sort(&to_remove);
+
+	get_partial_checkout_data(the_repository, &data);
+	fname = get_partial_checkout_filename(the_repository);
+	fp = fopen(fname, "w");
+	free(fname);
+
+	for (i = 0; i < data.len; i++) {
+		if (data.buf[i] == '\n') {
+			if (i > start + 1) {
+				data.buf[i] = '\0';
+
+				if (!string_list_has_string(&to_remove, data.buf + start))
+					fprintf(fp, "%s\n", data.buf + start);
+			}
+
+			start = i + 1;
+		}
+	}
+
+	fclose(fp);
+	strbuf_release(&data);
+	string_list_clear(&to_remove, 0);
+
+	return pc_read_tree() || pc_reset_hard();
+}
+
+static int partial_checkout_list(int argc, const char **argv)
+{
+	struct strbuf data = STRBUF_INIT;
+
+	get_partial_checkout_data(the_repository, &data);
+	printf("%s\n", data.buf);
+
+	return 0;
+}
+
+int cmd_partial_checkout(int argc, const char **argv, const char *prefix)
+{
+	static struct option builtin_partial_checkout_options[] = {
+		OPT_END(),
+	};
+
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage_with_options(builtin_partial_checkout_usage,
+				   builtin_partial_checkout_options);
+
+	git_config(git_default_config, NULL);
+	argc = parse_options(argc, argv, prefix,
+			     builtin_partial_checkout_options,
+			     builtin_partial_checkout_usage,
+			     PARSE_OPT_STOP_AT_NON_OPTION);
+
+	if (argc > 0) {
+		if (!strcmp(argv[0], "add"))
+			return partial_checkout_add(argc, argv);
+		if (!strcmp(argv[0], "remove"))
+			return partial_checkout_remove(argc, argv);
+		if (!strcmp(argv[0], "list"))
+			return partial_checkout_list(argc, argv);
+	}
+
+	usage_with_options(builtin_partial_checkout_usage,
+			   builtin_partial_checkout_options);
+}

--- a/git.c
+++ b/git.c
@@ -608,6 +608,7 @@ static struct cmd_struct commands[] = {
 	{ "name-rev", cmd_name_rev, RUN_SETUP },
 	{ "notes", cmd_notes, RUN_SETUP },
 	{ "pack-objects", cmd_pack_objects, RUN_SETUP },
+	{ "partial-checkout", cmd_partial_checkout, RUN_SETUP | NEED_WORK_TREE },
 	{ "pack-redundant", cmd_pack_redundant, RUN_SETUP | NO_PARSEOPT },
 	{ "pack-refs", cmd_pack_refs, RUN_SETUP },
 	{ "patch-id", cmd_patch_id, RUN_SETUP_GENTLY | NO_PARSEOPT },

--- a/partial-checkout.c
+++ b/partial-checkout.c
@@ -1,0 +1,293 @@
+#include "cache.h"
+#include "config.h"
+#include "dir.h"
+#include "hashmap.h"
+#include "repository.h"
+#include "run-command.h"
+#include "partial-checkout.h"
+
+static struct strbuf partial_checkout_data = STRBUF_INIT;
+
+/*
+ * Stores paths where everything starting with those paths
+ * is included.
+ */
+static struct hashmap pc_recursive_hashmap;
+
+/*
+ * Stores paths that are parents of recursive hashmap paths.
+ * Used to check single-level parents of blobs.
+ */
+static struct hashmap pc_parents_hashmap;
+
+int core_partial_checkout = -1;
+
+int use_partial_checkout(struct repository *r)
+{
+	if (core_partial_checkout >= 0)
+		return core_partial_checkout;
+
+	if (repo_config_get_bool(r, "core.partialcheckout", &core_partial_checkout))
+		core_partial_checkout = 0;
+
+	return core_partial_checkout;
+}
+
+char *get_partial_checkout_filename(struct repository *r)
+{
+	struct strbuf pc_filename = STRBUF_INIT;
+	strbuf_addstr(&pc_filename, r->gitdir);
+	strbuf_addstr(&pc_filename, "/info/partial-checkout");
+	return strbuf_detach(&pc_filename, NULL);
+}
+
+struct partial_checkout_entry {
+	struct hashmap_entry ent; /* must be the first member! */
+	const char *pattern;
+	int patternlen;
+};
+
+static unsigned int(*pc_hash)(const void *buf, size_t len);
+static int(*pc_cmp)(const char *a, const char *b, size_t len);
+
+static int pc_hashmap_cmp(const void *unused_cmp_data,
+	const void *a, const void *b, const void *key)
+{
+	const struct partial_checkout_entry *pc_1 = a;
+	const struct partial_checkout_entry *pc_2 = b;
+
+	return pc_cmp(pc_1->pattern, pc_2->pattern, pc_1->patternlen);
+}
+
+void get_partial_checkout_data(struct repository *r,
+			       struct strbuf *pc_data)
+{
+	char *pc_filename = get_partial_checkout_filename(r);
+
+	strbuf_read_file(pc_data, pc_filename, 0);
+
+	free(pc_filename);
+}
+
+static int check_hashmap(struct hashmap *map,
+			 const char *pattern,
+			 int patternlen)
+{
+	struct strbuf sb = STRBUF_INIT;
+	struct partial_checkout_entry pc;
+
+	/* Check straight mapping */
+	strbuf_reset(&sb);
+	strbuf_add(&sb, pattern, patternlen);
+	pc.pattern = sb.buf;
+	pc.patternlen = sb.len;
+	hashmap_entry_init(&pc, pc_hash(pc.pattern, pc.patternlen));
+	if (hashmap_get(map, &pc, NULL)) {
+		strbuf_release(&sb);
+		return 1;
+	}
+
+	strbuf_release(&sb);
+	return 0;
+}
+static int check_recursive_hashmap(struct hashmap *map,
+				   const char *pattern,
+				   int patternlen)
+{
+	struct strbuf sb = STRBUF_INIT;
+	struct partial_checkout_entry pc;
+	char *slash;
+
+	/* Check straight mapping */
+	strbuf_reset(&sb);
+	strbuf_add(&sb, pattern, patternlen);
+	pc.pattern = sb.buf;
+	pc.patternlen = sb.len;
+	hashmap_entry_init(&pc, pc_hash(pc.pattern, pc.patternlen));
+	if (hashmap_get(map, &pc, NULL)) {
+		strbuf_release(&sb);
+		return 1;
+	}
+
+	/*
+	 * Check to see if it matches a directory or any path
+	 * underneath it.  In other words, 'a/b/foo.txt' will match
+	 * '/', 'a/', and 'a/b/'.
+	 */
+	slash = strchr(sb.buf, '/');
+
+	/* include all values at root */
+	if (!slash) {
+		strbuf_release(&sb);
+		return 1;
+	}
+
+	while (slash) {
+		pc.pattern = sb.buf;
+		pc.patternlen = slash - sb.buf;
+		hashmap_entry_init(&pc, pc_hash(pc.pattern, pc.patternlen));
+		if (hashmap_get(map, &pc, NULL)) {
+			strbuf_release(&sb);
+			return 1;
+		}
+		slash = strchr(slash + 1, '/');
+	}
+
+	strbuf_release(&sb);
+	return 0;
+}
+
+static void includes_hashmap_add(struct hashmap *map, const char *pattern, const int patternlen)
+{
+	struct partial_checkout_entry *pc;
+
+	pc = xmalloc(sizeof(struct partial_checkout_entry));
+	pc->pattern = pattern;
+	pc->patternlen = patternlen;
+	hashmap_entry_init(pc, pc_hash(pc->pattern, pc->patternlen));
+	hashmap_add(map, pc);
+}
+
+static void initialize_includes_hashmap(struct hashmap *map, struct strbuf *pc_data)
+{
+	char *buf, *entry;
+	size_t len;
+	int i;
+
+	/*
+	 * Build a hashmap of the partial-checkout data we can use to look
+	 * for cache entry matches quickly
+	 */
+	pc_hash = ignore_case ? memihash : memhash;
+	pc_cmp = ignore_case ? strncasecmp : strncmp;
+	hashmap_init(map, pc_hashmap_cmp, NULL, 0);
+
+	entry = buf = pc_data->buf;
+	len = pc_data->len;
+	for (i = 0; i < len; i++) {
+		if (buf[i] == '\n') {
+			buf[i] = '\0';
+			includes_hashmap_add(map, entry, buf + i - entry);
+			entry = buf + i + 1;
+		}
+	}
+}
+
+static void pc_parents_hashmap_add(struct hashmap *map, const char *pattern, const int patternlen)
+{
+	char *slash;
+	struct partial_checkout_entry *pc;
+
+	/*
+	 * Add any directories leading up to the file as the excludes logic
+	 * needs to match directories leading up to the files as well. Detect
+	 * and prevent unnecessary duplicate entries which will be common.
+	 */
+	if (patternlen > 1) {
+		slash = strchr(pattern + 1, '/');
+		while (slash) {
+			struct strbuf added = STRBUF_INIT;
+			pc = xmalloc(sizeof(struct partial_checkout_entry));
+			pc->pattern = pattern;
+			pc->patternlen = slash - pattern;
+			hashmap_entry_init(pc, pc_hash(pc->pattern, pc->patternlen));
+			strbuf_add(&added, pc->pattern, pc->patternlen);
+			
+			if (hashmap_get(map, pc, NULL))
+				free(pc);
+			else
+				hashmap_add(map, pc);
+			slash = strchr(slash + 1, '/');
+		}
+	}
+}
+
+static void initialize_parents_hashmap(struct hashmap *map, struct strbuf *pc_data)
+{
+	char *buf, *entry;
+	size_t len;
+	int i;
+
+	/*
+	 * Build a hashmap of the parent directories contained in the virtual
+	 * file system data we can use to look for matches quickly
+	 */
+	pc_hash = ignore_case ? memihash : memhash;
+	pc_cmp = ignore_case ? strncasecmp : strncmp;
+	hashmap_init(map, pc_hashmap_cmp, NULL, 0);
+
+	entry = buf = pc_data->buf;
+	len = pc_data->len;
+	for (i = 0; i < len; i++) {
+		if (buf[i] == '\0') {
+			pc_parents_hashmap_add(map, entry, buf + i - entry);
+			entry = buf + i + 1;
+		}
+	}
+}
+
+/*
+ * Return 1 if the requested item is found in the partial-checkout file,
+ * 0 for not found and -1 for undecided.
+ */
+int is_included_in_partial_checkout(struct repository *r,
+				    const char *pathname, int pathlen)
+{
+	int result;
+	struct strbuf parent_pathname = STRBUF_INIT;
+
+	if (!core_partial_checkout)
+		return -1;
+
+	if (!pc_recursive_hashmap.tablesize && partial_checkout_data.len) {
+		initialize_includes_hashmap(&pc_recursive_hashmap, &partial_checkout_data);
+		initialize_parents_hashmap(&pc_parents_hashmap, &partial_checkout_data);
+	}
+	if (!pc_recursive_hashmap.tablesize)
+		return -1;
+	
+	result = check_recursive_hashmap(&pc_recursive_hashmap, pathname, pathlen);
+
+	if (result)
+		return result;
+
+	strbuf_add(&parent_pathname, pathname, pathlen);
+	parent_pathname.len = (int)(strrchr(parent_pathname.buf, '/') - parent_pathname.buf);
+	strbuf_setlen(&parent_pathname, parent_pathname.len);
+
+	result = check_hashmap(&pc_parents_hashmap,
+			       parent_pathname.buf,
+			       parent_pathname.len);
+
+	strbuf_release(&parent_pathname);
+	return result;
+}
+
+void apply_partial_checkout(struct repository *r, struct index_state *istate)
+{
+	int i;
+
+	if (!use_partial_checkout(r))
+		return;
+
+	if (!partial_checkout_data.len)
+		get_partial_checkout_data(r, &partial_checkout_data);
+
+	for (i = 0; i < istate->cache_nr; i++) {
+		if (is_included_in_partial_checkout(r,
+						    istate->cache[i]->name,
+						    istate->cache[i]->ce_namelen))
+			istate->cache[i]->ce_flags &= ~CE_SKIP_WORKTREE;
+		else
+			istate->cache[i]->ce_flags |= CE_SKIP_WORKTREE;
+	}
+}
+
+/*
+ * Free the partial-checkout file data structures.
+ */
+void free_partial_checkout(struct repository *r) {
+	hashmap_free(&pc_recursive_hashmap, 1);
+	hashmap_free(&pc_parents_hashmap, 1);
+	strbuf_release(&partial_checkout_data);
+}

--- a/partial-checkout.h
+++ b/partial-checkout.h
@@ -1,0 +1,30 @@
+#ifndef PARTIAL_CHECKOUT_H
+#define PARTIAL_CHECKOUT_H
+
+struct index_state;
+struct repository;
+
+int use_partial_checkout(struct repository *r);
+char *get_partial_checkout_filename(struct repository *r);
+
+/*
+ * Update the CE_SKIP_WORKTREE bits based on the partial-checkout file.
+ */
+void apply_partial_checkout(struct repository *r, struct index_state *istate);
+
+/*
+ * Return 1 if the requested item is included by the partial-checkout file
+ * 0 for not found and -1 for undecided.
+ */
+int is_included_in_partial_checkout(struct repository *r,
+				    const char *pathname, int pathlen);
+
+/*
+ * Free the partial-checkout data structures.
+ */
+void free_partial_checkout(struct repository *r);
+
+void get_partial_checkout_data(struct repository *r,
+			       struct strbuf *pc_data);
+
+#endif

--- a/read-cache.c
+++ b/read-cache.c
@@ -27,6 +27,7 @@
 #include "progress.h"
 #include "virtualfilesystem.h"
 #include "gvfs.h"
+#include "partial-checkout.h"
 
 /* Mask for the name length in ce_flags in the on-disk index */
 
@@ -1888,6 +1889,7 @@ static void post_read_index_from(struct index_state *istate)
 	tweak_split_index(istate);
 	tweak_fsmonitor(istate);
 	apply_virtualfilesystem(istate);
+	apply_partial_checkout(the_repository, istate);
 }
 
 static size_t estimate_cache_size_from_compressed(unsigned int entries)

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -17,13 +17,10 @@
 #include "fsmonitor.h"
 #include "object-store.h"
 #include "fetch-object.h"
-<<<<<<< HEAD
 #include "gvfs.h"
 #include "virtualfilesystem.h"
 #include "packfile.h"
-=======
 #include "partial-checkout.h"
->>>>>>> partial-checkout: integrate with reset and checkout
 
 /*
  * Error messages expected by scripts out of plumbing commands such as
@@ -1506,14 +1503,10 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 
 	trace_performance_enter();
 	memset(&el, 0, sizeof(el));
-	if (!core_apply_sparse_checkout || !o->update)
+	if ((!core_apply_sparse_checkout && !use_partial_checkout(the_repository)) || !o->update)
 		o->skip_sparse_checkout = 1;
 	if (!o->skip_sparse_checkout) {
-<<<<<<< HEAD
-		if (core_virtualfilesystem) {
-=======
-		if (use_partial_checkout(the_repository)) {
->>>>>>> partial-checkout: integrate with reset and checkout
+		if (core_virtualfilesystem || use_partial_checkout(the_repository)) {
 			o->el = &el;
 		} else {
 			char *sparse = git_pathdup("info/sparse-checkout");

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -59,7 +59,8 @@ struct unpack_trees_options {
 		     quiet,
 		     exiting_early,
 		     show_all_errors,
-		     dry_run;
+		     dry_run,
+		     partial_checkout;
 	const char *prefix;
 	int cache_bottom;
 	struct dir_struct *dir;


### PR DESCRIPTION
The included `partial-checkout` feature is a mix of the `sparse-checkout` feature and the virtualization hook. It is intended to be sent upstream, so it currently requires a merge commit to handle interactions with the virtualization hook.

Basic premise to test:

```
$ git clone https://github.com/microsoft/vfsforgit
$ cd vfsforgit
$ git config core.partialCheckout true
$ git partial-checkout add
GVFS/GVFS.Common
GVFS/GVFS
GitHooksLoader
^D
$ ls
AuthoringTests.md  GitHooksLoader GvFlt_EULA.md  GVFS  GVFS.sln  License.md  nuget.config  Protocol.md  Readme.md  Settings.StyleCo
$ ls GVFS
Directory.Build.props  GVFS  GVFS.Common LibGit2Sharp.NativeBinaries.props  ProjectedFSLib.NativeBinaries.props
```

The `partial-checkout` builtin allows you to `add` or `remove` folders to the `partial-checkout` file, or `list` the contents of the `partial-checkout` file.

TODO:
* [ ] `git clone --partial-checkout <url>` to allow an initial clone to show up with only blobs at root.
* [ ] TESTS!
* [ ] Integration with GSD.
* [ ] Clean up user doc.
* [ ] Include deep technical doc.
