### PR TITLE
[SPARSE] sparse-checkout builtin V0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@
 /git-show-branch
 /git-show-index
 /git-show-ref
+/git-sparse-checkout
 /git-stage
 /git-stash
 /git-status

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -660,7 +660,9 @@ core.gvfs::
 --
 
 core.sparseCheckout::
-	Enable "sparse checkout" feature. See section "Sparse checkout" in
+	Enable "sparse checkout" feature. Use "true" to enable the full pattern
+	set, or "cone" to enable the restricted cone-based patterns. Defaults to
+	"false", where the feature is disabled. See section "Sparse checkout" in
 	linkgit:git-read-tree[1] for more information.
 
 core.abbrev::

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -1,0 +1,120 @@
+git-sparse-checkout(1)
+=======================
+
+NAME
+----
+git-sparse-checkout - Initialize and modify the sparse-checkout
+configuration, which reduces the checkout to a set of directories
+given by a list of prefixes.
+
+
+SYNOPSIS
+--------
+[verse]
+'git sparse-checkout [init|add|list]'
+
+
+DESCRIPTION
+-----------
+
+Initialize and modify the sparse-checkout configuration, which reduces
+the checkout to a set of directories given by a list of prefixes.
+
+
+COMMANDS
+--------
+'init'::
+	Enable the `core.sparseCheckout` setting and clear all folders not
+	included by the sparse-checkout file. Typically, no sparse-checkout
+	file will exist when this command is run, so all directories in the
+	working directory will be removed.
+
+'add'::
+	Given a list of paths over stdin, add those paths to the
+	sparse-checkout file. Refresh the index and working directory to
+	place the necessary files on disk.
+
+'list'::
+	Provide a list of the contents in the sparse-checkout file.
+
+
+SPARSE CHECKOUT
+----------------
+
+The sparse-checkout feature provides simple way to reduce the "cone" of files
+in the working directory which are populated by Git. The sparse-checkout file
+specifies a list of directories from the working directory root, and the list
+of paths included are as follows:
+
+1. Any path that is contained in a folder listed in the sparse-checkout file.
+   For example, if `A/B/C` is in the sparse-checkout file, then `A/B/C/D/e.txt`
+   will exist in the working directory.
+
+2. Any path whose immediate parent folder is an ancestor of a folder listed in
+   the sparse-checkout file. For example, all files in the root directory are
+   included -- even if the sparse-checkout file is empty. As another example,
+   if `A/B/C` is in the sparse-checkout file, then `A/foo.txt` and `A/B/bar.c`
+   would be included. Note that `A/F/xyz.h` would not be included, as its
+   immediate parent (`A/F`) is not a prefix of `A/B/C`.
+
+Note that the pattern matching in the sparse-checkout feature is very restricted,
+unlike the sparse-checkout feature. The sparse-checkout and sparse-checkout
+features both use the skip-worktree bits in the index file to interact with
+other features in Git, but otherwise are incompatible. Creating a sparse-checkout
+file to include files according to the rules above is difficult, and the
+pattern matching required by the sparse-checkout feature leads to quadratic
+growth: for N patterns and M index entries, we must check O(N * M) patterns.
+
+Conversely, the sparse-checkout feature does not allow negative patterns or
+file-name based patterns. If you want to exclude all files ending in ".exe"
+you could include the line `!*.exe` in the sparse-checkout file. This is not
+available in the sparse-checkout feature.
+
+To use the sparse-checkout feature, you must enable the `core.partialCheckout`
+config setting. This setting will override the `core.sparseCheckout` setting,
+so any values in the sparse-checkout file will be ignored.
+
+To initialize an existing repo to use the sparse-checkout feature, run
+`git sparse-checkout init`. This will enable `core.partialCheckout`, remove
+all directories in the root of the working directory, and then update the
+working directory to contain the folders that may already exist in the
+sparse-checkout file. In the usual case, the sparse-checkout file will be
+empty and you will only see files in the working directory root.
+
+To add folders to the sparse-checkout file, run the `add` subcommand, and
+provide the list over standard-in:
+
+```
+$git sparse-checkout add
+A/B/C
+Docs
+tests
+^D
+```
+
+Since these folders do not exist in your working directory, you can use
+`git ls-tree HEAD -- <path>` to help discover folders that exist in your
+repo.
+
+After adding the folders to the sparse-checkout file, Git will update the index
+and run `git reset --hard` to place the files on disk. Due to the use of
+`git reset --hard`, the command will halt with an error before doing any work
+if you do not have a clean `git status`.
+
+If you wish to reduce your working directory, you can use the
+`git sparse-checkout remove` subcommand. It takes a list of folders from
+standard in, removes them from the sparse-checkout file and deletes them from
+your working directory, then runs `git reset --hard` to ensure the index is
+up to date.
+
+To check which folders are included in the sparse-checkout file, run the
+`git sparse-checkout list` subcommand.
+
+SEE ALSO
+--------
+
+linkgit:git-read-tree[1]
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Makefile
+++ b/Makefile
@@ -1135,6 +1135,7 @@ BUILTIN_OBJS += builtin/shortlog.o
 BUILTIN_OBJS += builtin/show-branch.o
 BUILTIN_OBJS += builtin/show-index.o
 BUILTIN_OBJS += builtin/show-ref.o
