### PR TITLE
gvfs-helper: fix race condition when creating loose object dirs

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1049,7 +1049,9 @@ static void create_tempfile_for_loose(
 	strbuf_complete(&buf_path, '/');
 	strbuf_add(&buf_path, hex, 2);
 
-	if (!file_exists(buf_path.buf) && mkdir(buf_path.buf, 0777) == -1) {
+	if (!file_exists(buf_path.buf) &&
+	    mkdir(buf_path.buf, 0777) == -1 &&
+		!file_exists(buf_path.buf)) {
 		strbuf_addf(&status->error_message,
 			    "cannot create directory for loose object '%s'",
 			    buf_path.buf);


### PR DESCRIPTION
When two gvfs-helper processes are the first to create a loose object
directory, the processes (A and B in the timeline below) could have
the following race:

1. A sees that the directory does not exist.
2. B sees that the directory does not exist.
3. A creates the directory with success.
4. B fails to create the directory and fails.

Instead of having B fail here, just check for the directory's
existence before reporting an error. That solves the race and
allows tests to pass.