### PR TITLE
[WIP] Improve 'git add .' performance

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -504,7 +504,8 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 
 	enable_fscache(0);
 	/* We do not really re-read the index but update the up-to-date flags */
-	preload_index(&the_index, &pathspec, 0);
+	refresh_index(&the_index, REFRESH_QUIET|REFRESH_UNMERGED,  &pathspec, 
+		      NULL, NULL);
 
 	if (add_new_files) {
 		int baselen;

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -512,6 +512,14 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 
 		/* Set up the default git porcelain excludes */
 		memset(&dir, 0, sizeof(dir));
+
+		/*
+		 * Include the flags used for the untracked cache (see
+		 * new_untracked_cache()) to improve the chances that it can be
+		 * used during fill_directory().
+		 */
+		dir.flags = DIR_SHOW_OTHER_DIRECTORIES | DIR_HIDE_EMPTY_DIRECTORIES;
+
 		if (!ignored_too) {
 			dir.flags |= DIR_COLLECT_IGNORED;
 			setup_standard_excludes(&dir);

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -517,7 +517,10 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 		}
 
 		/* This picks up the paths that are not tracked */
+		trace2_region_enter("add", "fill_directory", NULL);
 		baselen = fill_directory(&dir, &the_index, &pathspec);
+		trace2_region_leave("add", "fill_directory", NULL);
+
 		if (pathspec.nr)
 			seen = prune_directory(&dir, &pathspec, baselen);
 	}
@@ -566,13 +569,21 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 
 	plug_bulk_checkin();
 
-	if (add_renormalize)
+	if (add_renormalize) {
+		trace2_region_enter("add", "renormalize_tracked_files", NULL);
 		exit_status |= renormalize_tracked_files(&pathspec, flags);
-	else
+		trace2_region_leave("add", "renormalize_tracked_files", NULL);
+	} else {
+		trace2_region_enter("add", "add_files_to_cache", NULL);
 		exit_status |= add_files_to_cache(prefix, &pathspec, flags);
+		trace2_region_leave("add", "add_files_to_cache", NULL);
+	}
 
-	if (add_new_files)
+	if (add_new_files) {
+		trace2_region_enter("add", "add_files", NULL);
 		exit_status |= add_files(&dir, flags);
+		trace2_region_leave("add", "add_files", NULL);
+	}
 
 	if (chmod_arg && pathspec.nr)
 		chmod_pathspec(&pathspec, chmod_arg[0]);

--- a/dir.c
+++ b/dir.c
@@ -2412,7 +2412,15 @@ static struct untracked_cache_dir *validate_untracked_cache(struct dir_struct *d
 	 * use cache on just a subset of the worktree. pathspec
 	 * support could make the matter even worse.
 	 */
-	if (base_len || (pathspec && pathspec->nr))
+	if (base_len || (pathspec && pathspec->nr > 1))
+		return NULL;
+
+	/*
+	 * Allow single entry pathspecs if the pathspec has no effect on
+	 * matching (e.g. 'git add .' from the root of the repo)
+	 */
+
+	if (pathspec && pathspec->nr == 1 && pathspec->items[0].match[0] != '\0')
 		return NULL;
 
 	/* Different set of flags may produce different results */


### PR DESCRIPTION
Improve the performance of `git add .` when run from the root by using the untracked cache.

Additionally, add additional `trace2` regions to better understand where time is being spent.