+BUILTIN_OBJS += builtin/sparse-checkout.o
 BUILTIN_OBJS += builtin/stash.o
 BUILTIN_OBJS += builtin/stripspace.o
 BUILTIN_OBJS += builtin/submodule--helper.o

--- a/builtin.h
+++ b/builtin.h
@@ -223,6 +223,7 @@ int cmd_shortlog(int argc, const char **argv, const char *prefix);
 int cmd_show(int argc, const char **argv, const char *prefix);
 int cmd_show_branch(int argc, const char **argv, const char *prefix);
 int cmd_show_index(int argc, const char **argv, const char *prefix);
+int cmd_sparse_checkout(int argc, const char **argv, const char *prefix);
 int cmd_status(int argc, const char **argv, const char *prefix);
 int cmd_stash(int argc, const char **argv, const char *prefix);
 int cmd_stripspace(int argc, const char **argv, const char *prefix);

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -1,0 +1,277 @@
+#include "builtin.h"
+#include "config.h"
+#include "dir.h"
+#include "parse-options.h"
+#include "pathspec.h"
+#include "repository.h"
+#include "run-command.h"
+#include "strbuf.h"
+#include "string-list.h"
+
+static char const * const builtin_sparse_checkout_usage[] = {
+	N_("git sparse-checkout [init|add|list]"),
+	NULL
+};
+
+struct opts_sparse_checkout {
+	const char *subcommand;
+	int read_stdin;
+} opts;
+
+static char *get_sparse_checkout_filename(void)
+{
+	return git_pathdup("info/sparse-checkout");
+}
+
+static int sc_read_tree(void)
+{
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	int result = 0;
+	argv_array_pushl(&argv, "read-tree", "-m", "-u", "HEAD", NULL);
+
+	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
+		error(_("failed to update index with new sparse-checkout paths"));
+		result = 1;
+	}
+
+	argv_array_clear(&argv);
+	return result;
+}
+
+static int sc_enable_config(void)
+{
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	int result = 0;
+	argv_array_pushl(&argv, "config", "--add", "core.sparseCheckout", "cone", NULL);
+
+	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
+		error(_("failed to enable core.sparseCheckout"));
+		result = 1;
+	}
+
+	argv_array_clear(&argv);
+	return result;
+}
+
+static int delete_directory(const struct object_id *oid, struct strbuf *base,
+		const char *pathname, unsigned mode, int stage, void *context)
+{
+	struct strbuf dirname = STRBUF_INIT;
+	struct stat sb;
+
+	strbuf_addstr(&dirname, the_repository->worktree);
+	strbuf_addch(&dirname, '/');
+	strbuf_addstr(&dirname, pathname);
+
+	if (stat(dirname.buf, &sb) || !(sb.st_mode & S_IFDIR))
+		return 0;
+
+	if (remove_dir_recursively(&dirname, 0))
+		warning(_("failed to remove directory '%s'"),
+			dirname.buf);
+
+	strbuf_release(&dirname);
+	return 0;
+}
+
+static int sparse_checkout_init(int argc, const char **argv)
+{
+	struct tree *t;
+	struct object_id oid;
+	static struct pathspec pathspec;
+	char *sparse_filename;
+	FILE *fp;
+
+	if (sc_enable_config())
+		return 1;
+
+	sparse_filename = get_sparse_checkout_filename();
+
+	/* initial mode: all blobs at root */
+	fp = fopen(sparse_filename, "w");
+	fprintf(fp, "/*\n!/*/*\n");
+	fclose(fp);
+
+	/* remove all directories in the root, if tracked by Git */
+	if (get_oid("HEAD", &oid)) {
+		/* assume we are in a fresh repo */
+		fprintf(stderr, "NO HEAD FOUND!\n");
+		free(sparse_filename);
+		return 0;
+	}
+
+	t = parse_tree_indirect(&oid);
+
+	parse_pathspec(&pathspec, PATHSPEC_ALL_MAGIC &
+				  ~(PATHSPEC_FROMTOP | PATHSPEC_LITERAL),
+		       PATHSPEC_PREFER_CWD,
+		       "", NULL);
+
+	if (read_tree_recursive(the_repository, t, "", 0, 0, &pathspec,
+				delete_directory, NULL))
+		return 1;
+
+	free(sparse_filename);
+	return sc_read_tree();
+}
+
+static int sparse_checkout_add(int argc, const char **argv)
+{
+	struct strbuf line = STRBUF_INIT;
+	FILE *fp;
+	struct exclude_list el;
+	char *sparse_filename;
+	struct hashmap_iter iter;
+	struct exclude_entry *entry;
+	struct string_list sl = STRING_LIST_INIT_DUP;
+	int i;
+
+	memset(&el, 0, sizeof(el));
+	sparse_filename = get_sparse_checkout_filename();
+
+	if (add_excludes_from_file_to_list(sparse_filename, "", 0, &el, NULL) < 0)
+		return 0;
+	free(sparse_filename);
+
+	if (!el.use_restricted_patterns)
+		die(_("The sparse-checkout file has incompatible patterns. It may have been edited manually."));
+
+	strbuf_init(&line, PATH_MAX);
+
+	for (;;) {
+		if (strbuf_getline(&line, stdin)) {
+			if (feof(stdin))
+				break;
+			if (!ferror(stdin))
+				die("BUG: fgets returned NULL, not EOF, not error!");
+			if (errno != EINTR)
+				die_errno("fgets");
+			clearerr(stdin);
+			continue;
+		}
+
+		if (line.len)
+			insert_recursive_pattern(&el, &line);
+	}
+
+	fp = fopen(sparse_filename, "w");
+
+	hashmap_iter_init(&el.parent_hashmap, &iter);
+	while ((entry = hashmap_iter_next(&iter))) {
+		char *pattern = xstrdup(entry->pattern);
+		char *converted = pattern;
+		if (pattern[0] == '/')
+			converted++;
+		if (pattern[entry->patternlen - 1] == '/')
+			pattern[entry->patternlen - 1] = 0;
+		string_list_insert(&sl, converted);
+		free(pattern);
+	}
+
+	string_list_sort(&sl);
+	string_list_remove_duplicates(&sl, 0);
+
+	for (i = 0; i < sl.nr; i++) {
+		char *pattern = sl.items[i].string;
+
+		if (!strcmp(pattern, ""))
+			fprintf(fp, "/*\n!/*/*\n");
+		else
+			fprintf(fp, "/%s/*\n!/%s/*/*\n", pattern, pattern);
+	}
+
+	string_list_clear(&sl, 0);
+
+	hashmap_iter_init(&el.recursive_hashmap, &iter);
+	while ((entry = hashmap_iter_next(&iter))) {
+		char *pattern = xstrdup(entry->pattern);
+		char *converted = pattern;
+		if (pattern[0] == '/')
+			converted++;
+		if (pattern[entry->patternlen - 1] == '/')
+			pattern[entry->patternlen - 1] = 0;
+		string_list_insert(&sl, converted);
+		free(pattern);
+	}
+
+	string_list_sort(&sl);
+	string_list_remove_duplicates(&sl, 0);
+
+	for (i = 0; i < sl.nr; i++) {
+		char *pattern = sl.items[i].string;
+		fprintf(fp, "/%s/*\n", pattern);
+	}
+
+	fclose(fp);
+
+	return sc_read_tree();
+}
+
+static int sparse_checkout_list(int argc, const char **argv)
+{
+	struct exclude_list el;
+	char *sparse_filename;
+	int i;
+
+	memset(&el, 0, sizeof(el));
+
+	sparse_filename = get_sparse_checkout_filename();
+
+	if (add_excludes_from_file_to_list(sparse_filename, "", 0, &el, NULL) < 0)
+		return 0;
+	free(sparse_filename);
+
+	if (!el.use_restricted_patterns)
+		die(_("your sparse-checkout file does not use restricted patterns"));
+
+	for (i = 0; i < el.nr; i++) {
+		struct exclude *x = el.excludes[i];
+		char *truncate;
+
+		if (x->flags & EXC_FLAG_NEGATIVE)
+			continue;
+
+		if (x->patternlen < 2)
+			die(_("your sparse-checkout file contains an empty pattern"));
+
+		truncate = xstrdup(x->pattern);
+		truncate[x->patternlen - 1] = 0;
+		printf("%s", truncate);
+
+		if (is_recursive_pattern(&el, truncate))
+			printf("*");
+		printf("\n");
+		free(truncate);
+	}
+
+	return 0;
+}
+
+int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
+{
+	static struct option builtin_sparse_checkout_options[] = {
+		OPT_END(),
+	};
+
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage_with_options(builtin_sparse_checkout_usage,
+				   builtin_sparse_checkout_options);
+
+	git_config(git_default_config, NULL);
+	argc = parse_options(argc, argv, prefix,
+			     builtin_sparse_checkout_options,
+			     builtin_sparse_checkout_usage,
+			     PARSE_OPT_STOP_AT_NON_OPTION);
+
+	if (argc > 0) {
+		if (!strcmp(argv[0], "init"))
+			return sparse_checkout_init(argc, argv);
+		if (!strcmp(argv[0], "add"))
+			return sparse_checkout_add(argc, argv);
+		if (!strcmp(argv[0], "list"))
+			return sparse_checkout_list(argc, argv);
+	}
+
+	usage_with_options(builtin_sparse_checkout_usage,
+			   builtin_sparse_checkout_options);
+}

