### PR TITLE
[DRAFT, NOT FOR MERGE] fix sq_quote_buf_pretty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -733,6 +733,7 @@ TEST_BUILTINS_OBJS += test-path-utils.o
 TEST_BUILTINS_OBJS += test-pkt-line.o
 TEST_BUILTINS_OBJS += test-prefix-map.o
 TEST_BUILTINS_OBJS += test-prio-queue.o
+TEST_BUILTINS_OBJS += test-quote.o
 TEST_BUILTINS_OBJS += test-reach.o
 TEST_BUILTINS_OBJS += test-read-cache.o
 TEST_BUILTINS_OBJS += test-read-midx.o

--- a/quote.c
+++ b/quote.c
@@ -48,6 +48,15 @@ void sq_quote_buf_pretty(struct strbuf *dst, const char *src)
 	static const char ok_punct[] = "+,-./:=@_^";
 	const char *p;
 
+	/*
+	 * In case of null or empty strings, add a '' to ensure we 
+	 * don't inadvertently drop those tokens
+	 */
+	if (!src || !*src) {
+		strbuf_addstr(dst, "''");
+		return;
+	}
+
 	for (p = src; *p; p++) {
 		if (!isalpha(*p) && !isdigit(*p) && !strchr(ok_punct, *p)) {
 			sq_quote_buf(dst, src);

--- a/t/helper/test-quote.c
+++ b/t/helper/test-quote.c
@@ -1,0 +1,46 @@
+#include "test-tool.h"
+#include "quote.h"
+#include "strbuf.h"
+#include "string.h"
+
+int cmd__quote_buf_pretty(int argc, const char **argv)
+{
+	struct strbuf buf_payload = STRBUF_INIT;
+	char *nullString = 0;
+	char empty[5] = {'\0'};
+
+	if (!argv[1]) {
+		strbuf_release(&buf_payload);
+		die("missing input string");
+	}
+
+	if (!strcmp(argv[1], "nullString")) {
+		sq_quote_buf_pretty(&buf_payload, nullString);
+
+		/*
+		 * Cushion the result with '.'s 
+		 * to make the test script more readable
+		 */
+		printf(".%s.\n", buf_payload.buf);
+		strbuf_release(&buf_payload);
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "")) {
+		sq_quote_buf_pretty(&buf_payload, empty);
+
+		/*
+		 * Cushion the result with '.'s 
+		 * to make the test script more readable
+		 */
+		printf(".%s.\n", buf_payload.buf);
+		strbuf_release(&buf_payload);
+		return 0;
+	}
+
+	sq_quote_buf_pretty(&buf_payload, argv[1]);
+	printf("%s\n", buf_payload.buf);
+
+	strbuf_release(&buf_payload);
+	return 0;
+}

--- a/t/helper/test-tool.c
+++ b/t/helper/test-tool.c
@@ -57,6 +57,7 @@ static struct test_cmd cmds[] = {
 	{ "sha1-array", cmd__sha1_array },
 	{ "sha256", cmd__sha256 },
 	{ "sigchain", cmd__sigchain },
+	{ "quote-buf-pretty", cmd__quote_buf_pretty },
 	{ "strcmp-offset", cmd__strcmp_offset },
 	{ "string-list", cmd__string_list },
 	{ "submodule-config", cmd__submodule_config },

--- a/t/helper/test-tool.h
+++ b/t/helper/test-tool.h
@@ -47,6 +47,7 @@ int cmd__sha1(int argc, const char **argv);
 int cmd__sha1_array(int argc, const char **argv);
 int cmd__sha256(int argc, const char **argv);
 int cmd__sigchain(int argc, const char **argv);
+int cmd__quote_buf_pretty(int argc, const char **argv);
 int cmd__strcmp_offset(int argc, const char **argv);
 int cmd__string_list(int argc, const char **argv);
 int cmd__submodule_config(int argc, const char **argv);

--- a/t/t0091-quote.sh
+++ b/t/t0091-quote.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+test_description='Testing the sq_quote_buf_pretty method in quote.c'
+. ./test-lib.sh
+
+test_expect_success 'test method without input string' '
+	test_must_fail test-tool quote-buf-pretty
+'
+
+test_expect_success 'test null string' '
+	cat >expect <<-EOF &&
+	'.\'\'.'
+	EOF
+	test-tool quote-buf-pretty nullString >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'test empty string' '
+	cat >expect <<-EOF &&
+	'.\'\'.'
+	EOF
+	test-tool quote-buf-pretty "" >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'string without any punctuation' '
+	cat >expect <<-EOF &&
+	testString
+	EOF
+	test-tool quote-buf-pretty testString >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'string with punctuation that does not require special quotes' '
+	cat >expect <<-EOF &&
+	test+String
+	EOF
+	test-tool quote-buf-pretty test+String >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'string with punctuation that requires special quotes' '
+	cat >expect <<-EOF &&
+	'\'test~String\''
+	EOF
+	test-tool quote-buf-pretty test~String >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'string with punctuation that requires special quotes' '
+	cat >expect <<-EOF &&
+	'\'test\'\\!\'String\''
+	EOF
+	test-tool quote-buf-pretty test!String >actual &&
+	test_cmp expect actual
+'
+
+test_done


### PR DESCRIPTION
fix, tests: make sure sq_quote_buf_pretty doesn't inadvertently drop tokens that are empty and null, add tests for sq_quote_buf_pretty (quote.c) around some basic scenarios and to document the behavior of the method for null and empty strings

The only test failure is "not ok 48 - detect bogus diffFilter output" This has probably been fixed in git-for-windows but not microsoft/git. Completely unrelated to the changes here. 