### PR TITLE
commit: remove parse_commit_no_graph()

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -466,10 +466,6 @@ static int prepare_commit_graph(struct repository *r)
 	struct object_directory *odb;
 	int config_value;
 
-	if (git_env_bool(GIT_TEST_COMMIT_GRAPH_DIE_ON_LOAD, 0))
-		die("dying as requested by the '%s' variable on commit-graph load!",
-		    GIT_TEST_COMMIT_GRAPH_DIE_ON_LOAD);
-
 	if (r->objects->commit_graph_attempted)
 		return !!r->objects->commit_graph;
 	r->objects->commit_graph_attempted = 1;
@@ -834,7 +830,7 @@ static void write_graph_chunk_data(struct hashfile *f, int hash_len,
 		uint32_t packedDate[2];
 		display_progress(ctx->progress, ++ctx->progress_cnt);
 
-		parse_commit_no_graph(*list);
+		parse_commit(*list);
 		hashwrite(f, get_commit_tree_oid(*list)->hash, hash_len);
 
 		parent = (*list)->parents;
@@ -1052,7 +1048,7 @@ static void close_reachable(struct write_commit_graph_context *ctx)
 			if (!parse_commit(commit) &&
 			    commit->graph_pos == COMMIT_NOT_FROM_GRAPH)
 				add_missing_parents(ctx, commit);
-		} else if (!parse_commit_no_graph(commit))
+		} else if (!parse_commit(commit))
 			add_missing_parents(ctx, commit);
 	}
 	stop_progress(&ctx->progress);
@@ -1288,7 +1284,7 @@ static void copy_oids_to_commits(struct write_commit_graph_context *ctx)
 		    ctx->commits.list[ctx->commits.nr]->graph_pos != COMMIT_NOT_FROM_GRAPH)
 			continue;
 
-		parse_commit_no_graph(ctx->commits.list[ctx->commits.nr]);
+		parse_commit(ctx->commits.list[ctx->commits.nr]);
 
 		for (parent = ctx->commits.list[ctx->commits.nr]->parents;
 		     parent; parent = parent->next)

--- a/commit-graph.h
+++ b/commit-graph.h
@@ -7,7 +7,6 @@
 #include "cache.h"
 
 #define GIT_TEST_COMMIT_GRAPH "GIT_TEST_COMMIT_GRAPH"
-#define GIT_TEST_COMMIT_GRAPH_DIE_ON_LOAD "GIT_TEST_COMMIT_GRAPH_DIE_ON_LOAD"
 
 struct commit;
 

--- a/commit.h
+++ b/commit.h
@@ -89,12 +89,6 @@ static inline int repo_parse_commit(struct repository *r, struct commit *item)
 {
 	return repo_parse_commit_gently(r, item, 0);
 }
-
-static inline int parse_commit_no_graph(struct commit *commit)
-{
-	return repo_parse_commit_internal(the_repository, commit, 0, 0);
-}
-
 #ifndef NO_THE_REPOSITORY_COMPATIBILITY_MACROS
 #define parse_commit_internal(item, quiet, use) repo_parse_commit_internal(the_repository, item, quiet, use)
 #define parse_commit_gently(item, quiet) repo_parse_commit_gently(the_repository, item, quiet)


### PR DESCRIPTION
The parse_commit_no_graph() method was added in 43d35618 ("commit-graph
write: don't die if the existing graph is corrupt" 2019-03-25) as a way
to avoid persisting bad data across commit-graph files. That is, if the
commit-graph file has undetected corrupt data -- such as a flipped bit
in a parent int-id value -- then that data will persist to the next
commit-graph file. The parse_commit_no_graph() method was used to always
use the pack data directly instead.

Unfortunately, this comes at a significant performance cost. In both
time and memory, parsing from pack files is much slower than parsing
from the commit-graph file. In a repository with 4.5 million commits,
this can lead to Git taking up to 11gb of memory to rewrite the file.

Now that the incremental commit-graph file format exists, we can rely
on the quality of the commit-graph file if we follow the two-step
pattern of (1) write a commit-graph with "--split" and (2) run "git
commit-graph verify --shallow" to verify the tip file.

---

@jrbriggs, @jeffhostetler, @jamill and others: this change should revert
the performance problems we are seeing with the M153 release. I will
test this carefully after generating a Windows installer. I'm not sure if
this change would be something we can send upstream or not, but I
will start a conversation about it on the list.