--- a/cache.h
+++ b/cache.h
@@ -889,7 +889,14 @@ extern char *git_replace_ref_base;
 
 extern int fsync_object_files;
 extern int core_preload_index;
-extern int core_apply_sparse_checkout;
+
+enum sparse_checkout_options {
+	SPARSE_CHECKOUT_NONE = 0,
+	SPARSE_CHECKOUT_FULL = 1,
+	SPARSE_CHECKOUT_CONE = 2
+};
+
+extern enum sparse_checkout_options core_apply_sparse_checkout;
 extern const char *core_virtualfilesystem;
 extern int core_gvfs;
 extern int precomposed_unicode;

--- a/config.c
+++ b/config.c
@@ -1331,11 +1331,24 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 	}
 
 	if (!strcmp(var, "core.sparsecheckout")) {
+		int result;
+
 		/* virtual file system relies on the sparse checkout logic so force it on */
-		if (core_virtualfilesystem)
+		if (core_virtualfilesystem) {
 			core_apply_sparse_checkout = 1;
-		else
-			core_apply_sparse_checkout = git_config_bool(var, value);
+			return 0;
+		}
+
+		result = git_parse_maybe_bool(value);
+
+		if (result < 0) {
+			core_apply_sparse_checkout = SPARSE_CHECKOUT_NONE;
+
+			if (!strcasecmp(value, "cone"))
+				core_apply_sparse_checkout = SPARSE_CHECKOUT_CONE;
+		} else
+			core_apply_sparse_checkout = result;
+
 		return 0;
 	}
 

