### PR TITLE
trace2:gvfs:experiment Add addition unpack_trees() and report_tracking() data

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -924,12 +924,12 @@ static void update_refs_for_switch(const struct checkout_opts *opts,
 	    (new_branch_info->path || (!opts->force_detach && !strcmp(new_branch_info->name, "HEAD")))) {
 		unsigned long nr_unpack_entry_at_start;
 
-		trace2_region_enter("exp", "report_tracking", the_repository);
+		trace2_region_enter("tracking", "report_tracking", the_repository);
 		nr_unpack_entry_at_start = get_nr_unpack_entry();
 		report_tracking(new_branch_info);
-		trace2_data_intmax("exp", NULL, "report_tracking/nr_unpack_entries",
+		trace2_data_intmax("tracking", NULL, "report_tracking/nr_unpack_entries",
 				   (intmax_t)(get_nr_unpack_entry() - nr_unpack_entry_at_start));
-		trace2_region_leave("exp", "report_tracking", the_repository);
+		trace2_region_leave("tracking", "report_tracking", the_repository);
 	}
 }
 

--- a/remote.c
+++ b/remote.c
@@ -2003,7 +2003,16 @@ int format_tracking_info(struct branch *branch, struct strbuf *sb,
 	char *base;
 	int upstream_is_gone = 0;
 
+	trace2_region_enter("tracking", "stat_tracking_info", NULL);
 	sti = stat_tracking_info(branch, &ours, &theirs, &full_base, 0, abf);
+	trace2_data_intmax("tracking", NULL, "stat_tracking_info/ab_flags", abf);
+	trace2_data_intmax("tracking", NULL, "stat_tracking_info/ab_result", sti);
+	if (abf == AHEAD_BEHIND_FULL) {
+	    trace2_data_intmax("tracking", NULL, "stat_tracking_info/ab_ahead", ours);
+	    trace2_data_intmax("tracking", NULL, "stat_tracking_info/ab_behind", theirs);
+	}
+	trace2_region_leave("tracking", "stat_tracking_info", NULL);
+
 	if (sti < 0) {
 		if (!full_base)
 			return 0;

--- a/trace2/tr2_tgt_event.c
+++ b/trace2/tr2_tgt_event.c
@@ -32,7 +32,7 @@ static struct tr2_dst tr2dst_event = { TR2_SYSENV_EVENT, 0, 0, 0 };
  * event target.  Use the TR2_SYSENV_EVENT_NESTING setting to increase
  * region details in the event target.
  */
-static int tr2env_event_max_nesting_levels = 2;
+static int tr2env_event_max_nesting_levels = 4;
 
 /*
  * Use the TR2_SYSENV_EVENT_BRIEF to omit the <time>, <file>, and

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -369,8 +369,12 @@ static int check_updates(struct unpack_trees_options *o)
 	struct index_state *index = &o->result;
 	struct checkout state = CHECKOUT_INIT;
 	int i;
+	intmax_t sum_unlink = 0;
+	intmax_t sum_prefetch = 0;
+	intmax_t sum_checkout = 0;
 
 	trace_performance_enter();
+	trace2_region_enter("unpack_trees", "check_updates", NULL);
 	state.force = 1;
 	state.quiet = 1;
 	state.refresh_cache = 1;
@@ -392,8 +396,10 @@ static int check_updates(struct unpack_trees_options *o)
 
 		if (ce->ce_flags & CE_WT_REMOVE) {
 			display_progress(progress, ++cnt);
-			if (o->update && !o->dry_run)
+			if (o->update && !o->dry_run) {
 				unlink_entry(ce);
+				sum_unlink++;
+			}
 		}
 	}
 	remove_marked_cache_entries(index, 0);
@@ -421,6 +427,7 @@ static int check_updates(struct unpack_trees_options *o)
 				continue;
 			oid_array_append(&to_fetch, &ce->oid);
 		}
+		sum_prefetch = to_fetch.nr;
 		if (to_fetch.nr)
 			fetch_objects(repository_format_partial_clone,
 				      to_fetch.oid, to_fetch.nr);
@@ -437,6 +444,7 @@ static int check_updates(struct unpack_trees_options *o)
 			ce->ce_flags &= ~CE_UPDATE;
 			if (o->update && !o->dry_run) {
 				errs |= checkout_entry(ce, &state, NULL, NULL);
+				sum_checkout++;
 			}
 		}
 	}
@@ -447,6 +455,14 @@ static int check_updates(struct unpack_trees_options *o)
 
 	if (o->clone)
 		report_collided_checkout(index);
+
+	if (sum_unlink > 0)
+		trace2_data_intmax("unpack_trees", NULL, "check_updates/nr_unlink", sum_unlink);
+	if (sum_prefetch > 0)
+		trace2_data_intmax("unpack_trees", NULL, "check_updates/nr_prefetch", sum_prefetch);
+	if (sum_checkout > 0)
+		trace2_data_intmax("unpack_trees", NULL, "check_updates/nr_write", sum_checkout);
+	trace2_region_leave("unpack_trees", "check_updates", NULL);
 
 	trace_performance_leave("check_updates");
 	return errs != 0;
@@ -1415,16 +1431,16 @@ static int clear_ce_flags(struct index_state *istate,
 
 	strbuf_reset(&prefix);
 
-	xsnprintf(label, sizeof(label), "clear_ce_flags(0x%08lx,0x%08lx)",
+	xsnprintf(label, sizeof(label), "clear_ce_flags/0x%08lx_0x%08lx",
 		  (unsigned long)select_mask, (unsigned long)clear_mask);
-	trace2_region_enter("exp", label, the_repository);
+	trace2_region_enter("unpack_trees", label, the_repository);
 	rval = clear_ce_flags_1(istate,
 				istate->cache,
 				istate->cache_nr,
 				&prefix,
 				select_mask, clear_mask,
 				el, 0);
-	trace2_region_leave("exp", label, the_repository);
+	trace2_region_leave("unpack_trees", label, the_repository);
 
 	return rval;
 }
@@ -1480,7 +1496,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	if (len > MAX_UNPACK_TREES)
 		die("unpack_trees takes at most %d trees", MAX_UNPACK_TREES);
 
-	trace2_region_enter("exp", "unpack_trees", NULL);
+	trace2_region_enter("unpack_trees", "unpack_trees", NULL);
 	nr_unpack_entry_at_start = get_nr_unpack_entry();
 
 	trace_performance_enter();
@@ -1561,9 +1577,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		}
 
 		trace_performance_enter();
-		trace2_region_enter("exp", "traverse_trees", the_repository);
+		trace2_region_enter("unpack_trees", "traverse_trees", the_repository);
 		ret = traverse_trees(o->src_index, len, t, &info);
-		trace2_region_leave("exp", "traverse_trees", the_repository);
+		trace2_region_leave("unpack_trees", "traverse_trees", the_repository);
 		trace_performance_leave("traverse_trees");
 		if (ret < 0)
 			goto return_failed;
@@ -1663,9 +1679,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 done:
 	trace_performance_leave("unpack_trees");
 	clear_exclude_list(&el);
-	trace2_data_intmax("exp", NULL, "unpack_trees/nr_unpack_entries",
+	trace2_data_intmax("unpack_trees", NULL, "unpack_trees/nr_unpack_entries",
 			   (intmax_t)(get_nr_unpack_entry() - nr_unpack_entry_at_start));
-	trace2_region_leave("exp", "unpack_trees", NULL);
+	trace2_region_leave("unpack_trees", "unpack_trees", NULL);
 	return ret;
 
 return_failed:


### PR DESCRIPTION
This patch series updates the existing "exp" style tracing intended for `checkout` and `reset`
to have named categories.  It adds ahead/behind information.  And it adds data for the number
of files created or deleted during a checkout.

I've temporarily increased the default event-depth because some of the unpack_trees()
events are more deeply nested.
