### PR TITLE
checkout: fix leftover global constant

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -659,7 +659,7 @@ static int skip_merge_working_tree(const struct checkout_opts *opts,
 	 * Do the merge if sparse checkout is on and the user has not opted in
 	 * to the optimized behavior
 	 */
-	if (core_apply_sparse_checkout && !checkout_optimize_new_branch)
+	if (core_sparse_checkout && !checkout_optimize_new_branch)
 		return 0;
 
 	/*


### PR DESCRIPTION
In #183, I reverted a change to builtin/checkout.c that slowed
down 'git checkout -b'. That change introduced a new instance of
the core_apply_sparse_checkout global value that was not in the
previous version. I then merged #180 without regenerating a
build. My bad.

This fixes that remaining core_apply_sparse_checkout instance.