--- a/environment.c
+++ b/environment.c
@@ -68,7 +68,7 @@ enum push_default_type push_default = PUSH_DEFAULT_UNSPECIFIED;
 enum object_creation_mode object_creation_mode = OBJECT_CREATION_MODE;
 char *notes_ref_name;
 int grafts_replace_parents = 1;
-int core_apply_sparse_checkout;
+enum sparse_checkout_options core_apply_sparse_checkout;
 int core_gvfs;
 const char *core_virtualfilesystem;
 int merge_log_config = -1;

--- a/git.c
+++ b/git.c
@@ -644,6 +644,7 @@ static struct cmd_struct commands[] = {
 	{ "show-branch", cmd_show_branch, RUN_SETUP },
 	{ "show-index", cmd_show_index },
 	{ "show-ref", cmd_show_ref, RUN_SETUP },
+	{ "sparse-checkout", cmd_sparse_checkout, RUN_SETUP | NEED_WORK_TREE },
 	{ "stage", cmd_add, RUN_SETUP | NEED_WORK_TREE },
 	/*
 	 * NEEDSWORK: Until the builtin stash is thoroughly robust and no

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+test_description='sparse checkout builtin tests'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	echo "initial" >a &&
+	mkdir folder1 folder2 deep &&
+	mkdir deep/deeper1 deep/deeper2 &&
+	mkdir deep/deeper1/deepest &&
+	cp a folder1 &&
+	cp a folder2 &&
+	cp a deep &&
+	cp a deep/deeper1 &&
+	cp a deep/deeper2 &&
+	cp a deep/deeper1/deepest &&
+	git add . &&
+	git commit -m "initial commit" &&
+	mkdir test-output
+'
+
+test_expect_success 'git sparse-checkout list (empty)' '
+	git sparse-checkout list >test-output/list &&
+	test_line_count = 0 test-output/list
+'
+
+test_expect_success 'git sparse-checkout init' '
+	git sparse-checkout init &&
+	cat >test-output/expect <<-EOF &&
+		/*
+		!/*/*
+	EOF
+	test_cmp test-output/expect .git/info/sparse-checkout &&
+	git config --list >test-output/config &&
+	test_i18ngrep "core.sparsecheckout=cone" test-output/config &&
+	ls >test-output/dir  &&
+	cat >test-output/expect <<-EOF &&
+		a
+		test-output
+	EOF
+	test_cmp test-output/expect test-output/dir
+'
+
+test_expect_success 'git sparse-checkout list after init' '
+	git sparse-checkout list >test-output/actual &&
+	echo "/" >test-output/expect &&
+	test_cmp test-output/expect test-output/actual
+'
+
+test_expect_success 'git sparse-checkout add' '
+	git sparse-checkout add </dev/null &&
+	git sparse-checkout list >test-output/actual &&
+	test_cmp test-output/expect test-output/actual &&
+	git sparse-checkout add <<-EOF &&
+		folder1
+		deep/deeper1
+	EOF
+	cat >test-output/expect <<-EOF &&
+		/*
+		!/*/*
+		/deep/*
+		!/deep/*/*
+		/deep/deeper1/*
+		/folder1/*
+	EOF
+	test_cmp test-output/expect .git/info/sparse-checkout &&
+	ls >test-output/dir &&
+	cat >test-output/expect <<-EOF &&
+		a
+		deep
+		folder1
+		test-output
+	EOF
+	test_cmp test-output/expect test-output/dir &&
+	ls deep >test-output/dir &&
+	cat >test-output/expect <<-EOF &&
+		a
+		deeper1
+	EOF
+	test_cmp test-output/expect test-output/dir
+'
+
+test_expect_success 'git sparse-checkout list after add' '
+	git sparse-checkout list >test-output/actual &&
+	cat >test-output/expect <<-EOF &&
+		/
+		/deep/
+		/deep/deeper1/*
+		/folder1/*
+	EOF
+	test_cmp test-output/expect test-output/actual
+'
+
+test_expect_success 'git sparse-checkout add more' '
+	git sparse-checkout add <<-EOF &&
+		folder1
+		deep/deeper2
+	EOF
+	cat >test-output/expect <<-EOF &&
+		/*
+		!/*/*
+		/deep/*
+		!/deep/*/*
+		/deep/deeper1/*
+		/deep/deeper2/*
+		/folder1/*
+	EOF
+	test_cmp test-output/expect .git/info/sparse-checkout &&
+	ls >test-output/dir &&
+	cat >test-output/expect <<-EOF &&
+		a
+		deep
+		folder1
+		test-output
+	EOF
+	test_cmp test-output/expect test-output/dir &&
+	ls deep >test-output/dir &&
+	cat >test-output/expect <<-EOF &&
+		a
+		deeper1
+		deeper2
+	EOF
+	test_cmp test-output/expect test-output/dir
+'
+
+
+test_done


### PR DESCRIPTION
This is the "version zero" of the sparse-checkout builtin. This version is preliminary, and will eventually be replaced by something that can be sent upstream. This is being merged to the feature branch to facilitate moving forward with sparse-mode work in the [redacted] repo.

`git sparse-checkout init` initializes the `core.sparseCheckout` config variable to `cone`, which restricts the pattern set to our new model.

`git sparse-checkout add` reads a list of folders from `stdin` and creates the proper patterns in the sparse-checkout file, then runs `git read-tree -mu HEAD` to update the index and populate the working directory.

`git sparse-checkout list` shows the patterns in the sparse-checkout file.