### PR TITLE
features/sparse-checkout-2.24.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@
 /git-show-branch
 /git-show-index
 /git-show-ref
+/git-sparse-checkout
 /git-stage
 /git-stash
 /git-status

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@
 /git-gc
 /git-get-tar-commit-id
 /git-grep
+/git-gvfs-helper
 /git-hash-object
 /git-help
 /git-http-backend

--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -371,6 +371,8 @@ include::config/gui.txt[]
 
 include::config/guitool.txt[]
 
+include::config/gvfs.txt[]
+
 include::config/help.txt[]
 
 include::config/http.txt[]

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -593,8 +593,14 @@ core.multiPackIndex::
 	multi-pack-index design document].
 
 core.sparseCheckout::
-	Enable "sparse checkout" feature. See section "Sparse checkout" in
-	linkgit:git-read-tree[1] for more information.
+	Enable "sparse checkout" feature. See linkgit:git-sparse-checkout[1]
+	for more information.
+
+core.sparseCheckoutCone::
+	Enables the "cone mode" of the sparse checkout feature. When the
+	sparse-checkout file contains a limited set of patterns, then this
+	mode provides significant performance advantages. See
+	linkgit:git-sparse-checkout[1] for more information.
 
 core.abbrev::
 	Set the length object names are abbreviated to.  If

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -661,6 +661,9 @@ core.gvfs::
 		flag just blocks them from occurring at all.
 --
 
+core.useGvfsHelper::
+	TODO
+
 core.sparseCheckout::
 	Enable "sparse checkout" feature. See linkgit:git-sparse-checkout[1]
 	for more information.

--- a/Documentation/config/gvfs.txt
+++ b/Documentation/config/gvfs.txt
@@ -1,0 +1,5 @@
+gvfs.cache-server::
+	TODO
+
+gvfs.sharedcache::
+	TODO

--- a/Documentation/git-clone.txt
+++ b/Documentation/git-clone.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 	  [--dissociate] [--separate-git-dir <git dir>]
 	  [--depth <depth>] [--[no-]single-branch] [--no-tags]
 	  [--recurse-submodules[=<pathspec>]] [--[no-]shallow-submodules]
-	  [--[no-]remote-submodules] [--jobs <n>] [--] <repository>
+	  [--[no-]remote-submodules] [--jobs <n>] [--sparse] [--] <repository>
 	  [<directory>]
 
 DESCRIPTION
@@ -155,6 +155,12 @@ objects from the source repository into a pack in the cloned repository.
 	them to `refs/remotes/origin/`.  When this option is
 	used, neither remote-tracking branches nor the related
 	configuration variables are created.
+
+--sparse::
+	Initialize the sparse-checkout file so the working
+	directory starts with only the files in the root
+	of the repository. The sparse-checkout file can be
+	modified to grow the working directory as needed.
 
 --mirror::
 	Set up a mirror of the source repository.  This implies `--bare`.

--- a/Documentation/git-read-tree.txt
+++ b/Documentation/git-read-tree.txt
@@ -436,7 +436,7 @@ support.
 SEE ALSO
 --------
 linkgit:git-write-tree[1]; linkgit:git-ls-files[1];
-linkgit:gitignore[5]
+linkgit:gitignore[5]; linkgit:git-sparse-checkout[1];
 
 GIT
 ---

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -48,6 +48,10 @@ To avoid interfering with other worktrees, it first enables the
 	working directory to match the new patterns. Enable the
 	core.sparseCheckout config setting if it is not already enabled.
 
+'disable'::
+	Remove the sparse-checkout file, set `core.sparseCheckout` to
+	`false`, and restore the working directory to include all files.
+
 SPARSE CHECKOUT
 ---------------
 
@@ -65,6 +69,14 @@ directory, it updates the skip-worktree bits in the index based
 on this file. The files matching the patterns in the file will
 appear in the working directory, and the rest will not.
 
+To enable the sparse-checkout feature, run `git sparse-checkout init` to
+initialize a simple sparse-checkout file and enable the `core.sparseCheckout`
+config setting. Then, run `git sparse-checkout set` to modify the patterns in
+the sparse-checkout file.
+
+To repopulate the working directory with all files, use the
+`git sparse-checkout disable` command.
+
 ## FULL PATTERN SET
 
 By default, the sparse-checkout file uses the same syntax as `.gitignore`
@@ -79,21 +91,6 @@ using negative patterns. For example, to remove the file `unwanted`:
 !unwanted
 ----------------
 
-Another tricky thing is fully repopulating the working directory when you
-no longer want sparse checkout. You cannot just disable "sparse
-checkout" because skip-worktree bits are still in the index and your working
-directory is still sparsely populated. You should re-populate the working
-directory with the `$GIT_DIR/info/sparse-checkout` file content as
-follows:
-
-----------------
-/*
-----------------
-
-Then you can disable sparse checkout. Sparse checkout support in 'git
-checkout' and similar commands is disabled by default. You need to
-set `core.sparseCheckout` to `true` in order to have sparse checkout
-support.
 
 SEE ALSO
 --------

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -30,6 +30,17 @@ COMMANDS
 'list'::
 	Provide a list of the contents in the sparse-checkout file.
 
+'init'::
+	Enable the `core.sparseCheckout` setting. If the
+	sparse-checkout file does not exist, then populate it with
+	patterns that match every file in the root directory and
+	no other directories, then will remove all directories tracked
+	by Git. Add patterns to the sparse-checkout file to
+	repopulate the working directory.
++
+To avoid interfering with other worktrees, it first enables the
+`extensions.worktreeConfig` setting and makes sure to set the
+`core.sparseCheckout` setting in the worktree-specific config file.
 
 SPARSE CHECKOUT
 ---------------

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -42,6 +42,12 @@ To avoid interfering with other worktrees, it first enables the
 `extensions.worktreeConfig` setting and makes sure to set the
 `core.sparseCheckout` setting in the worktree-specific config file.
 
+'set'::
+	Write a set of patterns to the sparse-checkout file, as given as
+	a list of arguments following the 'set' subcommand. Update the
+	working directory to match the new patterns. Enable the
+	core.sparseCheckout config setting if it is not already enabled.
+
 SPARSE CHECKOUT
 ---------------
 

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -1,0 +1,89 @@
+git-sparse-checkout(1)
+======================
+
+NAME
+----
+git-sparse-checkout - Initialize and modify the sparse-checkout
+configuration, which reduces the checkout to a set of directories
+given by a list of prefixes.
+
+
+SYNOPSIS
+--------
+[verse]
+'git sparse-checkout <subcommand> [options]'
+
+
+DESCRIPTION
+-----------
+
+Initialize and modify the sparse-checkout configuration, which reduces
+the checkout to a set of directories given by a list of prefixes.
+
+THIS COMMAND IS EXPERIMENTAL. ITS BEHAVIOR, AND THE BEHAVIOR OF OTHER
+COMMANDS IN THE PRESENCE OF SPARSE-CHECKOUTS, WILL LIKELY CHANGE IN
+THE FUTURE.
+
+
+COMMANDS
+--------
+'list'::
+	Provide a list of the contents in the sparse-checkout file.
+
+
+SPARSE CHECKOUT
+---------------
+
+"Sparse checkout" allows populating the working directory sparsely.
+It uses the skip-worktree bit (see linkgit:git-update-index[1]) to tell
+Git whether a file in the working directory is worth looking at. If
+the skip-worktree bit is set, then the file is ignored in the working
+directory. Git will not populate the contents of those files, which
+makes a sparse checkout helpful when working in a repository with many
+files, but only a few are important to the current user.
+
+The `$GIT_DIR/info/sparse-checkout` file is used to define the
+skip-worktree reference bitmap. When Git updates the working
+directory, it updates the skip-worktree bits in the index based
+on this file. The files matching the patterns in the file will
+appear in the working directory, and the rest will not.
+
+## FULL PATTERN SET
+
+By default, the sparse-checkout file uses the same syntax as `.gitignore`
+files.
+
+While `$GIT_DIR/info/sparse-checkout` is usually used to specify what
+files are included, you can also specify what files are _not_ included,
+using negative patterns. For example, to remove the file `unwanted`:
+
+----------------
+/*
+!unwanted
+----------------
+
+Another tricky thing is fully repopulating the working directory when you
+no longer want sparse checkout. You cannot just disable "sparse
+checkout" because skip-worktree bits are still in the index and your working
+directory is still sparsely populated. You should re-populate the working
+directory with the `$GIT_DIR/info/sparse-checkout` file content as
+follows:
+
+----------------
+/*
+----------------
+
+Then you can disable sparse checkout. Sparse checkout support in 'git
+checkout' and similar commands is disabled by default. You need to
+set `core.sparseCheckout` to `true` in order to have sparse checkout
+support.
+
+SEE ALSO
+--------
+
+linkgit:git-read-tree[1]
+linkgit:gitignore[5]
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Documentation/git-sparse-checkout.txt
+++ b/Documentation/git-sparse-checkout.txt
@@ -92,6 +92,56 @@ using negative patterns. For example, to remove the file `unwanted`:
 ----------------
 
 
+## CONE PATTERN SET
+
+The full pattern set allows for arbitrary pattern matches and complicated
+inclusion/exclusion rules. These can result in O(N*M) pattern matches when
+updating the index, where N is the number of patterns and M is the number
+of paths in the index. To combat this performance issue, a more restricted
+pattern set is allowed when `core.spareCheckoutCone` is enabled.
+
+The accepted patterns in the cone pattern set are:
+
+1. *Recursive:* All paths inside a directory are included.
+
+2. *Parent:* All files immediately inside a directory are included.
+
+In addition to the above two patterns, we also expect that all files in the
+root directory are included. If a recursive pattern is added, then all
+leading directories are added as parent patterns.
+
+By default, when running `git sparse-checkout init`, the root directory is
+added as a parent pattern. At this point, the sparse-checkout file contains
+the following patterns:
+
+```
+/*
+!/*/
+```
+
+This says "include everything in root, but nothing two levels below root."
+If we then add the folder `A/B/C` as a recursive pattern, the folders `A` and
+`A/B` are added as parent patterns. The resulting sparse-checkout file is
+now
+
+```
+/*
+!/*/
+/A/
+!/A/*/
+/A/B/
+!/A/B/*/
+/A/B/C/
+```
+
+Here, order matters, so the negative patterns are overridden by the positive
+patterns that appear lower in the file.
+
+If `core.sparseCheckoutCone=true`, then Git will parse the sparse-checkout file
+expecting patterns of these types. Git will warn if the patterns do not match.
+If the patterns do match the expected format, then Git will use faster hash-
+based algorithms to compute inclusion in the sparse-checkout.
+
 SEE ALSO
 --------
 

--- a/Makefile
+++ b/Makefile
@@ -1125,6 +1125,7 @@ BUILTIN_OBJS += builtin/shortlog.o
 BUILTIN_OBJS += builtin/show-branch.o
 BUILTIN_OBJS += builtin/show-index.o
 BUILTIN_OBJS += builtin/show-ref.o
+BUILTIN_OBJS += builtin/sparse-checkout.o
 BUILTIN_OBJS += builtin/stash.o
 BUILTIN_OBJS += builtin/stripspace.o
 BUILTIN_OBJS += builtin/submodule--helper.o

--- a/Makefile
+++ b/Makefile
@@ -893,6 +893,7 @@ LIB_OBJS += gpg-interface.o
 LIB_OBJS += graph.o
 LIB_OBJS += grep.o
 LIB_OBJS += gvfs.o
+LIB_OBJS += gvfs-helper-client.o
 LIB_OBJS += hashmap.o
 LIB_OBJS += linear-assignment.o
 LIB_OBJS += help.o
@@ -1369,6 +1370,8 @@ ifdef CURL_LDFLAGS
 else
 	CURL_LIBCURL += $(shell $(CURL_CONFIG) --libs)
 endif
+
+	PROGRAM_OBJS += gvfs-helper.o
 
 	REMOTE_CURL_PRIMARY = git-remote-http$X
 	REMOTE_CURL_ALIASES = git-remote-https$X git-remote-ftp$X git-remote-ftps$X
@@ -2477,6 +2480,10 @@ $(REMOTE_CURL_ALIASES): $(REMOTE_CURL_PRIMARY)
 	cp $< $@
 
 $(REMOTE_CURL_PRIMARY): remote-curl.o http.o http-walker.o GIT-LDFLAGS $(GITLIBS)
+	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
+		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
+
+git-gvfs-helper$X: gvfs-helper.o http.o GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
 

--- a/builtin.h
+++ b/builtin.h
@@ -225,6 +225,7 @@ int cmd_shortlog(int argc, const char **argv, const char *prefix);
 int cmd_show(int argc, const char **argv, const char *prefix);
 int cmd_show_branch(int argc, const char **argv, const char *prefix);
 int cmd_show_index(int argc, const char **argv, const char *prefix);
+int cmd_sparse_checkout(int argc, const char **argv, const char *prefix);
 int cmd_status(int argc, const char **argv, const char *prefix);
 int cmd_stash(int argc, const char **argv, const char *prefix);
 int cmd_stripspace(int argc, const char **argv, const char *prefix);

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -781,7 +781,7 @@ static void sha1_object(const void *data, struct object_entry *obj_entry,
 	if (startup_info->have_repository) {
 		read_lock();
 		collision_test_needed =
-			has_object_file_with_flags(oid, OBJECT_INFO_QUICK);
+			has_object_file_with_flags(oid, OBJECT_INFO_FOR_PREFETCH);
 		read_unlock();
 	}
 

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -162,6 +162,7 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 	opts.head_idx = -1;
 	opts.src_index = &the_index;
 	opts.dst_index = &the_index;
+	opts.verbose_update = isatty(2);
 
 	git_config(git_read_tree_config, NULL);
 

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -186,7 +186,7 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 
 	if (opts.reset || opts.merge || opts.prefix) {
 		if (read_cache_unmerged() && (opts.prefix || opts.merge))
-			die("You need to resolve your current index first");
+			die(_("You need to resolve your current index first"));
 		stage = opts.merge = 1;
 	}
 	resolve_undo_clear();

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -154,6 +154,15 @@ static int write_patterns_and_update(struct pattern_list *pl)
 	return update_working_directory();
 }
 
+static char const * const builtin_sparse_checkout_set_usage[] = {
+	N_("git sparse-checkout set [--stdin|<patterns>]"),
+	NULL
+};
+
+static struct sparse_checkout_set_opts {
+	int use_stdin;
+} set_opts;
+
 static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 {
 	static const char *empty_base = "";
@@ -161,10 +170,32 @@ static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 	struct pattern_list pl;
 	int result;
 	int set_config = 0;
+
+	static struct option builtin_sparse_checkout_set_options[] = {
+		OPT_BOOL(0, "stdin", &set_opts.use_stdin,
+			 N_("read patterns from standard in")),
+		OPT_END(),
+	};
+
 	memset(&pl, 0, sizeof(pl));
 
-	for (i = 1; i < argc; i++)
-		add_pattern(argv[i], empty_base, 0, &pl, 0);
+	argc = parse_options(argc, argv, prefix,
+			     builtin_sparse_checkout_set_options,
+			     builtin_sparse_checkout_set_usage,
+			     PARSE_OPT_KEEP_UNKNOWN);
+
+	if (set_opts.use_stdin) {
+		struct strbuf line = STRBUF_INIT;
+
+		while (!strbuf_getline(&line, stdin)) {
+			size_t len;
+			char *buf = strbuf_detach(&line, &len);
+			add_pattern(buf, empty_base, 0, &pl, 0);
+		}
+	} else {
+		for (i = 0; i < argc; i++)
+			add_pattern(argv[i], empty_base, 0, &pl, 0);
+	}
 
 	if (!core_apply_sparse_checkout) {
 		sc_set_config(MODE_ALL_PATTERNS);

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -6,6 +6,7 @@
 #include "repository.h"
 #include "run-command.h"
 #include "strbuf.h"
+#include "string-list.h"
 
 static char const * const builtin_sparse_checkout_usage[] = {
 	N_("git sparse-checkout (init|list|set|disable) <options>"),
@@ -77,11 +78,13 @@ static int update_working_directory(void)
 enum sparse_checkout_mode {
 	MODE_NO_PATTERNS = 0,
 	MODE_ALL_PATTERNS = 1,
+	MODE_CONE_PATTERNS = 2,
 };
 
 static int sc_set_config(enum sparse_checkout_mode mode)
 {
 	struct argv_array argv = ARGV_ARRAY_INIT;
+	struct argv_array cone_argv = ARGV_ARRAY_INIT;
 
 	if (git_config_set_gently("extensions.worktreeConfig", "true")) {
 		error(_("failed to set extensions.worktreeConfig setting"));
@@ -100,8 +103,30 @@ static int sc_set_config(enum sparse_checkout_mode mode)
 		return 1;
 	}
 
+	argv_array_pushl(&cone_argv, "config", "--worktree",
+			 "core.sparseCheckoutCone", NULL);
+
+	if (mode == MODE_CONE_PATTERNS)
+		argv_array_push(&cone_argv, "true");
+	else
+		argv_array_push(&cone_argv, "false");
+
+	if (run_command_v_opt(cone_argv.argv, RUN_GIT_CMD)) {
+		error(_("failed to enable core.sparseCheckoutCone"));
+		return 1;
+	}
+
 	return 0;
 }
+
+static char const * const builtin_sparse_checkout_init_usage[] = {
+	N_("git sparse-checkout init [--cone]"),
+	NULL
+};
+
+static struct sparse_checkout_init_opts {
+	int cone_mode;
+} init_opts;
 
 static int sparse_checkout_init(int argc, const char **argv)
 {
@@ -110,8 +135,21 @@ static int sparse_checkout_init(int argc, const char **argv)
 	FILE *fp;
 	int res;
 	struct object_id oid;
+	int mode;
 
-	if (sc_set_config(MODE_ALL_PATTERNS))
+	static struct option builtin_sparse_checkout_init_options[] = {
+		OPT_BOOL(0, "cone", &init_opts.cone_mode,
+			 N_("initialize the sparse-checkout in cone mode")),
+		OPT_END(),
+	};
+
+	argc = parse_options(argc, argv, NULL,
+			     builtin_sparse_checkout_init_options,
+			     builtin_sparse_checkout_init_usage, 0);
+
+	mode = init_opts.cone_mode ? MODE_CONE_PATTERNS : MODE_ALL_PATTERNS;
+
+	if (sc_set_config(mode))
 		return 1;
 
 	memset(&pl, 0, sizeof(pl));
@@ -140,6 +178,70 @@ reset_dir:
 	return update_working_directory();
 }
 
+static void insert_recursive_pattern(struct pattern_list *pl, struct strbuf *path)
+{
+	struct pattern_entry *e = xmalloc(sizeof(*e));
+	e->patternlen = path->len;
+	e->pattern = strbuf_detach(path, NULL);
+	hashmap_entry_init(&e->ent, memhash(e->pattern, e->patternlen));
+
+	hashmap_add(&pl->recursive_hashmap, &e->ent);
+
+	while (e->patternlen) {
+		char *slash = strrchr(e->pattern, '/');
+		char *oldpattern = e->pattern;
+		size_t newlen;
+
+		if (slash == e->pattern)
+			break;
+
+		newlen = slash - e->pattern;
+		e = xmalloc(sizeof(struct pattern_entry));
+		e->patternlen = newlen;
+		e->pattern = xstrndup(oldpattern, newlen);
+		hashmap_entry_init(&e->ent, memhash(e->pattern, e->patternlen));
+
+		if (!hashmap_get_entry(&pl->parent_hashmap, e, ent, NULL))
+			hashmap_add(&pl->parent_hashmap, &e->ent);
+	}
+}
+
+static void write_cone_to_file(FILE *fp, struct pattern_list *pl)
+{
+	int i;
+	struct pattern_entry *pe;
+	struct hashmap_iter iter;
+	struct string_list sl = STRING_LIST_INIT_DUP;
+
+	hashmap_for_each_entry(&pl->parent_hashmap, &iter, pe, ent)
+		string_list_insert(&sl, pe->pattern);
+
+	string_list_sort(&sl);
+	string_list_remove_duplicates(&sl, 0);
+
+	fprintf(fp, "/*\n!/*/\n");
+
+	for (i = 0; i < sl.nr; i++) {
+		char *pattern = sl.items[i].string;
+
+		if (strlen(pattern))
+			fprintf(fp, "%s/\n!%s/*/\n", pattern, pattern);
+	}
+
+	string_list_clear(&sl, 0);
+
+	hashmap_for_each_entry(&pl->recursive_hashmap, &iter, pe, ent)
+		string_list_insert(&sl, pe->pattern);
+
+	string_list_sort(&sl);
+	string_list_remove_duplicates(&sl, 0);
+
+	for (i = 0; i < sl.nr; i++) {
+		char *pattern = sl.items[i].string;
+		fprintf(fp, "%s/\n", pattern);
+	}
+}
+
 static int write_patterns_and_update(struct pattern_list *pl)
 {
 	char *sparse_filename;
@@ -147,11 +249,31 @@ static int write_patterns_and_update(struct pattern_list *pl)
 
 	sparse_filename = get_sparse_checkout_filename();
 	fp = fopen(sparse_filename, "w");
-	write_patterns_to_file(fp, pl);
+
+	if (core_sparse_checkout_cone)
+		write_cone_to_file(fp, pl);
+	else
+		write_patterns_to_file(fp, pl);
+
 	fclose(fp);
 	free(sparse_filename);
 
 	return update_working_directory();
+}
+
+static void strbuf_to_cone_pattern(struct strbuf *line, struct pattern_list *pl)
+{
+	strbuf_trim(line);
+
+	strbuf_trim_trailing_dir_sep(line);
+
+	if (!line->len)
+		return;
+
+	if (line->buf[0] != '/')
+		strbuf_insert(line, 0, "/", 1);
+
+	insert_recursive_pattern(pl, line);
 }
 
 static char const * const builtin_sparse_checkout_set_usage[] = {
@@ -184,17 +306,34 @@ static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 			     builtin_sparse_checkout_set_usage,
 			     PARSE_OPT_KEEP_UNKNOWN);
 
-	if (set_opts.use_stdin) {
+	if (core_sparse_checkout_cone) {
 		struct strbuf line = STRBUF_INIT;
+		hashmap_init(&pl.recursive_hashmap, pl_hashmap_cmp, NULL, 0);
+		hashmap_init(&pl.parent_hashmap, pl_hashmap_cmp, NULL, 0);
 
-		while (!strbuf_getline(&line, stdin)) {
-			size_t len;
-			char *buf = strbuf_detach(&line, &len);
-			add_pattern(buf, empty_base, 0, &pl, 0);
+		if (set_opts.use_stdin) {
+			while (!strbuf_getline(&line, stdin))
+				strbuf_to_cone_pattern(&line, &pl);
+		} else {
+			for (i = 0; i < argc; i++) {
+				strbuf_setlen(&line, 0);
+				strbuf_addstr(&line, argv[i]);
+				strbuf_to_cone_pattern(&line, &pl);
+			}
 		}
 	} else {
-		for (i = 0; i < argc; i++)
-			add_pattern(argv[i], empty_base, 0, &pl, 0);
+		if (set_opts.use_stdin) {
+			struct strbuf line = STRBUF_INIT;
+
+			while (!strbuf_getline(&line, stdin)) {
+				size_t len;
+				char *buf = strbuf_detach(&line, &len);
+				add_pattern(buf, empty_base, 0, &pl, 0);
+			}
+		} else {
+			for (i = 0; i < argc; i++)
+				add_pattern(argv[i], empty_base, 0, &pl, 0);
+		}
 	}
 
 	if (!core_apply_sparse_checkout) {

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -306,25 +306,34 @@ static int write_patterns_and_update(struct pattern_list *pl)
 {
 	char *sparse_filename;
 	FILE *fp;
+	int fd;
+	struct lock_file lk = LOCK_INIT;
 	int result;
 
 	result = update_working_directory(pl);
 
+	sparse_filename = get_sparse_checkout_filename();
+	fd = hold_lock_file_for_update(&lk, sparse_filename,
+				      LOCK_DIE_ON_ERROR);
+
+	result = update_working_directory(pl);
 	if (result) {
+		rollback_lock_file(&lk);
+		free(sparse_filename);
 		clear_pattern_list(pl);
 		update_working_directory(NULL);
 		return result;
 	}
 
-	sparse_filename = get_sparse_checkout_filename();
-	fp = fopen(sparse_filename, "w");
+	fp = xfdopen(fd, "w");
 
 	if (core_sparse_checkout_cone)
 		write_cone_to_file(fp, pl);
 	else
 		write_patterns_to_file(fp, pl);
 
-	fclose(fp);
+	fflush(fp);
+	commit_lock_file(&lk);
 
 	free(sparse_filename);
 	clear_pattern_list(pl);

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -1,0 +1,86 @@
+#include "builtin.h"
+#include "config.h"
+#include "dir.h"
+#include "parse-options.h"
+#include "pathspec.h"
+#include "repository.h"
+#include "run-command.h"
+#include "strbuf.h"
+
+static char const * const builtin_sparse_checkout_usage[] = {
+	N_("git sparse-checkout list"),
+	NULL
+};
+
+static char *get_sparse_checkout_filename(void)
+{
+	return git_pathdup("info/sparse-checkout");
+}
+
+static void write_patterns_to_file(FILE *fp, struct pattern_list *pl)
+{
+	int i;
+
+	for (i = 0; i < pl->nr; i++) {
+		struct path_pattern *p = pl->patterns[i];
+
+		if (p->flags & PATTERN_FLAG_NEGATIVE)
+			fprintf(fp, "!");
+
+		fprintf(fp, "%s", p->pattern);
+
+		if (p->flags & PATTERN_FLAG_MUSTBEDIR)
+			fprintf(fp, "/");
+
+		fprintf(fp, "\n");
+	}
+}
+
+static int sparse_checkout_list(int argc, const char **argv)
+{
+	struct pattern_list pl;
+	char *sparse_filename;
+	int res;
+
+	memset(&pl, 0, sizeof(pl));
+
+	sparse_filename = get_sparse_checkout_filename();
+	res = add_patterns_from_file_to_list(sparse_filename, "", 0, &pl, NULL);
+	free(sparse_filename);
+
+	if (res < 0) {
+		warning(_("this worktree is not sparse (sparse-checkout file may not exist)"));
+		return 0;
+	}
+
+	write_patterns_to_file(stdout, &pl);
+	clear_pattern_list(&pl);
+
+	return 0;
+}
+
+int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
+{
+	static struct option builtin_sparse_checkout_options[] = {
+		OPT_END(),
+	};
+
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage_with_options(builtin_sparse_checkout_usage,
+				   builtin_sparse_checkout_options);
+
+	argc = parse_options(argc, argv, prefix,
+			     builtin_sparse_checkout_options,
+			     builtin_sparse_checkout_usage,
+			     PARSE_OPT_STOP_AT_NON_OPTION);
+
+	git_config(git_default_config, NULL);
+
+	if (argc > 0) {
+		if (!strcmp(argv[0], "list"))
+			return sparse_checkout_list(argc, argv);
+	}
+
+	usage_with_options(builtin_sparse_checkout_usage,
+			   builtin_sparse_checkout_options);
+}

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -109,6 +109,7 @@ static int sparse_checkout_init(int argc, const char **argv)
 	char *sparse_filename;
 	FILE *fp;
 	int res;
+	struct object_id oid;
 
 	if (sc_set_config(MODE_ALL_PATTERNS))
 		return 1;
@@ -129,6 +130,11 @@ static int sparse_checkout_init(int argc, const char **argv)
 	free(sparse_filename);
 	fprintf(fp, "/*\n!/*/\n");
 	fclose(fp);
+
+	if (get_oid("HEAD", &oid)) {
+		/* assume we are in a fresh repo */
+		return 0;
+	}
 
 reset_dir:
 	return update_working_directory();

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -8,7 +8,7 @@
 #include "strbuf.h"
 
 static char const * const builtin_sparse_checkout_usage[] = {
-	N_("git sparse-checkout (init|list|set) <options>"),
+	N_("git sparse-checkout (init|list|set|disable) <options>"),
 	NULL
 };
 
@@ -212,6 +212,28 @@ static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 	return result;
 }
 
+static int sparse_checkout_disable(int argc, const char **argv)
+{
+	char *sparse_filename;
+	FILE *fp;
+
+	if (sc_set_config(MODE_ALL_PATTERNS))
+		die(_("failed to change config"));
+
+	sparse_filename = get_sparse_checkout_filename();
+	fp = xfopen(sparse_filename, "w");
+	fprintf(fp, "/*\n");
+	fclose(fp);
+
+	if (update_working_directory())
+		die(_("error while refreshing working directory"));
+
+	unlink(sparse_filename);
+	free(sparse_filename);
+
+	return sc_set_config(MODE_NO_PATTERNS);
+}
+
 int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
 {
 	static struct option builtin_sparse_checkout_options[] = {
@@ -236,6 +258,8 @@ int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
 			return sparse_checkout_init(argc, argv);
 		if (!strcmp(argv[0], "set"))
 			return sparse_checkout_set(argc, argv, prefix);
+		if (!strcmp(argv[0], "disable"))
+			return sparse_checkout_disable(argc, argv);
 	}
 
 	usage_with_options(builtin_sparse_checkout_usage,

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -212,9 +212,17 @@ static void write_cone_to_file(FILE *fp, struct pattern_list *pl)
 	struct pattern_entry *pe;
 	struct hashmap_iter iter;
 	struct string_list sl = STRING_LIST_INIT_DUP;
+	struct strbuf parent_pattern = STRBUF_INIT;
 
-	hashmap_for_each_entry(&pl->parent_hashmap, &iter, pe, ent)
-		string_list_insert(&sl, pe->pattern);
+	hashmap_for_each_entry(&pl->parent_hashmap, &iter, pe, ent) {
+		if (hashmap_get_entry(&pl->recursive_hashmap, pe, ent, NULL))
+			continue;
+
+		if (!hashmap_contains_parent(&pl->recursive_hashmap,
+					     pe->pattern,
+					     &parent_pattern))
+			string_list_insert(&sl, pe->pattern);
+	}
 
 	string_list_sort(&sl);
 	string_list_remove_duplicates(&sl, 0);
@@ -230,8 +238,14 @@ static void write_cone_to_file(FILE *fp, struct pattern_list *pl)
 
 	string_list_clear(&sl, 0);
 
-	hashmap_for_each_entry(&pl->recursive_hashmap, &iter, pe, ent)
-		string_list_insert(&sl, pe->pattern);
+	hashmap_for_each_entry(&pl->recursive_hashmap, &iter, pe, ent) {
+		if (!hashmap_contains_parent(&pl->recursive_hashmap,
+					     pe->pattern,
+					     &parent_pattern))
+			string_list_insert(&sl, pe->pattern);
+	}
+
+	strbuf_release(&parent_pattern);
 
 	string_list_sort(&sl);
 	string_list_remove_duplicates(&sl, 0);

--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -7,6 +7,11 @@
 #include "run-command.h"
 #include "strbuf.h"
 #include "string-list.h"
+#include "cache.h"
+#include "cache-tree.h"
+#include "lockfile.h"
+#include "resolve-undo.h"
+#include "unpack-trees.h"
 
 static char const * const builtin_sparse_checkout_usage[] = {
 	N_("git sparse-checkout (init|list|set|disable) <options>"),
@@ -60,18 +65,54 @@ static int sparse_checkout_list(int argc, const char **argv)
 	return 0;
 }
 
-static int update_working_directory(void)
+static int update_working_directory(struct pattern_list *pl)
 {
-	struct argv_array argv = ARGV_ARRAY_INIT;
 	int result = 0;
-	argv_array_pushl(&argv, "read-tree", "-m", "-u", "HEAD", NULL);
+	struct unpack_trees_options o;
+	struct lock_file lock_file = LOCK_INIT;
+	struct object_id oid;
+	struct tree *tree;
+	struct tree_desc t;
+	struct repository *r = the_repository;
 
-	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
-		error(_("failed to update index with new sparse-checkout paths"));
-		result = 1;
-	}
+	if (repo_read_index_unmerged(r))
+		die(_("You need to resolve your current index first"));
 
-	argv_array_clear(&argv);
+	if (get_oid("HEAD", &oid))
+		return 0;
+
+	tree = parse_tree_indirect(&oid);
+	parse_tree(tree);
+	init_tree_desc(&t, tree->buffer, tree->size);
+
+	memset(&o, 0, sizeof(o));
+	o.verbose_update = isatty(2);
+	o.merge = 1;
+	o.update = 1;
+	o.fn = oneway_merge;
+	o.head_idx = -1;
+	o.src_index = r->index;
+	o.dst_index = r->index;
+	o.skip_sparse_checkout = 0;
+	o.pl = pl;
+	o.keep_pattern_list = !!pl;
+
+	resolve_undo_clear_index(r->index);
+	setup_work_tree();
+
+	cache_tree_free(&r->index->cache_tree);
+
+	repo_hold_locked_index(r, &lock_file, LOCK_DIE_ON_ERROR);
+
+	core_apply_sparse_checkout = 1;
+	result = unpack_trees(1, &t, &o);
+
+	if (!result) {
+		prime_cache_tree(r, r->index, tree);
+		write_locked_index(r->index, &lock_file, COMMIT_LOCK);
+	} else
+		rollback_lock_file(&lock_file);
+
 	return result;
 }
 
@@ -147,7 +188,11 @@ static int sparse_checkout_init(int argc, const char **argv)
 			     builtin_sparse_checkout_init_options,
 			     builtin_sparse_checkout_init_usage, 0);
 
-	mode = init_opts.cone_mode ? MODE_CONE_PATTERNS : MODE_ALL_PATTERNS;
+	if (init_opts.cone_mode) {
+		mode = MODE_CONE_PATTERNS;
+		core_sparse_checkout_cone = 1;
+	} else
+		mode = MODE_ALL_PATTERNS;
 
 	if (sc_set_config(mode))
 		return 1;
@@ -175,7 +220,8 @@ static int sparse_checkout_init(int argc, const char **argv)
 	}
 
 reset_dir:
-	return update_working_directory();
+	core_apply_sparse_checkout = 1;
+	return update_working_directory(NULL);
 }
 
 static void insert_recursive_pattern(struct pattern_list *pl, struct strbuf *path)
@@ -260,6 +306,15 @@ static int write_patterns_and_update(struct pattern_list *pl)
 {
 	char *sparse_filename;
 	FILE *fp;
+	int result;
+
+	result = update_working_directory(pl);
+
+	if (result) {
+		clear_pattern_list(pl);
+		update_working_directory(NULL);
+		return result;
+	}
 
 	sparse_filename = get_sparse_checkout_filename();
 	fp = fopen(sparse_filename, "w");
@@ -270,9 +325,11 @@ static int write_patterns_and_update(struct pattern_list *pl)
 		write_patterns_to_file(fp, pl);
 
 	fclose(fp);
-	free(sparse_filename);
 
-	return update_working_directory();
+	free(sparse_filename);
+	clear_pattern_list(pl);
+
+	return 0;
 }
 
 static void strbuf_to_cone_pattern(struct strbuf *line, struct pattern_list *pl)
@@ -324,6 +381,7 @@ static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
 		struct strbuf line = STRBUF_INIT;
 		hashmap_init(&pl.recursive_hashmap, pl_hashmap_cmp, NULL, 0);
 		hashmap_init(&pl.parent_hashmap, pl_hashmap_cmp, NULL, 0);
+		pl.use_cone_patterns = 1;
 
 		if (set_opts.use_stdin) {
 			while (!strbuf_getline(&line, stdin))
@@ -378,7 +436,8 @@ static int sparse_checkout_disable(int argc, const char **argv)
 	fprintf(fp, "/*\n");
 	fclose(fp);
 
-	if (update_working_directory())
+	core_apply_sparse_checkout = 1;
+	if (update_working_directory(NULL))
 		die(_("error while refreshing working directory"));
 
 	unlink(sparse_filename);

--- a/cache.h
+++ b/cache.h
@@ -918,11 +918,13 @@ extern char *git_replace_ref_base;
 
 extern int fsync_object_files;
 extern int core_preload_index;
-extern int core_apply_sparse_checkout;
 extern int precomposed_unicode;
 extern int protect_hfs;
 extern int protect_ntfs;
 extern const char *core_fsmonitor;
+
+int core_apply_sparse_checkout;
+int core_sparse_checkout_cone;
 
 /*
  * Include broken refs in all ref iterations, which will

--- a/cache.h
+++ b/cache.h
@@ -304,6 +304,7 @@ static inline unsigned int canon_mode(unsigned int mode)
 
 struct split_index;
 struct untracked_cache;
+struct progress;
 
 struct index_state {
 	struct cache_entry **cache;
@@ -326,6 +327,7 @@ struct index_state {
 	uint64_t fsmonitor_last_update;
 	struct ewah_bitmap *fsmonitor_dirty;
 	struct mem_pool *ce_mem_pool;
+	struct progress *progress;
 };
 
 /* Name hashing */

--- a/cache.h
+++ b/cache.h
@@ -928,7 +928,7 @@ extern int protect_ntfs;
 extern const char *core_fsmonitor;
 extern int core_use_gvfs_helper;
 extern const char *gvfs_cache_server_url;
-extern const char *gvfs_shared_cache_pathname;
+extern struct strbuf gvfs_shared_cache_pathname;
 
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;

--- a/cache.h
+++ b/cache.h
@@ -926,6 +926,9 @@ extern int precomposed_unicode;
 extern int protect_hfs;
 extern int protect_ntfs;
 extern const char *core_fsmonitor;
+extern int core_use_gvfs_helper;
+extern const char *gvfs_cache_server_url;
+extern const char *gvfs_shared_cache_pathname;
 
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;

--- a/command-list.txt
+++ b/command-list.txt
@@ -166,6 +166,7 @@ git-show-index                          plumbinginterrogators
 git-show-ref                            plumbinginterrogators
 git-sh-i18n                             purehelpers
 git-sh-setup                            purehelpers
+git-sparse-checkout                     mainporcelain           worktree
 git-stash                               mainporcelain
 git-stage                                                               complete
 git-status                              mainporcelain           info

--- a/config.c
+++ b/config.c
@@ -1364,6 +1364,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.sparsecheckoutcone")) {
+		core_sparse_checkout_cone = git_config_bool(var, value);
+		return 0;
+	}
+
 	if (!strcmp(var, "core.precomposeunicode")) {
 		precomposed_unicode = git_config_bool(var, value);
 		return 0;

--- a/config.c
+++ b/config.c
@@ -1508,19 +1508,17 @@ static int git_default_gvfs_config(const char *var, const char *value)
 	}
 
 	if (!strcmp(var, "gvfs.sharedcache") && value && *value) {
-		struct strbuf buf = STRBUF_INIT;
-		strbuf_addstr(&buf, value);
-		if (strbuf_normalize_path(&buf) < 0) {
+		strbuf_setlen(&gvfs_shared_cache_pathname, 0);
+		strbuf_addstr(&gvfs_shared_cache_pathname, value);
+		if (strbuf_normalize_path(&gvfs_shared_cache_pathname) < 0) {
 			/*
 			 * Pretend it wasn't set.  This will cause us to
 			 * fallback to ".git/objects" effectively.
 			 */
-			strbuf_release(&buf);
+			strbuf_release(&gvfs_shared_cache_pathname);
 			return 0;
 		}
-		strbuf_trim_trailing_dir_sep(&buf);
-
-		gvfs_shared_cache_pathname = strbuf_detach(&buf, NULL);
+		strbuf_trim_trailing_dir_sep(&gvfs_shared_cache_pathname);
 		return 0;
 	}
 

--- a/config.c
+++ b/config.c
@@ -21,6 +21,7 @@
 #include "color.h"
 #include "refs.h"
 #include "gvfs.h"
+#include "transport.h"
 
 struct config_source {
 	struct config_source *prev;
@@ -1365,6 +1366,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.usegvfshelper")) {
+		core_use_gvfs_helper = git_config_bool(var, value);
+		return 0;
+	}
+
 	if (!strcmp(var, "core.sparsecheckout")) {
 		/* virtual file system relies on the sparse checkout logic so force it on */
 		if (core_virtualfilesystem)
@@ -1490,6 +1496,37 @@ static int git_default_mailmap_config(const char *var, const char *value)
 	return 0;
 }
 
+static int git_default_gvfs_config(const char *var, const char *value)
+{
+	if (!strcmp(var, "gvfs.cache-server")) {
+		const char *v2 = NULL;
+
+		if (!git_config_string(&v2, var, value) && v2 && *v2)
+			gvfs_cache_server_url = transport_anonymize_url(v2);
+		free((char*)v2);
+		return 0;
+	}
+
+	if (!strcmp(var, "gvfs.sharedcache") && value && *value) {
+		struct strbuf buf = STRBUF_INIT;
+		strbuf_addstr(&buf, value);
+		if (strbuf_normalize_path(&buf) < 0) {
+			/*
+			 * Pretend it wasn't set.  This will cause us to
+			 * fallback to ".git/objects" effectively.
+			 */
+			strbuf_release(&buf);
+			return 0;
+		}
+		strbuf_trim_trailing_dir_sep(&buf);
+
+		gvfs_shared_cache_pathname = strbuf_detach(&buf, NULL);
+		return 0;
+	}
+
+	return 0;
+}
+
 int git_default_config(const char *var, const char *value, void *cb)
 {
 	if (starts_with(var, "core."))
@@ -1535,6 +1572,9 @@ int git_default_config(const char *var, const char *value, void *cb)
 		pack_compression_seen = 1;
 		return 0;
 	}
+
+	if (starts_with(var, "gvfs."))
+		return git_default_gvfs_config(var, value);
 
 	/* Add other config variables here and to Documentation/config.txt. */
 	return 0;

--- a/credential.c
+++ b/credential.c
@@ -224,6 +224,8 @@ static int run_credential_helper(struct credential *c,
 	else
 		helper.no_stdout = 1;
 
+	helper.trace2_child_class = "cred";
+
 	if (start_command(&helper) < 0)
 		return -1;
 

--- a/dir.c
+++ b/dir.c
@@ -611,6 +611,150 @@ void parse_path_pattern(const char **pattern,
 	*patternlen = len;
 }
 
+static int pl_hashmap_cmp(const void *unused_cmp_data,
+			  const struct hashmap_entry *a,
+			  const struct hashmap_entry *b,
+			  const void *key)
+{
+	const struct pattern_entry *ee1 =
+			container_of(a, struct pattern_entry, ent);
+	const struct pattern_entry *ee2 =
+			container_of(b, struct pattern_entry, ent);
+
+	size_t min_len = ee1->patternlen <= ee2->patternlen
+			 ? ee1->patternlen
+			 : ee2->patternlen;
+
+	return strncmp(ee1->pattern, ee2->pattern, min_len);
+}
+
+static void add_pattern_to_hashsets(struct pattern_list *pl, struct path_pattern *given)
+{
+	struct pattern_entry *translated;
+	char *truncated;
+	char *data = NULL;
+
+	if (!pl->use_cone_patterns)
+		return;
+
+	if (given->flags & PATTERN_FLAG_NEGATIVE &&
+	    given->flags & PATTERN_FLAG_MUSTBEDIR &&
+	    !strcmp(given->pattern, "/*")) {
+		pl->full_cone = 0;
+		return;
+	}
+
+	if (!given->flags && !strcmp(given->pattern, "/*")) {
+		pl->full_cone = 1;
+		return;
+	}
+
+	if (given->patternlen > 2 &&
+	    !strcmp(given->pattern + given->patternlen - 2, "/*")) {
+		if (!(given->flags & PATTERN_FLAG_NEGATIVE)) {
+			/* Not a cone pattern. */
+			pl->use_cone_patterns = 0;
+			warning(_("unrecognized pattern: '%s'"), given->pattern);
+			goto clear_hashmaps;
+		}
+
+		truncated = xstrdup(given->pattern);
+		truncated[given->patternlen - 2] = 0;
+
+		translated = xmalloc(sizeof(struct pattern_entry));
+		translated->pattern = truncated;
+		translated->patternlen = given->patternlen - 2;
+		hashmap_entry_init(&translated->ent,
+				   memhash(translated->pattern, translated->patternlen));
+
+		if (!hashmap_get_entry(&pl->recursive_hashmap,
+				       translated, ent, NULL)) {
+			/* We did not see the "parent" included */
+			warning(_("unrecognized negative pattern: '%s'"),
+				given->pattern);
+			free(truncated);
+			free(translated);
+			goto clear_hashmaps;
+		}
+
+		hashmap_add(&pl->parent_hashmap, &translated->ent);
+		hashmap_remove(&pl->recursive_hashmap, &translated->ent, &data);
+		free(data);
+		return;
+	}
+
+	if (given->flags & PATTERN_FLAG_NEGATIVE) {
+		warning(_("unrecognized negative pattern: '%s'"),
+			given->pattern);
+		goto clear_hashmaps;
+	}
+
+	translated = xmalloc(sizeof(struct pattern_entry));
+
+	translated->pattern = xstrdup(given->pattern);
+	translated->patternlen = given->patternlen;
+	hashmap_entry_init(&translated->ent,
+			   memhash(translated->pattern, translated->patternlen));
+
+	hashmap_add(&pl->recursive_hashmap, &translated->ent);
+
+	if (hashmap_get_entry(&pl->parent_hashmap, translated, ent, NULL)) {
+		/* we already included this at the parent level */
+		warning(_("your sparse-checkout file may have issues: pattern '%s' is repeated"),
+			given->pattern);
+		hashmap_remove(&pl->parent_hashmap, &translated->ent, &data);
+		free(data);
+		free(translated);
+	}
+
+	return;
+
+clear_hashmaps:
+	warning(_("disabling cone pattern matching"));
+	hashmap_free_entries(&pl->parent_hashmap, struct pattern_entry, ent);
+	hashmap_free_entries(&pl->recursive_hashmap, struct pattern_entry, ent);
+	pl->use_cone_patterns = 0;
+}
+
+static int hashmap_contains_path(struct hashmap *map,
+				 struct strbuf *pattern)
+{
+	struct pattern_entry p;
+
+	/* Check straight mapping */
+	p.pattern = pattern->buf;
+	p.patternlen = pattern->len;
+	hashmap_entry_init(&p.ent, memhash(p.pattern, p.patternlen));
+	return !!hashmap_get_entry(map, &p, ent, NULL);
+}
+
+int hashmap_contains_parent(struct hashmap *map,
+			    const char *path,
+			    struct strbuf *buffer)
+{
+	char *slash_pos;
+
+	strbuf_setlen(buffer, 0);
+
+	if (path[0] != '/')
+		strbuf_addch(buffer, '/');
+
+	strbuf_addstr(buffer, path);
+
+	slash_pos = strrchr(buffer->buf, '/');
+
+	while (slash_pos > buffer->buf) {
+		strbuf_setlen(buffer, slash_pos - buffer->buf);
+
+		if (hashmap_contains_path(map, buffer))
+			return 1;
+
+		slash_pos = strrchr(buffer->buf, '/');
+	}
+
+	return 0;
+}
+
 void add_pattern(const char *string, const char *base,
 		 int baselen, struct pattern_list *pl, int srcpos)
 {
@@ -635,6 +779,8 @@ void add_pattern(const char *string, const char *base,
 	ALLOC_GROW(pl->patterns, pl->nr + 1, pl->alloc);
 	pl->patterns[pl->nr++] = pattern;
 	pattern->pl = pl;
+
+	add_pattern_to_hashsets(pl, pattern);
 }
 
 static int read_skip_worktree_file_from_index(const struct index_state *istate,
@@ -859,6 +1005,9 @@ static int add_patterns_from_buffer(char *buf, size_t size,
 {
 	int i, lineno = 1;
 	char *entry;
+
+	hashmap_init(&pl->recursive_hashmap, pl_hashmap_cmp, NULL, 0);
+	hashmap_init(&pl->parent_hashmap, pl_hashmap_cmp, NULL, 0);
 
 	pl->filebuf = buf;
 
@@ -1096,16 +1245,58 @@ enum pattern_match_result path_matches_pattern_list(
 				struct index_state *istate)
 {
 	struct path_pattern *pattern;
-	pattern = last_matching_pattern_from_list(pathname, pathlen, basename,
-						  dtype, pl, istate);
-	if (pattern) {
-		if (pattern->flags & PATTERN_FLAG_NEGATIVE)
-			return NOT_MATCHED;
-		else
-			return MATCHED;
+	struct strbuf parent_pathname = STRBUF_INIT;
+	int result = NOT_MATCHED;
+	const char *slash_pos;
+
+	if (!pl->use_cone_patterns) {
+		pattern = last_matching_pattern_from_list(pathname, pathlen, basename,
+							dtype, pl, istate);
+		if (pattern) {
+			if (pattern->flags & PATTERN_FLAG_NEGATIVE)
+				return NOT_MATCHED;
+			else
+				return MATCHED;
+		}
+
+		return UNDECIDED;
 	}
 
-	return UNDECIDED;
+	if (pl->full_cone)
+		return MATCHED;
+
+	strbuf_addch(&parent_pathname, '/');
+	strbuf_add(&parent_pathname, pathname, pathlen);
+
+	if (hashmap_contains_path(&pl->recursive_hashmap,
+				  &parent_pathname)) {
+		result = MATCHED;
+		goto done;
+	}
+
+	slash_pos = strrchr(parent_pathname.buf, '/');
+
+	if (slash_pos == parent_pathname.buf) {
+		/* include every file in root */
+		result = MATCHED;
+		goto done;
+	}
+
+	strbuf_setlen(&parent_pathname, slash_pos - parent_pathname.buf);
+
+	if (hashmap_contains_path(&pl->parent_hashmap, &parent_pathname)) {
+		result = MATCHED;
+		goto done;
+	}
+
+	if (hashmap_contains_parent(&pl->recursive_hashmap,
+				    pathname,
+				    &parent_pathname))
+		result = MATCHED;
+
+done:
+	strbuf_release(&parent_pathname);
+	return result;
 }
 
 static struct path_pattern *last_matching_pattern_from_lists(

--- a/dir.c
+++ b/dir.c
@@ -611,10 +611,10 @@ void parse_path_pattern(const char **pattern,
 	*patternlen = len;
 }
 
-static int pl_hashmap_cmp(const void *unused_cmp_data,
-			  const struct hashmap_entry *a,
-			  const struct hashmap_entry *b,
-			  const void *key)
+int pl_hashmap_cmp(const void *unused_cmp_data,
+		   const struct hashmap_entry *a,
+		   const struct hashmap_entry *b,
+		   const void *key)
 {
 	const struct pattern_entry *ee1 =
 			container_of(a, struct pattern_entry, ent);

--- a/dir.c
+++ b/dir.c
@@ -1270,7 +1270,7 @@ enum pattern_match_result path_matches_pattern_list(
 
 	if (hashmap_contains_path(&pl->recursive_hashmap,
 				  &parent_pathname)) {
-		result = MATCHED;
+		result = MATCHED_RECURSIVE;
 		goto done;
 	}
 
@@ -1292,7 +1292,7 @@ enum pattern_match_result path_matches_pattern_list(
 	if (hashmap_contains_parent(&pl->recursive_hashmap,
 				    pathname,
 				    &parent_pathname))
-		result = MATCHED;
+		result = MATCHED_RECURSIVE;
 
 done:
 	strbuf_release(&parent_pathname);

--- a/dir.h
+++ b/dir.h
@@ -299,6 +299,10 @@ int is_excluded(struct dir_struct *dir,
 		struct index_state *istate,
 		const char *name, int *dtype);
 
+int pl_hashmap_cmp(const void *unused_cmp_data,
+		   const struct hashmap_entry *a,
+		   const struct hashmap_entry *b,
+		   const void *key);
 int hashmap_contains_parent(struct hashmap *map,
 			    const char *path,
 			    struct strbuf *buffer);

--- a/dir.h
+++ b/dir.h
@@ -264,6 +264,7 @@ enum pattern_match_result {
 	UNDECIDED = -1,
 	NOT_MATCHED = 0,
 	MATCHED = 1,
+	MATCHED_RECURSIVE = 2,
 };
 
 /*

--- a/dir.h
+++ b/dir.h
@@ -4,6 +4,7 @@
 /* See Documentation/technical/api-directory-listing.txt */
 
 #include "cache.h"
+#include "hashmap.h"
 #include "strbuf.h"
 
 struct dir_entry {
@@ -37,6 +38,13 @@ struct path_pattern {
 	int srcpos;
 };
 
+/* used for hashmaps for cone patterns */
+struct pattern_entry {
+	struct hashmap_entry ent;
+	char *pattern;
+	size_t patternlen;
+};
+
 /*
  * Each excludes file will be parsed into a fresh exclude_list which
  * is appended to the relevant exclude_list_group (either EXC_DIRS or
@@ -55,6 +63,26 @@ struct pattern_list {
 	const char *src;
 
 	struct path_pattern **patterns;
+
+	/*
+	 * While scanning the excludes, we attempt to match the patterns
+	 * with a more restricted set that allows us to use hashsets for
+	 * matching logic, which is faster than the linear lookup in the
+	 * excludes array above. If non-zero, that check succeeded.
+	 */
+	unsigned use_cone_patterns;
+	unsigned full_cone;
+
+	/*
+	 * Stores paths where everything starting with those paths
+	 * is included.
+	 */
+	struct hashmap recursive_hashmap;
+
+	/*
+	 * Used to check single-level parents of blobs.
+	 */
+	struct hashmap parent_hashmap;
 };
 
 /*
@@ -271,6 +299,9 @@ int is_excluded(struct dir_struct *dir,
 		struct index_state *istate,
 		const char *name, int *dtype);
 
+int hashmap_contains_parent(struct hashmap *map,
+			    const char *path,
+			    struct strbuf *buffer);
 struct pattern_list *add_pattern_list(struct dir_struct *dir,
 				      int group_type, const char *src);
 int add_patterns_from_file_to_list(const char *fname, const char *base, int baselen,

--- a/environment.c
+++ b/environment.c
@@ -67,6 +67,7 @@ enum object_creation_mode object_creation_mode = OBJECT_CREATION_MODE;
 char *notes_ref_name;
 int grafts_replace_parents = 1;
 int core_apply_sparse_checkout;
+int core_sparse_checkout_cone;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/environment.c
+++ b/environment.c
@@ -88,7 +88,7 @@ int protect_ntfs = PROTECT_NTFS_DEFAULT;
 const char *core_fsmonitor;
 int core_use_gvfs_helper;
 const char *gvfs_cache_server_url;
-const char *gvfs_shared_cache_pathname;
+struct strbuf gvfs_shared_cache_pathname = STRBUF_INIT;
 
 /*
  * The character that begins a commented line in user-editable file

--- a/environment.c
+++ b/environment.c
@@ -86,6 +86,9 @@ int protect_hfs = PROTECT_HFS_DEFAULT;
 #endif
 int protect_ntfs = PROTECT_NTFS_DEFAULT;
 const char *core_fsmonitor;
+int core_use_gvfs_helper;
+const char *gvfs_cache_server_url;
+const char *gvfs_shared_cache_pathname;
 
 /*
  * The character that begins a commented line in user-editable file

--- a/git.c
+++ b/git.c
@@ -572,6 +572,7 @@ static struct cmd_struct commands[] = {
 	{ "show-branch", cmd_show_branch, RUN_SETUP },
 	{ "show-index", cmd_show_index },
 	{ "show-ref", cmd_show_ref, RUN_SETUP },
+	{ "sparse-checkout", cmd_sparse_checkout, RUN_SETUP | NEED_WORK_TREE },
 	{ "stage", cmd_add, RUN_SETUP | NEED_WORK_TREE },
 	/*
 	 * NEEDSWORK: Until the builtin stash is thoroughly robust and no

--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -113,6 +113,9 @@ static void gh_client__update_loose_cache(const char *line)
 	if (!skip_prefix(line, "loose ", &v1_oid))
 		BUG("update_loose_cache: invalid line '%s'", line);
 
+	if (get_oid_hex(v1_oid, &oid))
+		BUG("update_loose_cache: invalid line '%s'", line);
+
 	odb_loose_cache_add_new_oid(gh_client__chosen_odb, &oid);
 }
 

--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -13,7 +13,6 @@
 
 static struct oidset gh_client__oidset_queued = OIDSET_INIT;
 static unsigned long gh_client__oidset_count;
-static int gh_client__includes_immediate;
 
 struct gh_server__process {
 	struct subprocess_entry subprocess; /* must be first */
@@ -24,13 +23,20 @@ static int gh_server__subprocess_map_initialized;
 static struct hashmap gh_server__subprocess_map;
 static struct object_directory *gh_client__chosen_odb;
 
-#define CAP_GET      (1u<<1)
+/*
+ * The "objects" capability has 2 verbs: "get" and "post".
+ */
+#define CAP_OBJECTS      (1u<<1)
+#define CAP_OBJECTS_NAME "objects"
+
+#define CAP_OBJECTS__VERB_GET1_NAME "get"
+#define CAP_OBJECTS__VERB_POST_NAME "post"
 
 static int gh_client__start_fn(struct subprocess_entry *subprocess)
 {
 	static int versions[] = {1, 0};
 	static struct subprocess_capability capabilities[] = {
-		{ "get", CAP_GET },
+		{ CAP_OBJECTS_NAME, CAP_OBJECTS },
 		{ NULL, 0 }
 	};
 
@@ -42,14 +48,16 @@ static int gh_client__start_fn(struct subprocess_entry *subprocess)
 }
 
 /*
- * Send:
+ * Send the queued OIDs in the OIDSET to gvfs-helper for it to
+ * fetch from the cache-server or main Git server using "/gvfs/objects"
+ * POST semantics.
  *
- *     get LF
+ *     objects.post LF
  *     (<hex-oid> LF)*
  *     <flush>
  *
  */
-static int gh_client__get__send_command(struct child_process *process)
+static int gh_client__send__objects_post(struct child_process *process)
 {
 	struct oidset_iter iter;
 	struct object_id *oid;
@@ -60,7 +68,9 @@ static int gh_client__get__send_command(struct child_process *process)
 	 * so that we don't have to.
 	 */
 
-	err = packet_write_fmt_gently(process->in, "get\n");
+	err = packet_write_fmt_gently(
+		process->in,
+		(CAP_OBJECTS_NAME "." CAP_OBJECTS__VERB_POST_NAME "\n"));
 	if (err)
 		return err;
 
@@ -71,6 +81,46 @@ static int gh_client__get__send_command(struct child_process *process)
 		if (err)
 			return err;
 	}
+
+	err = packet_flush_gently(process->in);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+/*
+ * Send the given OID to gvfs-helper for it to fetch from the
+ * cache-server or main Git server using "/gvfs/objects" GET
+ * semantics.
+ *
+ * This ignores any queued OIDs.
+ *
+ *     objects.get LF
+ *     <hex-oid> LF
+ *     <flush>
+ *
+ */
+static int gh_client__send__objects_get(struct child_process *process,
+					const struct object_id *oid)
+{
+	int err;
+
+	/*
+	 * We assume that all of the packet_ routines call error()
+	 * so that we don't have to.
+	 */
+
+	err = packet_write_fmt_gently(
+		process->in,
+		(CAP_OBJECTS_NAME "." CAP_OBJECTS__VERB_GET1_NAME "\n"));
+	if (err)
+		return err;
+
+	err = packet_write_fmt_gently(process->in, "%s\n",
+				      oid_to_hex(oid));
+	if (err)
+		return err;
 
 	err = packet_flush_gently(process->in);
 	if (err)
@@ -148,7 +198,7 @@ static void gh_client__update_packed_git(const char *line)
 }
 
 /*
- * We expect:
+ * Both CAP_OBJECTS verbs return the same format response:
  *
  *    <odb> 
  *    <data>*
@@ -179,7 +229,7 @@ static void gh_client__update_packed_git(const char *line)
  * grouped with a queued request for a blob.  The tree-walk *might* be
  * able to continue and let the 404 blob be handled later.
  */
-static int gh_client__get__receive_response(
+static int gh_client__objects__receive_response(
 	struct child_process *process,
 	enum gh_client__created *p_ghc,
 	int *p_nr_loose, int *p_nr_packfile)
@@ -259,17 +309,12 @@ static void gh_client__choose_odb(void)
 	}
 }
 
-static int gh_client__get(enum gh_client__created *p_ghc)
+static struct gh_server__process *gh_client__find_long_running_process(
+	unsigned int cap_needed)
 {
 	struct gh_server__process *entry;
-	struct child_process *process;
 	struct argv_array argv = ARGV_ARRAY_INIT;
 	struct strbuf quoted = STRBUF_INIT;
-	int nr_loose = 0;
-	int nr_packfile = 0;
-	int err = 0;
-
-	trace2_region_enter("gh-client", "get", the_repository);
 
 	gh_client__choose_odb();
 
@@ -285,6 +330,11 @@ static int gh_client__get(enum gh_client__created *p_ghc)
 
 	sq_quote_argv_pretty(&quoted, argv.argv);
 
+	/*
+	 * Find an existing long-running process with the above command
+	 * line -or- create a new long-running process for this and
+	 * subsequent 'get' requests.
+	 */
 	if (!gh_server__subprocess_map_initialized) {
 		gh_server__subprocess_map_initialized = 1;
 		hashmap_init(&gh_server__subprocess_map,
@@ -298,70 +348,24 @@ static int gh_client__get(enum gh_client__created *p_ghc)
 		entry = xmalloc(sizeof(*entry));
 		entry->supported_capabilities = 0;
 
-		err = subprocess_start_argv(
-			&gh_server__subprocess_map, &entry->subprocess, 1,
-			&argv, gh_client__start_fn);
-		if (err) {
-			free(entry);
-			goto leave_region;
-		}
+		if (subprocess_start_argv(&gh_server__subprocess_map,
+					  &entry->subprocess, 1,
+					  &argv, gh_client__start_fn))
+			FREE_AND_NULL(entry);
 	}
 
-	process = &entry->subprocess.process;
-
-	if (!(CAP_GET & entry->supported_capabilities)) {
-		error("gvfs-helper: does not support GET");
+	if (entry &&
+	    (entry->supported_capabilities & cap_needed) != cap_needed) {
+		error("gvfs-helper: does not support needed capabilities");
 		subprocess_stop(&gh_server__subprocess_map,
 				(struct subprocess_entry *)entry);
-		free(entry);
-		err = -1;
-		goto leave_region;
+		FREE_AND_NULL(entry);
 	}
 
-	sigchain_push(SIGPIPE, SIG_IGN);
-
-	err = gh_client__get__send_command(process);
-	if (!err)
-		err = gh_client__get__receive_response(process, p_ghc,
-						 &nr_loose, &nr_packfile);
-
-	sigchain_pop(SIGPIPE);
-
-	if (err) {
-		subprocess_stop(&gh_server__subprocess_map,
-				(struct subprocess_entry *)entry);
-		free(entry);
-	}
-
-leave_region:
 	argv_array_clear(&argv);
 	strbuf_release(&quoted);
 
-	trace2_data_intmax("gh-client", the_repository,
-			   "get/immediate", gh_client__includes_immediate);
-
-	trace2_data_intmax("gh-client", the_repository,
-			   "get/nr_objects", gh_client__oidset_count);
-
-	if (nr_loose)
-		trace2_data_intmax("gh-client", the_repository,
-				   "get/nr_loose", nr_loose);
-
-	if (nr_packfile)
-		trace2_data_intmax("gh-client", the_repository,
-				   "get/nr_packfile", nr_packfile);
-
-	if (err)
-		trace2_data_intmax("gh-client", the_repository,
-				   "get/error", err);
-
-	trace2_region_leave("gh-client", "get", the_repository);
-
-	oidset_clear(&gh_client__oidset_queued);
-	gh_client__oidset_count = 0;
-	gh_client__includes_immediate = 0;
-
-	return err;
+	return entry;
 }
 
 void gh_client__queue_oid(const struct object_id *oid)
@@ -388,28 +392,97 @@ void gh_client__queue_oid_array(const struct object_id *oids, int oid_nr)
 		gh_client__queue_oid(&oids[k]);
 }
 
+/*
+ * Bulk fetch all of the queued OIDs in the OIDSET.
+ */
 int gh_client__drain_queue(enum gh_client__created *p_ghc)
 {
+	struct gh_server__process *entry;
+	struct child_process *process;
+	int nr_loose = 0;
+	int nr_packfile = 0;
+	int err = 0;
+
 	*p_ghc = GHC__CREATED__NOTHING;
 
 	if (!gh_client__oidset_count)
 		return 0;
 
-	return gh_client__get(p_ghc);
+	entry = gh_client__find_long_running_process(CAP_OBJECTS);
+	if (!entry)
+		return -1;
+
+	trace2_region_enter("gh-client", "objects/post", the_repository);
+
+	process = &entry->subprocess.process;
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+
+	err = gh_client__send__objects_post(process);
+	if (!err)
+		err = gh_client__objects__receive_response(
+			process, p_ghc, &nr_loose, &nr_packfile);
+
+	sigchain_pop(SIGPIPE);
+
+	if (err) {
+		subprocess_stop(&gh_server__subprocess_map,
+				(struct subprocess_entry *)entry);
+		FREE_AND_NULL(entry);
+	}
+
+	trace2_data_intmax("gh-client", the_repository,
+			   "objects/post/nr_objects", gh_client__oidset_count);
+	trace2_region_leave("gh-client", "objects/post", the_repository);
+
+	oidset_clear(&gh_client__oidset_queued);
+	gh_client__oidset_count = 0;
+
+	return err;
 }
 
+/*
+ * Get exactly 1 object immediately.
+ * Ignore any queued objects.
+ */
 int gh_client__get_immediate(const struct object_id *oid,
 			     enum gh_client__created *p_ghc)
 {
-	gh_client__includes_immediate = 1;
+	struct gh_server__process *entry;
+	struct child_process *process;
+	int nr_loose = 0;
+	int nr_packfile = 0;
+	int err = 0;
 
 	// TODO consider removing this trace2.  it is useful for interactive
 	// TODO debugging, but may generate way too much noise for a data
 	// TODO event.
 	trace2_printf("gh_client__get_immediate: %s", oid_to_hex(oid));
 
-	if (!oidset_insert(&gh_client__oidset_queued, oid))
-		gh_client__oidset_count++;
+	entry = gh_client__find_long_running_process(CAP_OBJECTS);
+	if (!entry)
+		return -1;
 
-	return gh_client__drain_queue(p_ghc);
+	trace2_region_enter("gh-client", "objects/get", the_repository);
+
+	process = &entry->subprocess.process;
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+
+	err = gh_client__send__objects_get(process, oid);
+	if (!err)
+		err = gh_client__objects__receive_response(
+			process, p_ghc, &nr_loose, &nr_packfile);
+
+	sigchain_pop(SIGPIPE);
+
+	if (err) {
+		subprocess_stop(&gh_server__subprocess_map,
+				(struct subprocess_entry *)entry);
+		FREE_AND_NULL(entry);
+	}
+
+	trace2_region_leave("gh-client", "objects/get", the_repository);
+
+	return err;
 }

--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -1,0 +1,403 @@
+#include "cache.h"
+#include "argv-array.h"
+#include "trace2.h"
+#include "oidset.h"
+#include "object.h"
+#include "object-store.h"
+#include "gvfs-helper-client.h"
+#include "sub-process.h"
+#include "sigchain.h"
+#include "pkt-line.h"
+#include "quote.h"
+#include "packfile.h"
+
+static struct oidset ghc__oidset_queued = OIDSET_INIT;
+static unsigned long ghc__oidset_count;
+static int ghc__includes_immediate;
+
+struct ghs__process {
+	struct subprocess_entry subprocess; /* must be first */
+	unsigned int supported_capabilities;
+};
+
+static int ghs__subprocess_map_initialized;
+static struct hashmap ghs__subprocess_map;
+static struct object_directory *ghs__chosen_odb;
+
+#define CAP_GET      (1u<<1)
+
+static int ghc__start_fn(struct subprocess_entry *subprocess)
+{
+	static int versions[] = {1, 0};
+	static struct subprocess_capability capabilities[] = {
+		{ "get", CAP_GET },
+		{ NULL, 0 }
+	};
+
+	struct ghs__process *entry = (struct ghs__process *)subprocess;
+
+	return subprocess_handshake(subprocess, "gvfs-helper", versions,
+				    NULL, capabilities,
+				    &entry->supported_capabilities);
+}
+
+/*
+ * Send:
+ *
+ *     get LF
+ *     (<hex-oid> LF)*
+ *     <flush>
+ *
+ */
+static int ghc__get__send_command(struct child_process *process)
+{
+	struct oidset_iter iter;
+	struct object_id *oid;
+	int err;
+
+	/*
+	 * We assume that all of the packet_ routines call error()
+	 * so that we don't have to.
+	 */
+
+	err = packet_write_fmt_gently(process->in, "get\n");
+	if (err)
+		return err;
+
+	oidset_iter_init(&ghc__oidset_queued, &iter);
+	while ((oid = oidset_iter_next(&iter))) {
+		err = packet_write_fmt_gently(process->in, "%s\n",
+					      oid_to_hex(oid));
+		if (err)
+			return err;
+	}
+
+	err = packet_flush_gently(process->in);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+/*
+ * Verify that the pathname found in the "odb" response line matches
+ * what we requested.
+ *
+ * Since we ALWAYS send a "--shared-cache=<path>" arg to "gvfs-helper",
+ * we should be able to verify that the value is what we requested.
+ * In particular, I don't see a need to try to search for the response
+ * value in from our list of alternates.
+ */
+static void ghc__verify_odb_line(const char *line)
+{
+	const char *v1_odb_path;
+
+	if (!skip_prefix(line, "odb ", &v1_odb_path))
+		BUG("verify_odb_line: invalid line '%s'", line);
+
+	if (!ghs__chosen_odb || strcmp(v1_odb_path, ghs__chosen_odb->path))
+		BUG("verify_odb_line: unexpeced odb path '%s' vs '%s'",
+		    v1_odb_path, ghs__chosen_odb->path);
+}
+
+/*
+ * Update the loose object cache to include the newly created
+ * object.
+ */
+static void ghc__update_loose_cache(const char *line)
+{
+	const char *v1_oid;
+	struct object_id oid;
+
+	if (!skip_prefix(line, "loose ", &v1_oid))
+		BUG("update_loose_cache: invalid line '%s'", line);
+
+	odb_loose_cache_add_new_oid(ghs__chosen_odb, &oid);
+}
+
+/*
+ * Update the packed-git list to include the newly created packfile.
+ */
+static void ghc__update_packed_git(const char *line)
+{
+	struct strbuf path = STRBUF_INIT;
+	const char *v1_filename;
+	struct packed_git *p;
+	int is_local;
+
+	if (!skip_prefix(line, "packfile ", &v1_filename))
+		BUG("update_packed_git: invalid line '%s'", line);
+
+	/*
+	 * ODB[0] is the local .git/objects.  All others are alternates.
+	 */
+	is_local = (ghs__chosen_odb == the_repository->objects->odb);
+
+	strbuf_addf(&path, "%s/pack/%s", ghs__chosen_odb->path, v1_filename);
+	strbuf_strip_suffix(&path, ".pack");
+	strbuf_addstr(&path, ".idx");
+
+	p = add_packed_git(path.buf, path.len, is_local);
+	if (p)
+		install_packed_git_and_mru(the_repository, p);
+}
+
+/*
+ * We expect:
+ *
+ *    <odb> 
+ *    <data>*
+ *    <status>
+ *    <flush>
+ *
+ * Where:
+ *
+ * <odb>      ::= odb SP <directory> LF
+ *
+ * <data>     ::= <packfile> / <loose>
+ *
+ * <packfile> ::= packfile SP <filename> LF
+ *
+ * <loose>    ::= loose SP <hex-oid> LF
+ *
+ * <status>   ::=   ok LF
+ *                / partial LF
+ *                / error SP <message> LF
+ *
+ * Note that `gvfs-helper` controls how/if it chunks the request when
+ * it talks to the cache-server and/or main Git server.  So it is
+ * possible for us to receive many packfiles and/or loose objects *AND
+ * THEN* get a hard network error or a 404 on an individual object.
+ *
+ * If we get a partial result, we can let the caller try to continue
+ * -- for example, maybe an immediate request for a tree object was
+ * grouped with a queued request for a blob.  The tree-walk *might* be
+ * able to continue and let the 404 blob be handled later.
+ */
+static int ghc__get__receive_response(struct child_process *process,
+				      enum ghc__created *p_ghc,
+				      int *p_nr_loose, int *p_nr_packfile)
+{
+	enum ghc__created ghc = GHC__CREATED__NOTHING;
+	const char *v1;
+	char *line;
+	int len;
+	int err = 0;
+
+	while (1) {
+		/*
+		 * Warning: packet_read_line_gently() calls die()
+		 * despite the _gently moniker.
+		 */
+		len = packet_read_line_gently(process->out, NULL, &line);
+		if ((len < 0) || !line)
+			break;
+
+		if (starts_with(line, "odb")) {
+			ghc__verify_odb_line(line);
+		}
+
+		else if (starts_with(line, "packfile")) {
+			ghc__update_packed_git(line);
+			ghc |= GHC__CREATED__PACKFILE;
+			*p_nr_packfile += 1;
+		}
+
+		else if (starts_with(line, "loose")) {
+			ghc__update_loose_cache(line);
+			ghc |= GHC__CREATED__LOOSE;
+			*p_nr_loose += 1;
+		}
+
+		else if (starts_with(line, "ok"))
+			;
+		else if (starts_with(line, "partial"))
+			;
+		else if (skip_prefix(line, "error ", &v1)) {
+			error("gvfs-helper error: '%s'", v1);
+			err = -1;
+		}
+	}
+
+	*p_ghc = ghc;
+
+	return err;
+}
+
+static void ghc__choose_odb(void)
+{
+	struct object_directory *odb;
+
+	if (ghs__chosen_odb)
+		return;
+
+	prepare_alt_odb(the_repository);
+
+	if (gvfs_shared_cache_pathname && *gvfs_shared_cache_pathname) {
+		for (odb = the_repository->objects->odb; odb; odb = odb->next) {
+			if (!strcmp(odb->path, gvfs_shared_cache_pathname)) {
+				ghs__chosen_odb = odb;
+				return;
+			}
+		}
+	}
+
+	/*
+	 * Use .git/objects if "gvfs.sharedcache" not set or set to an
+	 * unknown pathname.
+	 */
+	ghs__chosen_odb = the_repository->objects->odb;
+}
+
+static int ghc__get(enum ghc__created *p_ghc)
+{
+	struct ghs__process *entry;
+	struct child_process *process;
+	struct argv_array argv = ARGV_ARRAY_INIT;
+	struct strbuf quoted = STRBUF_INIT;
+	int nr_loose = 0;
+	int nr_packfile = 0;
+	int err = 0;
+
+	trace2_region_enter("gh-client", "get", the_repository);
+
+	ghc__choose_odb();
+
+	/*
+	 * TODO decide what defaults we want.
+	 */
+	argv_array_push(&argv, "gvfs-helper");
+	argv_array_push(&argv, "--fallback");
+	argv_array_push(&argv, "--cache-server=trust");
+	argv_array_pushf(&argv, "--shared-cache=%s", ghs__chosen_odb->path);
+	argv_array_push(&argv, "server");
+
+	sq_quote_argv_pretty(&quoted, argv.argv);
+
+	if (!ghs__subprocess_map_initialized) {
+		ghs__subprocess_map_initialized = 1;
+		hashmap_init(&ghs__subprocess_map,
+			     (hashmap_cmp_fn)cmd2process_cmp, NULL, 0);
+		entry = NULL;
+	} else
+		entry = (struct ghs__process *)subprocess_find_entry(
+			&ghs__subprocess_map, quoted.buf);
+
+	if (!entry) {
+		entry = xmalloc(sizeof(*entry));
+		entry->supported_capabilities = 0;
+
+		err = subprocess_start_argv(
+			&ghs__subprocess_map, &entry->subprocess, 1,
+			&argv, ghc__start_fn);
+		if (err) {
+			free(entry);
+			goto leave_region;
+		}
+	}
+
+	process = &entry->subprocess.process;
+
+	if (!(CAP_GET & entry->supported_capabilities)) {
+		error("gvfs-helper: does not support GET");
+		subprocess_stop(&ghs__subprocess_map,
+				(struct subprocess_entry *)entry);
+		free(entry);
+		err = -1;
+		goto leave_region;
+	}
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+
+	err = ghc__get__send_command(process);
+	if (!err)
+		err = ghc__get__receive_response(process, p_ghc,
+						 &nr_loose, &nr_packfile);
+
+	sigchain_pop(SIGPIPE);
+
+	if (err) {
+		subprocess_stop(&ghs__subprocess_map,
+				(struct subprocess_entry *)entry);
+		free(entry);
+	}
+
+leave_region:
+	argv_array_clear(&argv);
+	strbuf_release(&quoted);
+
+	trace2_data_intmax("gh-client", the_repository,
+			   "get/immediate", ghc__includes_immediate);
+
+	trace2_data_intmax("gh-client", the_repository,
+			   "get/nr_objects", ghc__oidset_count);
+
+	if (nr_loose)
+		trace2_data_intmax("gh-client", the_repository,
+				   "get/nr_loose", nr_loose);
+
+	if (nr_packfile)
+		trace2_data_intmax("gh-client", the_repository,
+				   "get/nr_packfile", nr_packfile);
+
+	if (err)
+		trace2_data_intmax("gh-client", the_repository,
+				   "get/error", err);
+
+	trace2_region_leave("gh-client", "get", the_repository);
+
+	oidset_clear(&ghc__oidset_queued);
+	ghc__oidset_count = 0;
+	ghc__includes_immediate = 0;
+
+	return err;
+}
+
+void ghc__queue_oid(const struct object_id *oid)
+{
+	// TODO consider removing this trace2.  it is useful for interactive
+	// TODO debugging, but may generate way too much noise for a data
+	// TODO event.
+	trace2_printf("ghc__queue_oid: %s", oid_to_hex(oid));
+
+	if (!oidset_insert(&ghc__oidset_queued, oid))
+		ghc__oidset_count++;
+}
+
+/*
+ * This routine should actually take a "const struct oid_array *"
+ * rather than the component parts, but fetch_objects() uses
+ * this model (because of the call in sha1-file.c).
+ */
+void ghc__queue_oid_array(const struct object_id *oids, int oid_nr)
+{
+	int k;
+
+	for (k = 0; k < oid_nr; k++)
+		ghc__queue_oid(&oids[k]);
+}
+
+int ghc__drain_queue(enum ghc__created *p_ghc)
+{
+	*p_ghc = GHC__CREATED__NOTHING;
+
+	if (!ghc__oidset_count)
+		return 0;
+
+	return ghc__get(p_ghc);
+}
+
+int ghc__get_immediate(const struct object_id *oid, enum ghc__created *p_ghc)
+{
+	ghc__includes_immediate = 1;
+
+	// TODO consider removing this trace2.  it is useful for interactive
+	// TODO debugging, but may generate way too much noise for a data
+	// TODO event.
+	trace2_printf("ghc__get_immediate: %s", oid_to_hex(oid));
+
+	if (!oidset_insert(&ghc__oidset_queued, oid))
+		ghc__oidset_count++;
+
+	return ghc__drain_queue(p_ghc);
+}

--- a/gvfs-helper-client.h
+++ b/gvfs-helper-client.h
@@ -3,6 +3,7 @@
 
 struct repository;
 struct commit;
+struct object_id;
 
 enum gh_client__created {
 	/*

--- a/gvfs-helper-client.h
+++ b/gvfs-helper-client.h
@@ -1,0 +1,61 @@
+#ifndef GVFS_HELPER_CLIENT_H
+#define GVFS_HELPER_CLIENT_H
+
+struct repository;
+struct commit;
+
+enum ghc__created {
+	/*
+	 * The _get_ operation did not create anything.  If doesn't
+	 * matter if `gvfs-helper` had errors or not -- just that
+	 * nothing was created.
+	 */
+	GHC__CREATED__NOTHING  = 0,
+
+	/*
+	 * The _get_operation created one or more packfiles.
+	 */
+	GHC__CREATED__PACKFILE = 1<<1,
+
+	/*
+	 * The _get_ operation created one or more loose objects.
+	 * (Not necessarily the for the individual OID you requested.)
+	 */
+	GHC__CREATED__LOOSE    = 1<<2,
+
+	/*
+	 * The _get_ operation created one or more packfilea *and*
+	 * one or more loose objects.
+	 */
+	GHC__CREATED__PACKFILE_AND_LOOSE = (GHC__CREATED__PACKFILE |
+					    GHC__CREATED__LOOSE),
+};
+
+/*
+ * Ask `gvfs-helper server` to immediately fetch an object.
+ * Wait for the response.
+ *
+ * This may also fetch any queued (non-immediate) objects and
+ * so may create one or more loose objects and/or packfiles.
+ * It is undefined whether the requested OID will be loose or
+ * in a packfile.
+ */
+int ghc__get_immediate(const struct object_id *oid, enum ghc__created *p_ghc);
+
+/*
+ * Queue this OID for a future fetch using `gvfs-helper service`.
+ * It does not wait.
+ *
+ * The GHC layer is free to process this queue in any way it wants,
+ * including individual fetches, bulk fetches, and batching.  And
+ * it may add queued objects to immediate requests.
+ *
+ * Callers should not rely on the queued object being on disk until
+ * the queue has been drained.
+ */
+void ghc__queue_oid(const struct object_id *oid);
+void ghc__queue_oid_array(const struct object_id *oids, int oid_nr);
+
+int ghc__drain_queue(enum ghc__created *p_ghc);
+
+#endif /* GVFS_HELPER_CLIENT_H */

--- a/gvfs-helper-client.h
+++ b/gvfs-helper-client.h
@@ -32,13 +32,14 @@ enum gh_client__created {
 };
 
 /*
- * Ask `gvfs-helper server` to immediately fetch an object.
- * Wait for the response.
+ * Ask `gvfs-helper server` to immediately fetch a single object
+ * using "/gvfs/objects" GET semantics.
  *
- * This may also fetch any queued (non-immediate) objects and
- * so may create one or more loose objects and/or packfiles.
- * It is undefined whether the requested OID will be loose or
- * in a packfile.
+ * A long-running background process is used to make subsequent
+ * requests more efficient.
+ *
+ * A loose object will be created in the shared-cache ODB and
+ * in-memory cache updated.
  */
 int gh_client__get_immediate(const struct object_id *oid,
 			     enum gh_client__created *p_ghc);
@@ -47,16 +48,21 @@ int gh_client__get_immediate(const struct object_id *oid,
  * Queue this OID for a future fetch using `gvfs-helper service`.
  * It does not wait.
  *
- * The GHC layer is free to process this queue in any way it wants,
- * including individual fetches, bulk fetches, and batching.  And
- * it may add queued objects to immediate requests.
- *
  * Callers should not rely on the queued object being on disk until
  * the queue has been drained.
  */
 void gh_client__queue_oid(const struct object_id *oid);
 void gh_client__queue_oid_array(const struct object_id *oids, int oid_nr);
 
+/*
+ * Ask `gvfs-helper server` to fetch the set of queued OIDs using
+ * "/gvfs/objects" POST semantics.
+ *
+ * A long-running background process is used to subsequent requests
+ * more efficient.
+ *
+ * One or more packfiles will be created in the shared-cache ODB.
+ */
 int gh_client__drain_queue(enum gh_client__created *p_ghc);
 
 #endif /* GVFS_HELPER_CLIENT_H */

--- a/gvfs-helper-client.h
+++ b/gvfs-helper-client.h
@@ -4,7 +4,7 @@
 struct repository;
 struct commit;
 
-enum ghc__created {
+enum gh_client__created {
 	/*
 	 * The _get_ operation did not create anything.  If doesn't
 	 * matter if `gvfs-helper` had errors or not -- just that
@@ -13,7 +13,7 @@ enum ghc__created {
 	GHC__CREATED__NOTHING  = 0,
 
 	/*
-	 * The _get_operation created one or more packfiles.
+	 * The _get_ operation created one or more packfiles.
 	 */
 	GHC__CREATED__PACKFILE = 1<<1,
 
@@ -40,7 +40,8 @@ enum ghc__created {
  * It is undefined whether the requested OID will be loose or
  * in a packfile.
  */
-int ghc__get_immediate(const struct object_id *oid, enum ghc__created *p_ghc);
+int gh_client__get_immediate(const struct object_id *oid,
+			     enum gh_client__created *p_ghc);
 
 /*
  * Queue this OID for a future fetch using `gvfs-helper service`.
@@ -53,9 +54,9 @@ int ghc__get_immediate(const struct object_id *oid, enum ghc__created *p_ghc);
  * Callers should not rely on the queued object being on disk until
  * the queue has been drained.
  */
-void ghc__queue_oid(const struct object_id *oid);
-void ghc__queue_oid_array(const struct object_id *oids, int oid_nr);
+void gh_client__queue_oid(const struct object_id *oid);
+void gh_client__queue_oid_array(const struct object_id *oids, int oid_nr);
 
-int ghc__drain_queue(enum ghc__created *p_ghc);
+int gh_client__drain_queue(enum gh_client__created *p_ghc);
 
 #endif /* GVFS_HELPER_CLIENT_H */

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1049,7 +1049,9 @@ static void create_tempfile_for_loose(
 	strbuf_complete(&buf_path, '/');
 	strbuf_add(&buf_path, hex, 2);
 
-	if (!file_exists(buf_path.buf) && mkdir(buf_path.buf, 0777) == -1) {
+	if (!file_exists(buf_path.buf) &&
+	    mkdir(buf_path.buf, 0777) == -1 &&
+		!file_exists(buf_path.buf)) {
 		strbuf_addf(&status->error_message,
 			    "cannot create directory for loose object '%s'",
 			    buf_path.buf);

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -405,10 +405,16 @@ static void gh__response_status__set_from_slot(
 		strbuf_addf(&status->error_message, "%s (curl)",
 			    curl_easy_strerror(status->curl_code));
 		status->ec = GH__ERROR_CODE__CURL_ERROR;
+
+		trace2_data_string("gvfs-helper", NULL,
+				   "error/curl", status->error_message.buf);
 	} else {
 		strbuf_addf(&status->error_message, "HTTP %ld Unexpected",
 			    status->response_code);
 		status->ec = GH__ERROR_CODE__HTTP_UNEXPECTED_CODE;
+
+		trace2_data_string("gvfs-helper", NULL,
+				   "error/http", status->error_message.buf);
 	}
 
 	if (status->ec != GH__ERROR_CODE__OK)
@@ -1968,7 +1974,7 @@ static enum gh__error_code do_sub_cmd__get(int argc, const char **argv)
 }
 
 /*
- * Handle the 'get' command when in "server mode".  Only call error()
+ * Handle the 'get' command when in "server mode".  Only call error() and set ec
  * for hard errors where we cannot communicate correctly with the foreground
  * client process.  Pass any actual data errors (such as 404's or 401's from
  * the fetch back to the client process.
@@ -2040,10 +2046,15 @@ static enum gh__error_code do_server_subprocess_get(void)
 			goto cleanup;
 		}
 
+	/*
+	 * We only use status.ec to tell the client whether the request
+	 * was complete, incomplete, or had IO errors.  We DO NOT return
+	 * this value to our caller.
+	 */
 	err = 0;
-	if (ec == GH__ERROR_CODE__OK)
+	if (status.ec == GH__ERROR_CODE__OK)
 		err = packet_write_fmt_gently(1, "ok\n");
-	else if (ec == GH__ERROR_CODE__HTTP_404)
+	else if (status.ec == GH__ERROR_CODE__HTTP_404)
 		err = packet_write_fmt_gently(1, "partial\n");
 	else
 		err = packet_write_fmt_gently(1, "error %s\n",
@@ -2270,6 +2281,7 @@ int cmd_main(int argc, const char **argv)
 		usage_with_options(main_usage, main_options);
 
 	trace2_cmd_name("gvfs-helper");
+	packet_trace_identity("gvfs-helper");
 
 	setup_git_directory_gently(NULL);
 

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2528,17 +2528,11 @@ static void setup_gvfs_objects_progress(struct gh__request_params *params,
 		return;
 
 	if (params->b_is_post && params->object_count > 1) {
-		strbuf_addf(&params->progress_base_phase2_msg,
-			    "Requesting packfile %ld/%ld with %ld objects",
-			    num, den, params->object_count);
 		strbuf_addf(&params->progress_base_phase3_msg,
 			    "Receiving packfile %ld/%ld with %ld objects",
 			    num, den, params->object_count);
-	} else {
-		strbuf_addf(&params->progress_base_phase3_msg,
-			    "Receiving %ld/%ld loose object",
-			    num, den);
 	}
+	/* If requesting only one object, then do not show progress */
 }
 
 /*

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1,0 +1,2235 @@
+// TODO Write a man page.  Here are some notes for dogfooding.
+// TODO
+//
+// Usage: git gvfs-helper [<main_options>] <sub-command> [<sub-command-options>]
+//
+// <main_options>:
+//
+//     --remote=<remote-name>         // defaults to "origin"
+//
+//     --fallback                     // boolean. defaults to off
+//
+//            When a fetch from the cache-server fails, automatically
+//            fallback to the main Git server.  This option has no effect
+//            if no cache-server is defined.
+//
+//     --cache-server=<use>  // defaults to "verify"
+//
+//            verify   := lookup the set of defined cache-servers using
+//                        "gvfs/config" and confirm that the selected
+//                        cache-server is well-known.  Silently disable the
+//                        cache-server if not.  (See security notes later.)
+//
+//            error    := verify cache-server and abort if not well-known.
+//
+//            trust    := do not verify cache-server.  just use it.
+//
+//            disable  := disable the cache-server and always use the main
+//                        Git server.
+//
+//     --shared-cache=<odb-directory-pathname>
+//
+//            A relative or absolute pathname to the ODB directory to store
+//            fetched objects.
+//
+//            If this option is not specified, we default to the value
+//            in the "gvfs.sharedcache" config setting and then to the
+//            local ".git/objects" directory.
+//
+// <sub-command>:
+//
+//     config
+//
+//            Fetch the "gvfs/config" string from the main Git server.
+//            (The cache-server setting is ignored because cache-servers
+//            do not support this REST API.)
+//
+//     get
+//
+//            Fetch 1 or more objects.  If a cache-server is configured,
+//            try it first.  Optionally fallback to the main Git server.
+//
+//            The set of objects is given on stdin and is assumed to be
+//            a list of <oid>, one per line.
+//
+//            <get-options>:
+//
+//                 --block-size=<n>      // defaults to "4000"
+//
+//                       Request objects from server in batches of at
+//                       most n objects (not bytes).
+//
+//                 --depth=<depth>       // defaults to "1"
+//
+//     server
+//
+//            Interactive/sub-process mode.  Listen for a series of commands
+//            and data on stdin and return results on stdout.  This command
+//            uses pkt-line format [1] and implements the long-running process
+//            protocol [2] to communicate with the foreground/parent process.
+//
+//            <server-options>:
+//
+//                 --block-size=<n>      // defaults to "4000"
+//
+//                       Request objects from server in batches of at
+//                       most n objects (not bytes).
+//
+//                 --depth=<depth>       // defaults to "1"
+//
+//            Interactive verb: get
+//
+//                 Fetch 1 or more objects.  If a cache-server is configured,
+//                 try it first.  Optionally fallback to the main Git server.
+//                 Create 1 or more loose objects and/or packfiles in the
+//                 requested shared-cache directory (given on the command
+//                 line and which is reported at the beginning of the
+//                 response).
+//
+//                 git> get
+//                 git> <oid>
+//                 git> <oid>
+//                 git> ...
+//                 git> <oid>
+//                 git> 0000
+//
+//                 git< odb <directory>
+//                 git< loose <oid> | packfile <filename.pack>
+//                 git< loose <oid> | packfile <filename.pack>
+//                 gid< ...
+//                 git< loose <oid> | packfile <filename.pack>
+//                 git< ok | partial | error <message>
+//                 git< 0000
+//            
+//            [1] Documentation/technical/protocol-common.txt
+//            [2] Documentation/technical/long-running-process-protocol.txt
+//            [3] See GIT_TRACE_PACKET
+//
+// Example:
+//
+// $ git -c core.virtualizeobjects=false -c core.usegvfshelper=false
+//           rev-list --objects --no-walk --missing=print HEAD
+//     | grep "^?"
+//     | sed 's/^?//'
+//     | git gvfs-helper get-missing
+//
+// Note: In this example, we need to turn off "core.virtualizeobjects" and
+//       "core.usegvfshelper" when building the list of objects.  This prevents
+//       rev-list (in oid_object_info_extended() from automatically fetching
+//       them with read-object-hook or "gvfs-helper server" sub-process (and
+//       defeating the whole purpose of this example).
+//
+//////////////////////////////////////////////////////////////////
+
+#include "cache.h"
+#include "config.h"
+#include "remote.h"
+#include "connect.h"
+#include "strbuf.h"
+#include "walker.h"
+#include "http.h"
+#include "exec-cmd.h"
+#include "run-command.h"
+#include "pkt-line.h"
+#include "string-list.h"
+#include "sideband.h"
+#include "argv-array.h"
+#include "credential.h"
+#include "sha1-array.h"
+#include "send-pack.h"
+#include "protocol.h"
+#include "quote.h"
+#include "transport.h"
+#include "parse-options.h"
+#include "object-store.h"
+#include "json-writer.h"
+#include "tempfile.h"
+#include "oidset.h"
+#include "dir.h"
+#include "progress.h"
+
+static const char * const main_usage[] = {
+	N_("git gvfs-helper [<main_options>] config      [<options>]"),
+	N_("git gvfs-helper [<main_options>] get         [<options>]"),
+	N_("git gvfs-helper [<main_options>] server      [<options>]"),
+	NULL
+};
+
+static const char *const get_usage[] = {
+	N_("git gvfs-helper [<main_options>] get [<options>]"),
+	NULL
+};
+
+static const char *const server_usage[] = {
+	N_("git gvfs-helper [<main_options>] server [<options>]"),
+	NULL
+};
+
+#define GH__DEFAULT_BLOCK_SIZE 4000
+
+/*
+ * Our exit-codes.
+ */
+enum gh__error_code {
+	GH__ERROR_CODE__USAGE = -1, /* will be mapped to usage() */
+	GH__ERROR_CODE__OK = 0,
+	GH__ERROR_CODE__ERROR = 1, /* unspecified */
+//	GH__ERROR_CODE__CACHE_SERVER_NOT_FOUND = 2,
+	GH__ERROR_CODE__CURL_ERROR = 3,
+	GH__ERROR_CODE__HTTP_401 = 4,
+	GH__ERROR_CODE__HTTP_404 = 5,
+	GH__ERROR_CODE__HTTP_UNEXPECTED_CODE = 6,
+	GH__ERROR_CODE__UNEXPECTED_CONTENT_TYPE = 7,
+	GH__ERROR_CODE__COULD_NOT_CREATE_TEMPFILE = 8,
+	GH__ERROR_CODE__COULD_NOT_INSTALL_LOOSE = 9,
+	GH__ERROR_CODE__COULD_NOT_INSTALL_PACKFILE = 10,
+	GH__ERROR_CODE__SUBPROCESS_SYNTAX = 11,
+};
+
+enum gh__cache_server_mode {
+	/* verify URL. disable if unknown. */
+	GH__CACHE_SERVER_MODE__VERIFY_DISABLE = 0,
+	/* verify URL. error if unknown. */
+	GH__CACHE_SERVER_MODE__VERIFY_ERROR,
+	/* disable the cache-server, if defined */
+	GH__CACHE_SERVER_MODE__DISABLE,
+	/* trust any cache-server */
+	GH__CACHE_SERVER_MODE__TRUST_WITHOUT_VERIFY,
+};
+
+/*
+ * The set of command line, config, and environment variables
+ * that we use as input to decide how we should operate.
+ */
+static struct gh__cmd_opts {
+	const char *remote_name;
+
+	int try_fallback; /* to git server if cache-server fails */
+	int show_progress;
+
+	int depth;
+	int block_size;
+
+	enum gh__cache_server_mode cache_server_mode;
+} gh__cmd_opts;
+
+/*
+ * The chosen global state derrived from the inputs in gh__cmd_opts.
+ */
+static struct gh__global {
+	struct remote *remote;
+
+	struct credential main_creds;
+	struct credential cache_creds;
+
+	const char *main_url;
+	const char *cache_server_url;
+
+	struct strbuf buf_odb_path;
+
+	int http_is_initialized;
+	int cache_server_is_initialized; /* did sub-command look for one */
+	int main_creds_need_approval; /* try to only approve them once */
+
+} gh__global;
+
+/*
+ * Stolen from http.c
+ */
+static CURLcode gh__curlinfo_strbuf(CURL *curl, CURLINFO info, struct strbuf *buf)
+{
+	char *ptr;
+	CURLcode ret;
+
+	strbuf_reset(buf);
+	ret = curl_easy_getinfo(curl, info, &ptr);
+	if (!ret && ptr)
+		strbuf_addstr(buf, ptr);
+	return ret;
+}
+
+enum gh__progress_state {
+	GH__PROGRESS_STATE__START = 0,
+	GH__PROGRESS_STATE__PHASE1,
+	GH__PROGRESS_STATE__PHASE2,
+	GH__PROGRESS_STATE__PHASE3,
+};
+
+/*
+ * Parameters to drive an HTTP request (with any necessary retries).
+ */
+struct gh__request_params {
+	int b_is_post;            /* POST=1 or GET=0 */
+	int b_write_to_file;      /* write to file=1 or strbuf=0 */
+	int b_no_cache_server;    /* force main server only */
+
+	unsigned long object_count; /* number of objects being fetched */
+
+	const struct strbuf *post_payload; /* POST body to send */
+
+	struct curl_slist *headers; /* additional http headers to send */
+	struct tempfile *tempfile; /* for response content when file */
+	struct strbuf *buffer;     /* for response content when strbuf */
+	struct strbuf label;       /* for trace2 regions */
+
+	struct strbuf loose_path;
+
+	/*
+	 * Note that I am putting all of the progress-related instance data
+	 * inside the request-params in the hope that we can eventually
+	 * do multi-threaded/concurrent HTTP requests when chunking
+	 * large requests.  However, the underlying "struct progress" API
+	 * is not thread safe (that is, it doesn't allow concurrent progress
+	 * reports (since that might require multiple lines on the screen
+	 * or something)).
+	 */
+	enum gh__progress_state progress_state;
+	struct strbuf progress_base_phase2_msg;
+	struct strbuf progress_base_phase3_msg;
+
+	/*
+	 * The buffer for the formatted progress message is shared by the
+	 * "struct progress" API and must remain valid for the duration of
+	 * the start_progress..stop_progress lifespan.
+	 */
+	struct strbuf progress_msg;
+	struct progress *progress;
+};
+
+#define GH__REQUEST_PARAMS_INIT { \
+	.b_is_post = 0, \
+	.b_write_to_file = 0, \
+	.b_no_cache_server = 0, \
+	.object_count = 0, \
+	.post_payload = NULL, \
+	.headers = NULL, \
+	.tempfile = NULL, \
+	.buffer = NULL, \
+	.label = STRBUF_INIT, \
+	.loose_path = STRBUF_INIT, \
+	.progress_state = GH__PROGRESS_STATE__START, \
+	.progress_base_phase2_msg = STRBUF_INIT, \
+	.progress_base_phase3_msg = STRBUF_INIT, \
+	.progress_msg = STRBUF_INIT, \
+	.progress = NULL, \
+	}
+
+static void gh__request_params__release(struct gh__request_params *params)
+{
+	if (!params)
+		return;
+
+	params->post_payload = NULL; /* we do not own this */
+
+	curl_slist_free_all(params->headers);
+	params->headers = NULL;
+
+	delete_tempfile(&params->tempfile);
+
+	params->buffer = NULL; /* we do not own this */
+
+	strbuf_release(&params->label);
+	strbuf_release(&params->loose_path);
+
+	strbuf_release(&params->progress_base_phase2_msg);
+	strbuf_release(&params->progress_base_phase3_msg);
+	strbuf_release(&params->progress_msg);
+
+	stop_progress(&params->progress);
+	params->progress = NULL;
+}
+
+/*
+ * Bucket to describe the results of an HTTP requests (may be
+ * overwritten during retries so that it describes the final attempt).
+ */
+struct gh__response_status {
+	struct strbuf error_message;
+	struct strbuf content_type;
+	long response_code; /* http response code */
+	CURLcode curl_code;
+	enum gh__error_code ec;
+	intmax_t bytes_received;
+};
+
+#define GH__RESPONSE_STATUS_INIT { \
+	.error_message = STRBUF_INIT, \
+	.content_type = STRBUF_INIT, \
+	.response_code = 0, \
+	.curl_code = CURLE_OK, \
+	.ec = GH__ERROR_CODE__OK, \
+	.bytes_received = 0, \
+	}
+
+static void gh__response_status__zero(struct gh__response_status *s)
+{
+	strbuf_setlen(&s->error_message, 0);
+	strbuf_setlen(&s->content_type, 0);
+	s->response_code = 0;
+	s->curl_code = CURLE_OK;
+	s->ec = GH__ERROR_CODE__OK;
+	s->bytes_received = 0;
+}
+
+/*
+ * Create a single normalized 'ec' error-code from the status we
+ * received from the HTTP request.  Map a few of the expected HTTP
+ * status code to 'ec', but don't get too crazy here.
+ */
+static void gh__response_status__set_from_slot(
+	struct gh__request_params *params,
+	struct gh__response_status *status,
+	const struct active_request_slot *slot)
+{
+	status->curl_code = slot->results->curl_result;
+	gh__curlinfo_strbuf(slot->curl, CURLINFO_CONTENT_TYPE,
+			    &status->content_type);
+	curl_easy_getinfo(slot->curl, CURLINFO_RESPONSE_CODE,
+			  &status->response_code);
+
+	strbuf_setlen(&status->error_message, 0);
+
+	if (status->response_code == 200)
+		status->ec = GH__ERROR_CODE__OK;
+
+	else if (status->response_code == 401) {
+		strbuf_addstr(&status->error_message, "401 Not Authorized");
+		status->ec = GH__ERROR_CODE__HTTP_401;
+
+	} else if (status->response_code == 404) {
+		strbuf_addstr(&status->error_message, "404 Not Found");
+		status->ec = GH__ERROR_CODE__HTTP_404;
+
+	} else if (status->curl_code != CURLE_OK) {
+		strbuf_addf(&status->error_message, "%s (curl)",
+			    curl_easy_strerror(status->curl_code));
+		status->ec = GH__ERROR_CODE__CURL_ERROR;
+	} else {
+		strbuf_addf(&status->error_message, "HTTP %ld Unexpected",
+			    status->response_code);
+		status->ec = GH__ERROR_CODE__HTTP_UNEXPECTED_CODE;
+	}
+
+	if (status->ec != GH__ERROR_CODE__OK)
+		status->bytes_received = 0;
+	else if (params->b_write_to_file)
+		status->bytes_received = (intmax_t)ftell(params->tempfile->fp);
+	else
+		status->bytes_received = (intmax_t)params->buffer->len;
+}
+
+static void gh__response_status__release(struct gh__response_status *status)
+{
+	if (!status)
+		return;
+	strbuf_release(&status->error_message);
+	strbuf_release(&status->content_type);
+}
+
+/*
+ * The cache-server sends a somewhat bogus 400 instead of
+ * the normal 401 when AUTH is required.  Fixup the status
+ * to hide that.
+ */
+static void fixup_cache_server_400_to_401(struct gh__response_status *status)
+{
+	if (status->response_code != 400)
+		return;
+
+	/*
+	 * TODO Technically, the cache-server could send a 400
+	 * TODO for many reasons, not just for their bogus
+	 * TODO pseudo-401, but we're going to assume it is a
+	 * TODO 401 for now.  We should confirm the expected
+	 * TODO error message in the response-body.
+	 */
+	status->response_code = 401;
+}
+
+static int gh__curl_progress_cb(void *clientp,
+				curl_off_t dltotal, curl_off_t dlnow,
+				curl_off_t ultotal, curl_off_t ulnow)
+{
+	struct gh__request_params *params = clientp;
+
+	/*
+	 * From what I can tell, CURL progress arrives in 3 phases.
+	 *
+	 * [1] An initial connection setup phase where we get [0,0] [0,0].
+	 * [2] An upload phase where we start sending the request headers
+	 *     and body. ulnow will be > 0.  ultotal may or may not be 0.
+	 * [3] A download phase where we start receiving the response
+	 *     headers and payload body.  dlnow will be > 0. dltotal may
+	 *     or may not be 0.
+	 *
+	 * If we pass zero for the total to the "struct progress" API, we
+	 * get simple numbers rather than percentages.  So our progress
+	 * output format may vary depending.
+	 *     
+	 * It is unclear if CURL will give us a final callback after
+	 * everything is finished, so we leave the progress handle open
+	 * and let the caller issue the final stop_progress().
+	 *
+	 * There is a bit of a mismatch between the CURL API and the
+	 * "struct progress" API.  The latter requires us to set the
+	 * progress message when we call one of the start_progress
+	 * methods.  We cannot change the progress message while we are
+	 * showing progress state.  And we cannot change the denominator
+	 * (total) after we start.  CURL may or may not give us the total
+	 * sizes for each phase.
+	 *
+	 * Also be advised that the "struct progress" API eats messages
+	 * so that the screen is only updated every second or so.  And
+	 * may not print anything if the start..stop happen in less then
+	 * 2 seconds.  Whereas CURL calls this callback very frequently.
+	 * The net-net is that we may not actually see this progress
+	 * message for small/fast HTTP requests.
+	 */
+
+	switch (params->progress_state) {
+	case GH__PROGRESS_STATE__START: /* first callback */
+		if (dlnow == 0 && ulnow == 0)
+			goto enter_phase_1;
+
+		if (ulnow)
+			goto enter_phase_2;
+		else
+			goto enter_phase_3;
+
+	case GH__PROGRESS_STATE__PHASE1:
+		if (dlnow == 0 && ulnow == 0)
+			return 0;
+
+		if (ulnow)
+			goto enter_phase_2;
+		else
+			goto enter_phase_3;
+
+	case GH__PROGRESS_STATE__PHASE2:
+		display_progress(params->progress, ulnow);
+		if (dlnow == 0)
+			return 0;
+
+		stop_progress(&params->progress);
+		goto enter_phase_3;
+
+	case GH__PROGRESS_STATE__PHASE3:
+		display_progress(params->progress, dlnow);
+		return 0;
+
+	default:
+		return 0;
+	}
+
+enter_phase_1:
+	/*
+	 * Don't bother to create a progress handle during phase [1].
+	 * Because we get [0,0,0,0], we don't have any data to report
+	 * and would just have to synthesize some type of progress.
+	 * From my testing, phase [1] is fairly quick (probably just
+	 * the SSL handshake), so the "struct progress" API will most
+	 * likely completely eat any messages that we did produce.
+	 */
+	params->progress_state = GH__PROGRESS_STATE__PHASE1;
+	return 0;
+
+enter_phase_2:
+	strbuf_setlen(&params->progress_msg, 0);
+	if (params->progress_base_phase2_msg.len) {
+		strbuf_addf(&params->progress_msg, "%s (bytes sent)",
+			    params->progress_base_phase2_msg.buf);
+		params->progress = start_progress(params->progress_msg.buf, ultotal);
+		display_progress(params->progress, ulnow);
+	}
+	params->progress_state = GH__PROGRESS_STATE__PHASE2;
+	return 0;
+
+enter_phase_3:
+	strbuf_setlen(&params->progress_msg, 0);
+	if (params->progress_base_phase3_msg.len) {
+		strbuf_addf(&params->progress_msg, "%s (bytes received)",
+			    params->progress_base_phase3_msg.buf);
+		params->progress = start_progress(params->progress_msg.buf, dltotal);
+		display_progress(params->progress, dlnow);
+	}
+	params->progress_state = GH__PROGRESS_STATE__PHASE3;
+	return 0;
+}
+
+/*
+ * Run the request without using "run_one_slot()" because we
+ * don't want the post-request normalization, error handling,
+ * and auto-reauth handling in http.c.
+ */
+static void gh__run_one_slot(struct active_request_slot *slot,
+			     struct gh__request_params *params,
+			     struct gh__response_status *status)
+{
+	trace2_region_enter("gvfs-helper", params->label.buf, NULL);
+
+	if (!start_active_slot(slot)) {
+		status->curl_code = CURLE_FAILED_INIT; /* a bit of a lie */
+		strbuf_addstr(&status->error_message,
+			      "failed to start HTTP request");
+	} else {
+		run_active_slot(slot);
+		if (params->b_write_to_file)
+			fflush(params->tempfile->fp);
+
+		gh__response_status__set_from_slot(params, status, slot);
+
+		if (status->ec == GH__ERROR_CODE__OK) {
+			int old_len = params->label.len;
+
+			strbuf_addstr(&params->label, "/nr_objects");
+			trace2_data_intmax("gvfs-helper", NULL,
+					   params->label.buf,
+					   params->object_count);
+			strbuf_setlen(&params->label, old_len);
+
+			strbuf_addstr(&params->label, "/nr_bytes");
+			trace2_data_intmax("gvfs-helper", NULL,
+					   params->label.buf,
+					   status->bytes_received);
+			strbuf_setlen(&params->label, old_len);
+		}
+	}
+
+	if (params->progress)
+		stop_progress(&params->progress);
+
+	trace2_region_leave("gvfs-helper", params->label.buf, NULL);
+}
+
+static int option_parse_cache_server_mode(const struct option *opt,
+					  const char *arg, int unset)
+{
+	if (unset) /* should not happen */
+		return error(_("missing value for switch '%s'"),
+			     opt->long_name);
+
+	else if (!strcmp(arg, "verify"))
+		gh__cmd_opts.cache_server_mode =
+			GH__CACHE_SERVER_MODE__VERIFY_DISABLE;
+
+	else if (!strcmp(arg, "error"))
+		gh__cmd_opts.cache_server_mode =
+			GH__CACHE_SERVER_MODE__VERIFY_ERROR;
+
+	else if (!strcmp(arg, "disable"))
+		gh__cmd_opts.cache_server_mode =
+			GH__CACHE_SERVER_MODE__DISABLE;
+
+	else if (!strcmp(arg, "trust"))
+		gh__cmd_opts.cache_server_mode =
+			GH__CACHE_SERVER_MODE__TRUST_WITHOUT_VERIFY;
+
+	else
+		return error(_("invalid value for switch '%s'"),
+			     opt->long_name);
+
+	return 0;
+}
+
+/*
+ * Let command line args override "gvfs.sharedcache" config setting.
+ *
+ * It would be nice to move this to parse-options.c as an
+ * OPTION_PATHNAME handler.  And maybe have flags for exists()
+ * and is_directory().
+ */
+static int option_parse_shared_cache_directory(const struct option *opt,
+					       const char *arg, int unset)
+{
+	if (unset) /* should not happen */
+		return error(_("missing value for switch '%s'"),
+			     opt->long_name);
+
+	if (!is_directory(arg))
+		return error(_("value for switch '%s' is not a directory: '%s'"),
+			     opt->long_name, arg);
+
+	gvfs_shared_cache_pathname = arg;
+
+	return 0;
+}
+
+/*
+ * Lookup the URL for this remote (defaults to 'origin').
+ */
+static void lookup_main_url(void)
+{
+	/*
+	 * Both VFS and Scalar only work with 'origin', so we expect this.
+	 * The command line arg is mainly for debugging.
+	 */
+	if (!gh__cmd_opts.remote_name || !*gh__cmd_opts.remote_name)
+		gh__cmd_opts.remote_name = "origin";
+
+	gh__global.remote = remote_get(gh__cmd_opts.remote_name);
+	if (!gh__global.remote->url[0] || !*gh__global.remote->url[0])
+		die("unknown remote '%s'", gh__cmd_opts.remote_name);
+
+	/*
+	 * Strip out any in-line auth in the origin server URL so that
+	 * we can control which creds we fetch.
+	 *
+	 * Azure DevOps has been known to suggest https URLS of the
+	 * form "https://<account>@dev.azure.com/<account>/<path>".
+	 *
+	 * Break that so that we can force the use of a PAT.
+	 */
+	gh__global.main_url = transport_anonymize_url(gh__global.remote->url[0]);
+
+	trace2_data_string("gvfs-helper", NULL, "remote/url", gh__global.main_url);
+}
+
+static void do__gvfs_config(struct gh__response_status *status,
+			    struct strbuf *config_data);
+
+/*
+ * Find the URL of the cache-server, if we have one.
+ *
+ * This routined is called by the initialization code and is allowed
+ * to call die() rather than returning an 'ec'.
+ */
+static void select_cache_server(void)
+{
+	struct gh__response_status status = GH__RESPONSE_STATUS_INIT;
+	struct strbuf config_data = STRBUF_INIT;
+	const char *match = NULL;
+
+	/*
+	 * This only indicates that the sub-command actually called
+	 * this routine.  We rely on gh__global.cache_server_url to tell
+	 * us if we actually have a cache-server configured.
+	 */
+	gh__global.cache_server_is_initialized = 1;
+	gh__global.cache_server_url = NULL;
+
+	if (gh__cmd_opts.cache_server_mode == GH__CACHE_SERVER_MODE__DISABLE) {
+		trace2_data_string("gvfs-helper", NULL, "cache/url", "disabled");
+		return;
+	}
+
+	/*
+	 * If the cache-server and main Git server have the same URL, we
+	 * can silently disable the cache-server (by NOT setting the field
+	 * in gh__global and explicitly disable the fallback logic.)
+	 */
+	if (!strcmp(gvfs_cache_server_url, gh__global.main_url)) {
+		gh__cmd_opts.try_fallback = 0;
+		trace2_data_string("gvfs-helper", NULL, "cache/url", "same");
+		return;
+	}
+
+	if (gh__cmd_opts.cache_server_mode ==
+	    GH__CACHE_SERVER_MODE__TRUST_WITHOUT_VERIFY) {
+		gh__global.cache_server_url = gvfs_cache_server_url;
+		trace2_data_string("gvfs-helper", NULL, "cache/url",
+				   gvfs_cache_server_url);
+		return;
+	}
+
+	/*
+	 * GVFS cache-servers use the main Git server's creds rather
+	 * than having their own creds.  This feels like a security
+	 * hole.  For example, if the cache-server URL is pointed to a
+	 * bad site, we'll happily send them our creds to the main Git
+	 * server with each request to the cache-server.  This would
+	 * allow an attacker to later use our creds to impersonate us
+	 * on the main Git server.
+	 *
+	 * So we optionally verify that the URL to the cache-server is
+	 * well-known by the main Git server.
+	 */
+
+	do__gvfs_config(&status, &config_data);
+
+	if (status.ec == GH__ERROR_CODE__OK) {
+		/*
+		 * The gvfs/config response is in JSON, but I don't think
+		 * we need to parse it and all that.  Lets just do a simple
+		 * strstr() and assume it is sufficient.
+		 *
+		 * We do add some context to the pattern to guard against
+		 * some attacks.
+		 */
+		struct strbuf pattern = STRBUF_INIT;
+
+		strbuf_addf(&pattern, "\"Url\":\"%s\"", gvfs_cache_server_url);
+		match = strstr(config_data.buf, pattern.buf);
+
+		strbuf_release(&pattern);
+	}
+
+	strbuf_release(&config_data);
+
+	if (match) {
+		gh__global.cache_server_url = gvfs_cache_server_url;
+		trace2_data_string("gvfs-helper", NULL, "cache/url",
+				   gvfs_cache_server_url);
+	}
+
+	else if (gh__cmd_opts.cache_server_mode ==
+		 GH__CACHE_SERVER_MODE__VERIFY_ERROR) {
+		if (status.ec != GH__ERROR_CODE__OK)
+			die("could not verify cache-server '%s': %s",
+			    gvfs_cache_server_url,
+			    status.error_message.buf);
+		else
+			die("could not verify cache-server '%s'",
+			    gvfs_cache_server_url);
+	}
+
+	else if (gh__cmd_opts.cache_server_mode ==
+		 GH__CACHE_SERVER_MODE__VERIFY_DISABLE) {
+		if (status.ec != GH__ERROR_CODE__OK)
+			warning("could not verify cache-server '%s': %s",
+				gvfs_cache_server_url,
+				status.error_message.buf);
+		else
+			warning("could not verify cache-server '%s'",
+				gvfs_cache_server_url);
+		trace2_data_string("gvfs-helper", NULL, "cache/url",
+				   "disabled");
+	}
+
+	gh__response_status__release(&status);
+}
+
+/*
+ * Read stdin until EOF (or a blank line) and add the desired OIDs
+ * to the oidset.
+ *
+ * Stdin should contain a list of OIDs.  It may have additional
+ * decoration that we need to strip out.
+ *
+ * We expect:
+ * <hex_oid> [<path>]   // present OIDs
+ */
+static unsigned long read_stdin_from_rev_list(struct oidset *oids)
+{
+	struct object_id oid;
+	struct strbuf buf_stdin = STRBUF_INIT;
+	unsigned long count = 0;
+
+	do {
+		if (strbuf_getline(&buf_stdin, stdin) == EOF || !buf_stdin.len)
+			break;
+
+		if (get_oid_hex(buf_stdin.buf, &oid))
+			continue; /* just silently eat it */
+
+		if (!oidset_insert(oids, &oid))
+			count++;
+	} while (1);
+
+	return count;
+}
+
+/*
+ * Build a complete JSON payload for a gvfs/objects POST request
+ * containing the first n OIDs in an OIDSET index by the iterator.
+ *
+ * https://github.com/microsoft/VFSForGit/blob/master/Protocol.md
+ */
+static unsigned long build_json_payload__gvfs_objects(
+	struct json_writer *jw_req,
+	struct oidset_iter *iter,
+	unsigned long nr_in_block)
+{
+	unsigned long k;
+	const struct object_id *oid;
+
+	k = 0;
+
+	jw_init(jw_req);
+	jw_object_begin(jw_req, 0);
+	jw_object_intmax(jw_req, "commitDepth", gh__cmd_opts.depth);
+	jw_object_inline_begin_array(jw_req, "objectIds");
+	while (k < nr_in_block && (oid = oidset_iter_next(iter))) {
+		jw_array_string(jw_req, oid_to_hex(oid));
+		k++;
+	}
+	jw_end(jw_req);
+	jw_end(jw_req);
+
+	return k;
+}
+
+/*
+ * Lookup the creds for the main/origin Git server.
+ */
+static void lookup_main_creds(void)
+{
+	if (gh__global.main_creds.username && *gh__global.main_creds.username)
+		return;
+
+	credential_from_url(&gh__global.main_creds, gh__global.main_url);
+	credential_fill(&gh__global.main_creds);
+	gh__global.main_creds_need_approval = 1;
+}
+
+/*
+ * If we have a set of creds for the main Git server, tell the credential
+ * manager to throw them away and ask it to reacquire them.
+ */
+static void refresh_main_creds(void)
+{
+	if (gh__global.main_creds.username && *gh__global.main_creds.username)
+		credential_reject(&gh__global.main_creds);
+
+	lookup_main_creds();
+
+	// TODO should we compare before and after values of u/p and
+	// TODO shortcut reauth if we already know it will fail?
+	// TODO if so, return a bool if same/different.
+}
+
+static void approve_main_creds(void)
+{
+	if (!gh__global.main_creds_need_approval)
+		return;
+
+	credential_approve(&gh__global.main_creds);
+	gh__global.main_creds_need_approval = 0;
+}
+
+/*
+ * Build a set of creds for the cache-server based upon the main Git
+ * server (assuming we have a cache-server configured).
+ *
+ * That is, we NEVER fill them directly for the cache-server -- we
+ * only synthesize them from the filled main creds.
+ */
+static void synthesize_cache_server_creds(void)
+{
+	if (!gh__global.cache_server_is_initialized)
+		BUG("sub-command did not initialize cache-server vars");
+
+	if (!gh__global.cache_server_url)
+		return;
+
+	if (gh__global.cache_creds.username && *gh__global.cache_creds.username)
+		return;
+
+	/*
+	 * Get the main Git server creds so we can borrow the username
+	 * and password when we talk to the cache-server.
+	 */
+	lookup_main_creds();
+	gh__global.cache_creds.username = xstrdup(gh__global.main_creds.username);
+	gh__global.cache_creds.password = xstrdup(gh__global.main_creds.password);
+}
+
+/*
+ * Flush and refresh the cache-server creds.  Because the cache-server
+ * does not do 401s (or manage creds), we have to reload the main Git
+ * server creds first.
+ *
+ * That is, we NEVER reject them directly because we never filled them.
+ */
+static void refresh_cache_server_creds(void)
+{
+	credential_clear(&gh__global.cache_creds);
+
+	refresh_main_creds();
+	synthesize_cache_server_creds();
+}
+
+/*
+ * We NEVER approve cache-server creds directly because we never directly
+ * filled them.  However, we should be able to infer that the main ones
+ * are valid and can approve them if necessary.
+ */
+static void approve_cache_server_creds(void)
+{
+	approve_main_creds();
+}
+
+/*
+ * Select the ODB directory where we will write objects that we
+ * download.  If was given on the command line or define in the
+ * config, use the local ODB (in ".git/objects").
+ */
+static void select_odb(void)
+{
+	const char *odb_path = NULL;
+
+	strbuf_init(&gh__global.buf_odb_path, 0);
+
+	if (gvfs_shared_cache_pathname && *gvfs_shared_cache_pathname)
+		odb_path = gvfs_shared_cache_pathname;
+	else {
+		prepare_alt_odb(the_repository);
+		odb_path = the_repository->objects->odb->path;
+	}
+
+	strbuf_addstr(&gh__global.buf_odb_path, odb_path);
+}
+
+/*
+ * Create a tempfile to stream the packfile into.
+ *
+ * We create a tempfile in the chosen ODB directory and let CURL
+ * automatically stream data to the file.  If successful, we can
+ * later rename it to a proper .pack and run "git index-pack" on
+ * it to create the corresponding .idx file.
+ *
+ * TODO I would rather to just stream the packfile directly into
+ * TODO "git index-pack --stdin" (and save some I/O) because it
+ * TODO will automatically take care of the rename of both files
+ * TODO and any other cleanup.  BUT INDEX-PACK WILL ONLY WRITE
+ * TODO TO THE PRIMARY ODB -- it will not write into the alternates
+ * TODO (this is considered bad form).  So we would need to add
+ * TODO an option to index-pack to handle this.  I don't want to
+ * TODO deal with this issue right now.
+ *
+ * TODO Consider using lockfile for this rather than naked tempfile.
+ */
+static struct tempfile *create_tempfile_for_packfile(void)
+{
+	static unsigned int nth = 0;
+	static struct timeval tv = {0};
+	static struct tm tm = {0};
+	static time_t secs = 0;
+	static char tbuf[32] = {0};
+
+	struct tempfile *tempfile = NULL;
+	struct strbuf buf_path = STRBUF_INIT;
+
+	if (!nth) {
+		gettimeofday(&tv, NULL);
+		secs = tv.tv_sec;
+		gmtime_r(&secs, &tm);
+
+		xsnprintf(tbuf, sizeof(tbuf), "%4d%02d%02d-%02d%02d%02d-%06ld",
+			  tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+			  tm.tm_hour, tm.tm_min, tm.tm_sec,
+			  (long)tv.tv_usec);
+	}
+
+	// TODO should this be in the "<ODB>/pack/tempPacks/"
+	// TODO directory instead? YES
+
+	strbuf_addbuf(&buf_path, &gh__global.buf_odb_path);
+	strbuf_complete(&buf_path, '/');
+	strbuf_addf(&buf_path, "pack/vfs-%s-%04d.temp", tbuf, nth++);
+
+	tempfile = create_tempfile(buf_path.buf);
+	fdopen_tempfile(tempfile, "w");
+
+	strbuf_release(&buf_path);
+
+	return tempfile;
+}
+
+/*
+ * Create a tempfile to stream a loose object into.
+ *
+ * We create a tempfile in the chosen ODB directory and let CURL
+ * automatically stream data to the file.
+ *
+ * We put it directly in the "<odb>/xx/" directory.
+ */
+static void create_tempfile_for_loose(
+	struct gh__request_params *params,
+	struct gh__response_status *status,
+	const struct object_id *oid)
+{
+	struct strbuf buf_path = STRBUF_INIT;
+	const char *hex;
+
+	gh__response_status__zero(status);
+
+	hex = oid_to_hex(oid);
+
+	strbuf_addbuf(&buf_path, &gh__global.buf_odb_path);
+	strbuf_complete(&buf_path, '/');
+	strbuf_add(&buf_path, hex, 2);
+
+	if (!file_exists(buf_path.buf) && mkdir(buf_path.buf, 0777) == -1) {
+		strbuf_addf(&status->error_message,
+			    "cannot create directory for loose object '%s'",
+			    buf_path.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_CREATE_TEMPFILE;
+		goto cleanup;
+	}
+
+	strbuf_addch(&buf_path, '/');
+	strbuf_addstr(&buf_path, hex+2);
+
+	/* Remember the full path of the final destination. */
+	strbuf_setlen(&params->loose_path, 0);
+	strbuf_addbuf(&params->loose_path, &buf_path);
+
+	/*
+	 * Build a unique tempfile pathname based upon it.  We avoid
+	 * using lockfiles to avoid issues with stale locks after
+	 * crashes.
+	 */
+	strbuf_addf(&buf_path, ".%08u.temp", getpid());
+
+	params->tempfile = create_tempfile(buf_path.buf);
+	if (!params->tempfile) {
+		strbuf_addstr(&status->error_message,
+			      "could not create tempfile for loose object");
+		status->ec = GH__ERROR_CODE__COULD_NOT_CREATE_TEMPFILE;
+		goto cleanup;
+	}
+
+	fdopen_tempfile(params->tempfile, "w");
+
+cleanup:
+	strbuf_release(&buf_path);
+}
+
+/*
+ * Extract the filename portion of the given pathname.
+ *
+ * TODO Wish I could find a strbuf_filename() function for this.
+ */
+static void extract_filename(struct strbuf *filename,
+			     const struct strbuf *pathname)
+{
+	size_t len = pathname->len;
+
+	strbuf_setlen(filename, 0);
+
+	while (len > 0 && !is_dir_sep(pathname->buf[len - 1]))
+		len--;
+
+	strbuf_addstr(filename, &pathname->buf[len]);
+}
+
+/*
+ * Convert the tempfile into a permanent .pack packfile in the ODB.
+ * Create the corresponding .idx file.
+ *
+ * Return the filename (not pathname) of the resulting packfile.
+ */
+static void install_packfile(struct gh__response_status *status,
+			     struct tempfile **pp_tempfile,
+			     struct strbuf *packfile_filename)
+{
+	struct child_process ip = CHILD_PROCESS_INIT;
+	struct strbuf pack_name_tmp = STRBUF_INIT;
+	struct strbuf pack_name_dst = STRBUF_INIT;
+	struct strbuf idx_name_tmp = STRBUF_INIT;
+	struct strbuf idx_name_dst = STRBUF_INIT;
+	size_t len_base;
+
+	gh__response_status__zero(status);
+
+	strbuf_setlen(packfile_filename, 0);
+
+	/*
+	 * start with "<base>.temp" (that is owned by tempfile class).
+	 * rename to "<base>.pack.temp" to break ownership.
+	 *
+	 * create "<base>.idx.temp" on provisional packfile.
+	 *
+	 * officially install both "<base>.{pack,idx}.temp" as
+	 * "<base>.{pack,idx}".
+	 */
+
+	strbuf_addstr(&pack_name_tmp, get_tempfile_path(*pp_tempfile));
+	if (!strip_suffix(pack_name_tmp.buf, ".temp", &len_base)) {
+		/*
+		 * This is more of a BUG(), but I want the error
+		 * code propagated.
+		 */
+		strbuf_addf(&status->error_message,
+			    "packfile tempfile does not end in '.temp': '%s'",
+			    pack_name_tmp.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_INSTALL_PACKFILE;
+		goto cleanup;
+	}
+
+	strbuf_setlen(&pack_name_tmp, (int)len_base);
+	strbuf_addbuf(&pack_name_dst, &pack_name_tmp);
+	strbuf_addbuf(&idx_name_tmp, &pack_name_tmp);
+	strbuf_addbuf(&idx_name_dst, &pack_name_tmp);
+
+	strbuf_addstr(&pack_name_tmp, ".pack.temp");
+	strbuf_addstr(&pack_name_dst, ".pack");
+	strbuf_addstr(&idx_name_tmp, ".idx.temp");
+	strbuf_addstr(&idx_name_dst, ".idx");
+
+	// TODO if either pack_name_dst or idx_name_dst already
+	// TODO exists in the ODB, create alternate names so that
+	// TODO we don't step on them.
+
+	if (rename_tempfile(pp_tempfile, pack_name_tmp.buf) == -1) {
+		strbuf_addf(&status->error_message,
+			    "could not rename packfile to '%s'",
+			    pack_name_tmp.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_INSTALL_PACKFILE;
+		goto cleanup;
+	}
+
+	argv_array_push(&ip.args, "index-pack");
+	if (gh__cmd_opts.show_progress)
+		argv_array_push(&ip.args, "-v");
+	argv_array_pushl(&ip.args, "-o", idx_name_tmp.buf, NULL);
+	argv_array_push(&ip.args, pack_name_tmp.buf);
+	ip.git_cmd = 1;
+	ip.no_stdin = 1;
+	ip.no_stdout = 1;
+
+	// TODO consider capturing stdout from index-pack because
+	// TODO it will contain the SHA of the packfile and we can
+	// TODO (should?) add it to the .pack and .idx pathnames
+	// TODO when we install them.
+	// TODO
+	// TODO See pipe_command() rather than run_command().
+	// TODO
+	// TODO Or should be SHA-it ourselves (or read the last 20 bytes)?
+
+	/*
+	 * Note that I DO NOT have a region around the index-pack process.
+	 * The region in gh__run_one_slot() currently only covers the
+	 * download time.  This index-pack is a separate step not covered
+	 * in the above region.  Later, if/when we have CURL directly stream
+	 * to index-pack, that region will be the combined download+index
+	 * time.  So, I'm not going to introduce it here.
+	 */
+	if (run_command(&ip)) {
+		unlink(pack_name_tmp.buf);
+		unlink(idx_name_tmp.buf);
+		strbuf_addf(&status->error_message,
+			    "index-pack failed on '%s'", pack_name_tmp.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_INSTALL_PACKFILE;
+		goto cleanup;
+	}
+
+	if (finalize_object_file(pack_name_tmp.buf, pack_name_dst.buf) ||
+	    finalize_object_file(idx_name_tmp.buf, idx_name_dst.buf)) {
+		unlink(pack_name_tmp.buf);
+		unlink(pack_name_dst.buf);
+		unlink(idx_name_tmp.buf);
+		unlink(idx_name_dst.buf);
+		strbuf_addf(&status->error_message,
+			    "could not install packfile '%s'",
+			    pack_name_dst.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_INSTALL_PACKFILE;
+		goto cleanup;
+	}
+
+	extract_filename(packfile_filename, &pack_name_dst);
+
+cleanup:
+	child_process_clear(&ip);
+	strbuf_release(&pack_name_tmp);
+	strbuf_release(&pack_name_dst);
+	strbuf_release(&idx_name_tmp);
+	strbuf_release(&idx_name_dst);
+}
+
+/*
+ * Convert the tempfile into a permanent loose object in the ODB.
+ */
+static void install_loose(struct gh__request_params *params,
+			  struct gh__response_status *status)
+{
+	struct strbuf tmp_path = STRBUF_INIT;
+
+	gh__response_status__zero(status);
+
+	/*
+	 * close tempfile to steal ownership away from tempfile class.
+	 */
+	strbuf_addstr(&tmp_path, get_tempfile_path(params->tempfile));
+	close_tempfile_gently(params->tempfile);
+
+	/*
+	 * Try to install the tempfile as the actual loose object.
+	 *
+	 * If the loose object already exists, finalize_object_file()
+	 * will NOT overwrite/replace it.  It will silently eat the
+	 * EEXIST error and unlink the tempfile as it if was
+	 * successful.  We just let it lie to us.
+	 *
+	 * Since our job is to back-fill missing objects needed by a
+	 * foreground git process -- git should have called
+	 * oid_object_info_extended() and loose_object_info() BEFORE
+	 * asking us to download the missing object.  So if we get a
+	 * collision we have to assume something else is happening in
+	 * parallel and we lost the race.  And that's OK.
+	 */
+	if (finalize_object_file(tmp_path.buf, params->loose_path.buf)) {
+		unlink(tmp_path.buf);
+		strbuf_addf(&status->error_message,
+			    "could not install loose object '%s'",
+			    params->loose_path.buf);
+		status->ec = GH__ERROR_CODE__COULD_NOT_INSTALL_LOOSE;
+	}
+
+	strbuf_release(&tmp_path);
+}
+
+/*
+ * Our wrapper to initialize the HTTP layer.
+ *
+ * We always use the real origin server, not the cache-server, when
+ * initializing the http/curl layer.
+ */
+static void gh_http_init(void)
+{
+	if (gh__global.http_is_initialized)
+		return;
+
+	http_init(gh__global.remote, gh__global.main_url, 0);
+	gh__global.http_is_initialized = 1;
+}
+
+static void gh_http_cleanup(void)
+{
+	if (!gh__global.http_is_initialized)
+		return;
+
+	http_cleanup();
+	gh__global.http_is_initialized = 0;
+}
+
+/*
+ * Do a single HTTP request without auth-retry or fallback.
+ */
+static void do_req(const char *url_base,
+		   const char *url_component,
+		   const struct credential *creds,
+		   struct gh__request_params *params,
+		   struct gh__response_status *status)
+{
+	struct active_request_slot *slot;
+	struct slot_results results;
+	struct strbuf rest_url = STRBUF_INIT;
+
+	gh__response_status__zero(status);
+
+	if (params->b_write_to_file) {
+		// TODO ftruncate tempfile ??
+	} else {
+		strbuf_setlen(params->buffer, 0);
+	}
+
+	end_url_with_slash(&rest_url, url_base);
+	strbuf_addstr(&rest_url, url_component);
+
+	slot = get_active_slot();
+	slot->results = &results;
+
+	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0); /* not a HEAD request */
+	curl_easy_setopt(slot->curl, CURLOPT_URL, rest_url.buf);
+	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, params->headers);
+
+	if (params->b_is_post) {
+		curl_easy_setopt(slot->curl, CURLOPT_POST, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_ENCODING, NULL);
+		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS,
+				 params->post_payload->buf);
+		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE,
+				 params->post_payload->len);
+	} else {
+		curl_easy_setopt(slot->curl, CURLOPT_POST, 0);
+	}
+
+	if (params->b_write_to_file) {
+		curl_easy_setopt(slot->curl, CURLOPT_WRITEFUNCTION, fwrite);
+		curl_easy_setopt(slot->curl, CURLOPT_WRITEDATA,
+				 (void*)params->tempfile->fp);
+	} else {
+		curl_easy_setopt(slot->curl, CURLOPT_WRITEFUNCTION,
+				 fwrite_buffer);
+		curl_easy_setopt(slot->curl, CURLOPT_FILE, params->buffer);
+	}
+
+	if (creds && creds->username) {
+		/*
+		 * Force CURL to respect the username/password we provide by
+		 * turning off the AUTH-ANY negotiation stuff.
+		 *
+		 * That is, CURLAUTH_ANY causes CURL to NOT send the creds
+		 * on an initial request in order to force a 401 and let it
+		 * negotiate the best auth scheme and then retry.
+		 *
+		 * This is problematic when talking to the cache-servers
+		 * because they send a 400 (with a "A valid Basic Auth..."
+		 * message body) rather than a 401.  This means that the
+		 * the automatic retry will never happen.  And even if we
+		 * do force a retry, CURL still won't send the creds.
+		 *
+		 * So we turn it off and force it use our creds.
+		 */
+		curl_easy_setopt(slot->curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		curl_easy_setopt(slot->curl, CURLOPT_USERNAME, creds->username);
+		curl_easy_setopt(slot->curl, CURLOPT_PASSWORD, creds->password);
+	} else {
+		/*
+		 * Turn on the AUTH-ANY negotiation.  This only works
+		 * with the main Git server (because the cache-server
+		 * doesn't handle 401s).
+		 *
+		 * TODO Think about if we really need to handle this case
+		 * TODO and if so, add an .is_main to params.
+		 */
+		curl_easy_setopt(slot->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+	}
+
+	if (params->progress_base_phase2_msg.len ||
+	    params->progress_base_phase3_msg.len) {
+		curl_easy_setopt(slot->curl, CURLOPT_XFERINFOFUNCTION,
+				 gh__curl_progress_cb);
+		curl_easy_setopt(slot->curl, CURLOPT_XFERINFODATA, params);
+		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 0);
+	} else {
+		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 1);
+	}
+
+	gh__run_one_slot(slot, params, status);
+}
+
+static void do_req__to_main(const char *url_component,
+			    struct gh__request_params *params,
+			    struct gh__response_status *status)
+{
+//	lookup_main_creds();
+
+	do_req(gh__global.main_url, url_component, &gh__global.main_creds,
+	       params, status);
+
+	if (status->response_code == 401) {
+		refresh_main_creds();
+
+		do_req(gh__global.main_url, url_component, &gh__global.main_creds,
+		       params, status);
+	}
+
+	if (status->response_code == 200)
+		approve_main_creds();
+}
+
+static void do_req__to_cache_server(const char *url_component,
+				    struct gh__request_params *params,
+				    struct gh__response_status *status)
+{
+	synthesize_cache_server_creds();
+
+	do_req(gh__global.cache_server_url, url_component, &gh__global.cache_creds,
+	       params, status);
+	fixup_cache_server_400_to_401(status);
+
+	if (status->response_code == 401) {
+		refresh_cache_server_creds();
+
+		do_req(gh__global.cache_server_url, url_component,
+		       &gh__global.cache_creds, params, status);
+		fixup_cache_server_400_to_401(status);
+	}
+
+	if (status->response_code == 200)
+		approve_cache_server_creds();
+}
+
+static void do_req__with_fallback(const char *url_component,
+				  struct gh__request_params *params,
+				  struct gh__response_status *status)
+{
+	if (gh__global.cache_server_url && !params->b_no_cache_server) {
+		do_req__to_cache_server(url_component, params, status);
+
+		if (status->response_code == 200)
+			return;
+
+		if (!gh__cmd_opts.try_fallback)
+			return;
+
+		/*
+		 * The cache-server shares creds with the main Git server,
+		 * so if our creds failed against the cache-server, they
+		 * will also fail against the main Git server.  We just let
+		 * this fail.
+		 *
+		 * Falling-back would likely just cause the 3rd (or maybe
+		 * 4th) cred prompt.
+		 */
+		if (status->response_code == 401)
+			return;
+	}
+
+	do_req__to_main(url_component, params, status);
+}
+
+/*
+ * Call "gvfs/config" REST API.
+ *
+ * Return server's response buffer.  This is probably a raw JSON string.
+ */
+static void do__gvfs_config(struct gh__response_status *status,
+			    struct strbuf *config_data)
+{
+	struct gh__request_params params = GH__REQUEST_PARAMS_INIT;
+
+	strbuf_addstr(&params.label, "GET/config");
+
+	params.b_is_post = 0;
+	params.b_write_to_file = 0;
+	params.b_no_cache_server = 1; /* they don't handle gvfs/config API */
+	params.buffer = config_data;
+
+	params.object_count = 1; /* a bit of a lie */
+
+	/*
+	 * "X-TFS-FedAuthRedirect: Suppress" disables the 302 + 203 redirect
+	 * sequence to a login page and forces the main Git server to send a
+	 * normal 401.
+	 */
+	params.headers = http_copy_default_headers();
+	params.headers = curl_slist_append(params.headers,
+					   "X-TFS-FedAuthRedirect: Suppress");
+	params.headers = curl_slist_append(params.headers,
+					   "Pragma: no-cache");
+
+	if (gh__cmd_opts.show_progress) {
+		/*
+		 * gvfs/config has a very small reqest payload, so I don't
+		 * see any need to report progress on the upload side of
+		 * the GET.  So just report progress on the download side.
+		 */
+		strbuf_addstr(&params.progress_base_phase3_msg,
+			      "Receiving gvfs/config");
+	}
+
+	do_req__with_fallback("gvfs/config", &params, status);
+
+	gh__request_params__release(&params);
+}
+
+/*
+ * Call "gvfs/objects/<oid>" REST API to fetch a loose object
+ * and write it to the ODB.
+ */
+static void do__loose__gvfs_object(struct gh__response_status *status,
+				   const struct object_id *oid)
+{
+	struct gh__request_params params = GH__REQUEST_PARAMS_INIT;
+	struct strbuf component_url = STRBUF_INIT;
+
+	gh__response_status__zero(status);
+
+	strbuf_addf(&component_url, "gvfs/objects/%s", oid_to_hex(oid));
+
+	strbuf_addstr(&params.label, "GET/objects");
+
+	params.b_is_post = 0;
+	params.b_write_to_file = 1;
+	params.b_no_cache_server = 0;
+
+	params.object_count = 1;
+
+	params.headers = http_copy_default_headers();
+	params.headers = curl_slist_append(params.headers,
+					   "X-TFS-FedAuthRedirect: Suppress");
+	params.headers = curl_slist_append(params.headers,
+					   "Pragma: no-cache");
+
+	create_tempfile_for_loose(&params, status, oid);
+	if (!params.tempfile)
+		goto cleanup;
+
+	if (gh__cmd_opts.show_progress) {
+		/*
+		 * Likewise, a gvfs/objects/{oid} has a very small reqest
+		 * payload, so I don't see any need to report progress on
+		 * the upload side of the GET.  So just report progress
+		 * on the download side.
+		 */
+		strbuf_addstr(&params.progress_base_phase3_msg,
+			      "Receiving 1 loose object");
+	}
+
+	do_req__with_fallback(component_url.buf, &params, status);
+
+	if (status->ec == GH__ERROR_CODE__OK)
+		install_loose(&params, status);
+
+cleanup:
+	gh__request_params__release(&params);
+	strbuf_release(&component_url);
+}
+
+/*
+ * Call "gvfs/objects" POST REST API to fetch a packfile containing
+ * the objects in the requested OIDSET.  Returns the filename (not
+ * pathname) to the new packfile.
+ */
+static void do__packfile__gvfs_objects(struct gh__response_status *status,
+				       struct oidset_iter *iter,
+				       unsigned long nr_wanted_in_block,
+				       struct strbuf *output_filename,
+				       unsigned long *nr_taken)
+{
+	struct json_writer jw_req = JSON_WRITER_INIT;
+	struct gh__request_params params = GH__REQUEST_PARAMS_INIT;
+
+	gh__response_status__zero(status);
+
+	params.object_count = build_json_payload__gvfs_objects(
+		&jw_req, iter, nr_wanted_in_block);
+	*nr_taken = params.object_count;
+
+	strbuf_addstr(&params.label, "POST/objects");
+
+	params.b_is_post = 1;
+	params.b_write_to_file = 1;
+	params.b_no_cache_server = 0;
+
+	params.post_payload = &jw_req.json;
+
+	params.headers = http_copy_default_headers();
+	params.headers = curl_slist_append(params.headers,
+					   "X-TFS-FedAuthRedirect: Suppress");
+	params.headers = curl_slist_append(params.headers,
+					   "Pragma: no-cache");
+	params.headers = curl_slist_append(params.headers,
+					   "Content-Type: application/json");
+	/*
+	 * We really always want a packfile.  But if the payload only
+	 * requests 1 OID, the server will/may send us a single loose
+	 * objects instead.  (Apparently the server ignores us when we
+	 * only send application/x-git-packfile and does it anyway.)
+	 *
+	 * So to make it clear to my future self, go ahead and add
+	 * an accept header for loose objects and own it.
+	 */
+	params.headers = curl_slist_append(params.headers,
+					   "Accept: application/x-git-packfile");
+	params.headers = curl_slist_append(params.headers,
+					   "Accept: application/x-git-loose-object");
+
+	params.tempfile = create_tempfile_for_packfile();
+	if (!params.tempfile) {
+		strbuf_addstr(&status->error_message,
+			      "could not create tempfile for packfile");
+		status->ec = GH__ERROR_CODE__COULD_NOT_CREATE_TEMPFILE;
+		goto cleanup;
+	}
+
+	if (gh__cmd_opts.show_progress) {
+		strbuf_addf(&params.progress_base_phase2_msg,
+			    "Requesting packfile with %ld objects",
+			    params.object_count);
+		strbuf_addf(&params.progress_base_phase3_msg,
+			    "Receiving packfile with %ld objects",
+			    params.object_count);
+	}
+
+	do_req__with_fallback("gvfs/objects", &params, status);
+
+	if (status->ec == GH__ERROR_CODE__OK) {
+		if (!strcmp(status->content_type.buf,
+			    "application/x-git-packfile")) {
+
+			// TODO Consider having a worker thread to manage
+			// TODO running index-pack and then install the
+			// TODO resulting .idx and .pack files.  This would
+			// TODO let us interleave those steps with our thread
+			// TODO fetching the next block of objects from the
+			// TODO server.  (Need to think about how progress
+			// TODO messages from our thread and index-pack
+			// TODO would mesh.)
+			// TODO
+			// TODO But then again, if we hack index-pack to write
+			// TODO to our alternate and stream the data thru it,
+			// TODO it won't matter.
+
+			install_packfile(status, &params.tempfile,
+					 output_filename);
+			goto cleanup;
+		}
+
+		if (!strcmp(status->content_type.buf,
+			    "application/x-git-loose-object"))
+		{
+			/*
+			 * This should not happen (when we request
+			 * more than one object).  The server can send
+			 * us a loose object (even when we use the
+			 * POST form) if there is only one object in
+			 * the payload (and despite the set of accept
+			 * headers we send), so I'm going to leave
+			 * this here.
+			 */
+			strbuf_addstr(&status->error_message,
+				      "received loose object when packfile expected");
+			status->ec = GH__ERROR_CODE__UNEXPECTED_CONTENT_TYPE;
+			goto cleanup;
+		}
+
+		strbuf_addf(&status->error_message,
+			    "received unknown content-type '%s'",
+			    status->content_type.buf);
+		status->ec = GH__ERROR_CODE__UNEXPECTED_CONTENT_TYPE;
+		goto cleanup;
+	}
+
+cleanup:
+	gh__request_params__release(&params);
+	jw_release(&jw_req);
+}
+
+/*
+ * Bulk or individually fetch a list of objects in one or more http requests.
+ * Create one or more packfiles and/or loose objects.
+ *
+ * We accumulate results for each request in `result_list` until we get a
+ * hard error and have to stop.
+ */
+static void do_fetch_oidset(struct gh__response_status *status,
+			    struct oidset *oids,
+			    unsigned long nr_total,
+			    struct string_list *result_list)
+{
+	struct oidset_iter iter;
+	struct strbuf output_filename = STRBUF_INIT;
+	struct strbuf msg = STRBUF_INIT;
+	struct strbuf err404 = STRBUF_INIT;
+	const struct object_id *oid;
+	unsigned long k;
+	unsigned long nr_taken;
+	int had_404 = 0;
+
+	gh__response_status__zero(status);
+	if (!nr_total)
+		return;
+
+	oidset_iter_init(oids, &iter);
+
+	for (k = 0; k < nr_total; k += nr_taken) {
+		if (nr_total - k == 1 || gh__cmd_opts.block_size == 1) {
+			oid = oidset_iter_next(&iter);
+			nr_taken = 1;
+
+			do__loose__gvfs_object(status, oid);
+
+			/*
+			 * If we get a 404 for an individual object, ignore
+			 * it and get the rest.  We'll fixup the 'ec' later.
+			 */
+			if (status->ec == GH__ERROR_CODE__HTTP_404) {
+				if (!err404.len)
+					strbuf_addf(&err404, "%s: loose object %s",
+						    status->error_message.buf,
+						    oid_to_hex(oid));
+				/*
+				 * Mark the fetch as "incomplete", but don't
+				 * stop trying to get other chunks.
+				 */
+				had_404 = 1;
+				continue;
+			}
+
+			if (status->ec != GH__ERROR_CODE__OK) {
+				/* Stop at the first hard error. */
+				strbuf_addf(&status->error_message, ": loose %s",
+					    oid_to_hex(oid));
+				goto cleanup;
+			}
+
+			strbuf_setlen(&msg, 0);
+			strbuf_addf(&msg, "loose %s", oid_to_hex(oid));
+			string_list_append(result_list, msg.buf);
+
+		} else {
+			strbuf_setlen(&output_filename, 0);
+
+			do__packfile__gvfs_objects(status, &iter,
+						   gh__cmd_opts.block_size,
+						   &output_filename,
+						   &nr_taken);
+
+			/*
+			 * Because the oidset iterator has random
+			 * order, it does no good to say the k-th or
+			 * n-th chunk was incomplete; the client
+			 * cannot use that index for anything.
+			 *
+			 * We get a 404 when at least one object in
+			 * the chunk was not found.
+			 *
+			 * TODO Consider various retry strategies (such as
+			 * TODO loose or bisect) on the members within this
+			 * TODO chunk to reduce the impact of the miss.
+			 *
+			 * For now, ignore the 404 and go on to the
+			 * next chunk and then fixup the 'ec' later.
+			 */
+			if (status->ec == GH__ERROR_CODE__HTTP_404) {
+				if (!err404.len)
+					strbuf_addf(&err404,
+						    "%s: packfile object",
+						    status->error_message.buf);
+				/*
+				 * Mark the fetch as "incomplete", but don't
+				 * stop trying to get other chunks.
+				 */
+				had_404 = 1;
+				continue;
+			}
+
+			if (status->ec != GH__ERROR_CODE__OK) {
+				/* Stop at the first hard error. */
+				strbuf_addstr(&status->error_message,
+					      ": in packfile");
+				goto cleanup;
+			}
+
+			strbuf_setlen(&msg, 0);
+			strbuf_addf(&msg, "packfile %s", output_filename.buf);
+			string_list_append(result_list, msg.buf);
+		}
+	}
+
+cleanup:
+	strbuf_release(&msg);
+	strbuf_release(&err404);
+	strbuf_release(&output_filename);
+
+	if (had_404 && status->ec == GH__ERROR_CODE__OK) {
+		strbuf_setlen(&status->error_message, 0);
+		strbuf_addstr(&status->error_message, "404 Not Found");
+		status->ec = GH__ERROR_CODE__HTTP_404;
+	}
+}
+
+/*
+ * Finish with initialization.  This happens after the main option
+ * parsing, dispatch to sub-command, and sub-command option parsing
+ * and before actually doing anything.
+ *
+ * Optionally configure the cache-server if the sub-command will
+ * use it.
+ */
+static void finish_init(int setup_cache_server)
+{
+	select_odb();
+
+	lookup_main_url();
+	gh_http_init();
+
+	if (setup_cache_server)
+		select_cache_server();
+}
+
+/*
+ * Request gvfs/config from main Git server.  (Config data is not
+ * available from a GVFS cache-server.)
+ *
+ * Print the received server configuration (as the raw JSON string).
+ */
+static enum gh__error_code do_sub_cmd__config(int argc, const char **argv)
+{
+	struct gh__response_status status = GH__RESPONSE_STATUS_INIT;
+	struct strbuf config_data = STRBUF_INIT;
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+
+	trace2_cmd_mode("config");
+
+	finish_init(0);
+
+	do__gvfs_config(&status, &config_data);
+	ec = status.ec;
+
+	if (ec == GH__ERROR_CODE__OK)
+		printf("%s\n", config_data.buf);
+	else
+		error("config: %s", status.error_message.buf);
+
+	gh__response_status__release(&status);
+	strbuf_release(&config_data);
+
+	return ec;
+}
+
+/*
+ * Read a list of objects from stdin and fetch them in a single request (or
+ * multiple block-size requests).
+ */
+static enum gh__error_code do_sub_cmd__get(int argc, const char **argv)
+{
+	static struct option get_options[] = {
+		OPT_MAGNITUDE('b', "block-size", &gh__cmd_opts.block_size,
+			      N_("number of objects to request at a time")),
+		OPT_INTEGER('d', "depth", &gh__cmd_opts.depth,
+			    N_("Commit depth")),
+		OPT_END(),
+	};
+
+	struct gh__response_status status = GH__RESPONSE_STATUS_INIT;
+	struct oidset oids = OIDSET_INIT;
+	struct string_list result_list = STRING_LIST_INIT_DUP;
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+	unsigned long nr_total;
+	int k;
+
+	trace2_cmd_mode("get");
+
+	if (argc > 1 && !strcmp(argv[1], "-h"))
+		usage_with_options(get_usage, get_options);
+
+	argc = parse_options(argc, argv, NULL, get_options, get_usage, 0);
+	if (gh__cmd_opts.depth < 1)
+		gh__cmd_opts.depth = 1;
+
+	finish_init(1);
+
+	nr_total = read_stdin_from_rev_list(&oids);
+
+	trace2_region_enter("gvfs-helper", "get", NULL);
+	trace2_data_intmax("gvfs-helper", NULL, "get/nr_objects", nr_total);
+	do_fetch_oidset(&status, &oids, nr_total, &result_list);
+	trace2_region_leave("gvfs-helper", "get", NULL);
+
+	ec = status.ec;
+
+	for (k = 0; k < result_list.nr; k++)
+		printf("%s\n", result_list.items[k].string);
+
+	if (ec != GH__ERROR_CODE__OK)
+		error("get: %s", status.error_message.buf);
+
+	gh__response_status__release(&status);
+	oidset_clear(&oids);
+	string_list_clear(&result_list, 0);
+
+	return ec;
+}
+
+/*
+ * Handle the 'get' command when in "server mode".  Only call error()
+ * for hard errors where we cannot communicate correctly with the foreground
+ * client process.  Pass any actual data errors (such as 404's or 401's from
+ * the fetch back to the client process.
+ */
+static enum gh__error_code do_server_subprocess_get(void)
+{
+	struct gh__response_status status = GH__RESPONSE_STATUS_INIT;
+	struct oidset oids = OIDSET_INIT;
+	struct object_id oid;
+	struct string_list result_list = STRING_LIST_INIT_DUP;
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+	char *line;
+	int len;
+	int err;
+	int k;
+	unsigned long nr_total = 0;
+
+	/*
+	 * Inside the "get" command, we expect a list of OIDs
+	 * and a flush.
+	 */
+	while (1) {
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line)
+			break;
+
+		if (get_oid_hex(line, &oid)) {
+			error("server: invalid oid syntax '%s'", line);
+			ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+			goto cleanup;
+		}
+
+		if (!oidset_insert(&oids, &oid))
+			nr_total++;
+	}
+
+	if (!nr_total) {
+		if (packet_write_fmt_gently(1, "ok\n")) {
+			error("server: cannot write 'get' result to client");
+			ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		} else
+			ec = GH__ERROR_CODE__OK;
+		goto cleanup;
+	}
+
+	trace2_region_enter("gvfs-helper", "server/get", NULL);
+	trace2_data_intmax("gvfs-helper", NULL, "server/get/nr_objects", nr_total);
+	do_fetch_oidset(&status, &oids, nr_total, &result_list);
+	trace2_region_leave("gvfs-helper", "server/get", NULL);
+
+	/*
+	 * Write pathname of the ODB where we wrote all of the objects
+	 * we fetched.
+	 */
+	if (packet_write_fmt_gently(1, "odb %s\n",
+				    gh__global.buf_odb_path.buf)) {
+		error("server: cannot write 'odb' to client");
+		ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		goto cleanup;
+	}
+	
+	for (k = 0; k < result_list.nr; k++)
+		if (packet_write_fmt_gently(1, "%s\n",
+					    result_list.items[k].string))
+		{
+			error("server: cannot write result to client: '%s'",
+			      result_list.items[k].string);
+			ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+			goto cleanup;
+		}
+
+	err = 0;
+	if (ec == GH__ERROR_CODE__OK)
+		err = packet_write_fmt_gently(1, "ok\n");
+	else if (ec == GH__ERROR_CODE__HTTP_404)
+		err = packet_write_fmt_gently(1, "partial\n");
+	else
+		err = packet_write_fmt_gently(1, "error %s\n",
+					      status.error_message.buf);
+	if (err) {
+		error("server: cannot write result to client");
+		ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		goto cleanup;
+	}
+
+	if (packet_flush_gently(1)) {
+		error("server: cannot flush result to client");
+		ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		goto cleanup;
+	}
+
+cleanup:
+	oidset_clear(&oids);
+	string_list_clear(&result_list, 0);
+
+	return ec;
+}
+
+typedef enum gh__error_code (fn_subprocess_cmd)(void);
+
+struct subprocess_capability {
+	const char *name;
+	int client_has;
+	fn_subprocess_cmd *pfn;
+};
+
+static struct subprocess_capability caps[] = {
+	{ "get", 0, do_server_subprocess_get },
+	{ NULL, 0, NULL },
+};
+
+/*
+ * Handle the subprocess protocol handshake as described in:
+ * [] Documentation/technical/protocol-common.txt
+ * [] Documentation/technical/long-running-process-protocol.txt
+ */
+static int do_protocol_handshake(void)
+{
+#define OUR_SUBPROCESS_VERSION "1"
+
+	char *line;
+	int len;
+	int k;
+	int b_support_our_version = 0;
+
+	len = packet_read_line_gently(0, NULL, &line);
+	if (len < 0 || !line || strcmp(line, "gvfs-helper-client")) {
+		error("server: subprocess welcome handshake failed: %s", line);
+		return -1;
+	}
+
+	while (1) {
+		const char *v;
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line)
+			break;
+		if (!skip_prefix(line, "version=", &v)) {
+			error("server: subprocess version handshake failed: %s",
+			      line);
+			return -1;
+		}
+		b_support_our_version |= (!strcmp(v, OUR_SUBPROCESS_VERSION));
+	}
+	if (!b_support_our_version) {
+		error("server: client does not support our version: %s",
+		      OUR_SUBPROCESS_VERSION);
+		return -1;
+	}
+
+	if (packet_write_fmt_gently(1, "gvfs-helper-server\n") ||
+	    packet_write_fmt_gently(1, "version=%s\n",
+				    OUR_SUBPROCESS_VERSION) ||
+	    packet_flush_gently(1)) {
+		error("server: cannot write version handshake");
+		return -1;
+	}
+
+	while (1) {
+		const char *v;
+		int k;
+
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line)
+			break;
+		if (!skip_prefix(line, "capability=", &v)) {
+			error("server: subprocess capability handshake failed: %s",
+			      line);
+			return -1;
+		}
+		for (k = 0; caps[k].name; k++)
+			if (!strcmp(v, caps[k].name))
+				caps[k].client_has = 1;
+	}
+
+	for (k = 0; caps[k].name; k++)
+		if (caps[k].client_has)
+			if (packet_write_fmt_gently(1, "capability=%s\n",
+						    caps[k].name)) {
+				error("server: cannot write capabilities handshake: %s",
+				      caps[k].name);
+				return -1;
+			}
+	if (packet_flush_gently(1)) {
+		error("server: cannot write capabilities handshake");
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Interactively listen to stdin for a series of commands and execute them.
+ */
+static enum gh__error_code do_sub_cmd__server(int argc, const char **argv)
+{
+	static struct option server_options[] = {
+		OPT_MAGNITUDE('b', "block-size", &gh__cmd_opts.block_size,
+			      N_("number of objects to request at a time")),
+		OPT_INTEGER('d', "depth", &gh__cmd_opts.depth,
+			    N_("Commit depth")),
+		OPT_END(),
+	};
+
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+	char *line;
+	int len;
+	int k;
+
+	trace2_cmd_mode("server");
+
+	if (argc > 1 && !strcmp(argv[1], "-h"))
+		usage_with_options(server_usage, server_options);
+
+	argc = parse_options(argc, argv, NULL, server_options, server_usage, 0);
+	if (gh__cmd_opts.depth < 1)
+		gh__cmd_opts.depth = 1;
+
+	finish_init(1);
+
+	if (do_protocol_handshake()) {
+		ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		goto cleanup;
+	}
+
+top_of_loop:
+	while (1) {
+		len = packet_read_line_gently(0, NULL, &line);
+		if (len < 0 || !line) {
+			/* use extra FLUSH as a QUIT */
+			ec = GH__ERROR_CODE__OK;
+			goto cleanup;
+		}
+
+		for (k = 0; caps[k].name; k++) {
+			if (caps[k].client_has && !strcmp(line, caps[k].name)) {
+				ec = (caps[k].pfn)();
+				if (ec != GH__ERROR_CODE__OK)
+					goto cleanup;
+				goto top_of_loop;
+			}
+		}
+
+		error("server: unknown command '%s'", line);
+		ec = GH__ERROR_CODE__SUBPROCESS_SYNTAX;
+		goto cleanup;
+	}
+
+cleanup:
+	return ec;
+}
+
+static enum gh__error_code do_sub_cmd(int argc, const char **argv)
+{
+	if (!strcmp(argv[0], "get"))
+		return do_sub_cmd__get(argc, argv);
+
+	if (!strcmp(argv[0], "config"))
+		return do_sub_cmd__config(argc, argv);
+
+	if (!strcmp(argv[0], "server"))
+		return do_sub_cmd__server(argc, argv);
+
+	// TODO have "test" mode that could be used to drive
+	// TODO unit testing.
+
+	return GH__ERROR_CODE__USAGE;
+}
+
+/*
+ * Communicate with the primary Git server or a GVFS cache-server using the
+ * GVFS Protocol.
+ *
+ * https://github.com/microsoft/VFSForGit/blob/master/Protocol.md
+ */
+int cmd_main(int argc, const char **argv)
+{
+	static struct option main_options[] = {
+		OPT_STRING('r', "remote", &gh__cmd_opts.remote_name,
+			   N_("remote"),
+			   N_("Remote name")),
+		OPT_BOOL('f', "fallback", &gh__cmd_opts.try_fallback,
+			 N_("Fallback to Git server if cache-server fails")),
+		OPT_CALLBACK(0, "cache-server", NULL,
+			     N_("cache-server"),
+			     N_("cache-server=disable|trust|verify|error"),
+			     option_parse_cache_server_mode),
+		OPT_CALLBACK(0, "shared-cache", NULL,
+			     N_("pathname"),
+			     N_("Pathname to shared objects directory"),
+			     option_parse_shared_cache_directory),
+		OPT_BOOL('p', "progress", &gh__cmd_opts.show_progress,
+			 N_("Show progress")),
+		OPT_END(),
+	};
+
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+
+	if (argc > 1 && !strcmp(argv[1], "-h"))
+		usage_with_options(main_usage, main_options);
+
+	trace2_cmd_name("gvfs-helper");
+
+	setup_git_directory_gently(NULL);
+
+	git_config(git_default_config, NULL);
+
+	/* Set any non-zero initial values in gh__cmd_opts. */
+	gh__cmd_opts.depth = 1;
+	gh__cmd_opts.block_size = GH__DEFAULT_BLOCK_SIZE;
+	gh__cmd_opts.show_progress = !!isatty(2);
+
+	argc = parse_options(argc, argv, NULL, main_options, main_usage,
+			     PARSE_OPT_STOP_AT_NON_OPTION);
+	if (argc == 0)
+		usage_with_options(main_usage, main_options);
+
+	ec = do_sub_cmd(argc, argv);
+
+	gh_http_cleanup();
+
+	if (ec == GH__ERROR_CODE__USAGE)
+		usage_with_options(main_usage, main_options);
+
+	return ec;
+}

--- a/object-store.h
+++ b/object-store.h
@@ -56,6 +56,14 @@ void add_to_alternates_memory(const char *dir);
 struct oid_array *odb_loose_cache(struct object_directory *odb,
 				  const struct object_id *oid);
 
+/*
+ * Add a new object to the loose object cache (possibly after the
+ * cache was populated).  This might be used after dynamically
+ * fetching a missing object.
+ */
+void odb_loose_cache_add_new_oid(struct object_directory *odb,
+				 const struct object_id *oid);
+
 /* Empty the loose object cache for the specified object directory. */
 void odb_clear_loose_cache(struct object_directory *odb);
 

--- a/packfile.c
+++ b/packfile.c
@@ -759,6 +759,12 @@ void install_packed_git(struct repository *r, struct packed_git *pack)
 	r->objects->packed_git = pack;
 }
 
+void install_packed_git_and_mru(struct repository *r, struct packed_git *pack)
+{
+	install_packed_git(r, pack);
+	list_add(&pack->mru, &r->objects->packed_git_mru);
+}
+
 void (*report_garbage)(unsigned seen_bits, const char *path);
 
 static void report_helper(const struct string_list *list,

--- a/packfile.h
+++ b/packfile.h
@@ -53,6 +53,7 @@ extern void (*report_garbage)(unsigned seen_bits, const char *path);
 
 void reprepare_packed_git(struct repository *r);
 void install_packed_git(struct repository *r, struct packed_git *pack);
+void install_packed_git_and_mru(struct repository *r, struct packed_git *pack);
 
 struct packed_git *get_packed_git(struct repository *r);
 struct list_head *get_packed_git_mru(struct repository *r);

--- a/promisor-remote.c
+++ b/promisor-remote.c
@@ -3,6 +3,7 @@
 #include "promisor-remote.h"
 #include "config.h"
 #include "transport.h"
+#include "gvfs-helper-client.h"
 
 static char *repository_format_partial_clone;
 static const char *core_partial_clone_filter_default;
@@ -39,6 +40,7 @@ static int fetch_objects(const char *remote_name,
 {
 	struct ref *ref = NULL;
 	int i;
+
 
 	for (i = 0; i < oid_nr; i++) {
 		struct ref *new_ref = alloc_ref(oid_to_hex(&oids[i]));
@@ -199,7 +201,7 @@ struct promisor_remote *promisor_remote_find(const char *remote_name)
 
 int has_promisor_remote(void)
 {
-	return !!promisor_remote_find(NULL);
+	return core_use_gvfs_helper || !!promisor_remote_find(NULL);
 }
 
 static int remove_fetched_oids(struct repository *repo,
@@ -243,6 +245,14 @@ int promisor_remote_get_direct(struct repository *repo,
 	int remaining_nr = oid_nr;
 	int to_free = 0;
 	int res = -1;
+
+	if (core_use_gvfs_helper) {
+		enum gh_client__created ghc = GHC__CREATED__NOTHING;
+
+		trace2_data_intmax("bug", the_repository, "fetch_objects/gvfs-helper", oid_nr);
+		gh_client__queue_oid_array(oids, oid_nr);
+		return gh_client__drain_queue(&ghc);
+	}
 
 	promisor_remote_init();
 

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -35,6 +35,7 @@
 #include "sigchain.h"
 #include "sub-process.h"
 #include "pkt-line.h"
+#include "gvfs-helper-client.h"
 
 /* The maximum size for an object header. */
 #define MAX_HEADER_LEN 32
@@ -1556,6 +1557,7 @@ int oid_object_info_extended(struct repository *r, const struct object_id *oid,
 	const struct object_id *real = oid;
 	int already_retried = 0;
 	int tried_hook = 0;
+	int tried_gvfs_helper = 0;
 
 	if (flags & OBJECT_INFO_LOOKUP_REPLACE)
 		real = lookup_replace_object(r, oid);
@@ -1598,13 +1600,41 @@ retry:
 		if (!loose_object_info(r, real, oi, flags))
 			return 0;
 
+		if (core_use_gvfs_helper && !tried_gvfs_helper) {
+			enum ghc__created ghc;
+
+			if (flags & OBJECT_INFO_SKIP_FETCH_OBJECT)
+				return -1;
+
+			ghc__get_immediate(real, &ghc);
+			tried_gvfs_helper = 1;
+
+			/*
+			 * Retry the lookup IIF `gvfs-helper` created one
+			 * or more new packfiles or loose objects.
+			 */
+			if (ghc != GHC__CREATED__NOTHING)
+				continue;
+
+			/*
+			 * If `gvfs-helper` fails, we just want to return -1.
+			 * But allow the other providers to have a shot at it.
+			 * (At least until we have a chance to consolidate
+			 * them.)
+			 */
+		}
+
 		/* Not a loose object; someone else may have just packed it. */
 		if (!(flags & OBJECT_INFO_QUICK)) {
 			reprepare_packed_git(r);
 			if (find_pack_entry(r, real, &e))
 				break;
 			if (core_virtualize_objects && !tried_hook) {
+				// TODO Assert or at least trace2 if gvfs-helper
+				// TODO was tried and failed and then read-object-hook
+				// TODO is successful at getting this object.
 				tried_hook = 1;
+				// TODO BUG? Should 'oid' be 'real' ?
 				if (!read_object_process(oid))
 					goto retry;
 			}

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -1676,12 +1676,12 @@ retry:
 			return 0;
 
 		if (core_use_gvfs_helper && !tried_gvfs_helper) {
-			enum ghc__created ghc;
+			enum gh_client__created ghc;
 
 			if (flags & OBJECT_INFO_SKIP_FETCH_OBJECT)
 				return -1;
 
-			ghc__get_immediate(real, &ghc);
+			gh_client__get_immediate(real, &ghc);
 			tried_gvfs_helper = 1;
 
 			/*

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -2482,6 +2482,39 @@ struct oid_array *odb_loose_cache(struct object_directory *odb,
 	return &odb->loose_objects_cache[subdir_nr];
 }
 
+void odb_loose_cache_add_new_oid(struct object_directory *odb,
+				 const struct object_id *oid)
+{
+	int subdir_nr = oid->hash[0];
+
+	if (subdir_nr < 0 ||
+	    subdir_nr >= ARRAY_SIZE(odb->loose_objects_subdir_seen))
+		BUG("subdir_nr out of range");
+
+	/*
+	 * If the looose object cache already has an oid_array covering
+	 * cell [xx], we assume that the cache was loaded *before* the
+	 * new object was created, so we just need to append our new one
+	 * to the existing array.
+	 *
+	 * Otherwise, cause the [xx] cell to be created by scanning the
+	 * directory.  And since this happens *after* our caller created
+	 * the loose object, we don't need to explicitly add it to the
+	 * array.
+	 *
+	 * TODO If the subdir has not been seen, we don't technically
+	 * TODO need to force load it now.  We could wait and let our
+	 * TODO caller (or whoever requested the missing object) cause
+	 * TODO try to read the xx/ object and fill the cache.
+	 * TODO Not sure it matters either way.
+	 */
+	if (odb->loose_objects_subdir_seen[subdir_nr])
+		append_loose_object(oid, NULL,
+				    &odb->loose_objects_cache[subdir_nr]);
+	else
+		odb_loose_cache(odb, oid);
+}
+
 void odb_clear_loose_cache(struct object_directory *odb)
 {
 	int i;

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -442,6 +442,8 @@ const char *loose_object_path(struct repository *r, struct strbuf *buf,
 	return odb_loose_path(r->objects->odb, buf, oid);
 }
 
+static int gvfs_matched_shared_cache_to_alternate;
+
 /*
  * Return non-zero iff the path is usable as an alternate object database.
  */
@@ -450,6 +452,52 @@ static int alt_odb_usable(struct raw_object_store *o,
 			  const char *normalized_objdir)
 {
 	struct object_directory *odb;
+
+	if (!strbuf_cmp(path, &gvfs_shared_cache_pathname)) {
+		/*
+		 * `gvfs.sharedCache` is the preferred alternate that we
+		 * will use with `gvfs-helper.exe` to dynamically fetch
+		 * missing objects.  It is set during git_default_config().
+		 *
+		 * Make sure the directory exists on disk before we let the
+		 * stock code discredit it.
+		 */
+		struct strbuf buf_pack_foo = STRBUF_INIT;
+		enum scld_error scld;
+
+		/*
+		 * Force create the "<odb>" and "<odb>/pack" directories, if
+		 * not present on disk.  Append an extra bogus directory to
+		 * get safe_create_leading_directories() to see "<odb>/pack"
+		 * as a leading directory of something deeper (which it
+		 * won't create).
+		 */
+		strbuf_addf(&buf_pack_foo, "%s/pack/foo", path->buf);
+
+		scld = safe_create_leading_directories(buf_pack_foo.buf);
+		if (scld != SCLD_OK && scld != SCLD_EXISTS) {
+			error_errno(_("could not create shared-cache ODB '%s'"),
+				    gvfs_shared_cache_pathname.buf);
+
+			strbuf_release(&buf_pack_foo);
+
+			/*
+			 * Pretend no shared-cache was requested and
+			 * effectively fallback to ".git/objects" for
+			 * fetching missing objects.
+			 */
+			strbuf_release(&gvfs_shared_cache_pathname);
+			return 0;
+		}
+
+		/*
+		 * We know that there is an alternate (either from
+		 * .git/objects/info/alternates or from a memory-only
+		 * entry) associated with the shared-cache directory.
+		 */
+		gvfs_matched_shared_cache_to_alternate++;
+		strbuf_release(&buf_pack_foo);
+	}
 
 	/* Detect cases where alternate disappeared */
 	if (!is_directory(path->buf)) {
@@ -866,6 +914,33 @@ void prepare_alt_odb(struct repository *r)
 	link_alt_odb_entries(r, r->objects->alternate_db, PATH_SEP, NULL, 0);
 
 	read_info_alternates(r, r->objects->odb->path, 0);
+
+	if (gvfs_shared_cache_pathname.len &&
+	    !gvfs_matched_shared_cache_to_alternate) {
+		/*
+		 * There is no entry in .git/objects/info/alternates for
+		 * the requested shared-cache directory.  Therefore, the
+		 * odb-list does not contain this directory.
+		 *
+		 * Force this directory into the odb-list as an in-memory
+		 * alternate.  Implicitly create the directory on disk, if
+		 * necessary.
+		 *
+		 * See GIT_ALTERNATE_OBJECT_DIRECTORIES for another example
+		 * of this kind of usage.
+		 *
+		 * Note: This has the net-effect of allowing Git to treat
+		 * `gvfs.sharedCache` as an unofficial alternate.  This
+		 * usage should be discouraged for compatbility reasons
+		 * with other tools in the overall Git ecosystem (that
+		 * won't know about this trick).  It would be much better
+		 * for us to update .git/objects/info/alternates instead.
+		 * The code here is considered a backstop.
+		 */
+		link_alt_odb_entries(r, gvfs_shared_cache_pathname.buf,
+				     '\n', NULL, 0);
+	}
+
 	r->objects->loaded_alternates = 1;
 }
 

--- a/sub-process.c
+++ b/sub-process.c
@@ -80,7 +80,12 @@ int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, co
 	int err;
 	struct child_process *process;
 
-	entry->cmd = cmd;
+	// BUGBUG most callers to subprocess_start() pass in "cmd" the value
+	// BUGBUG of find_hook() which returns a static buffer (that's only
+	// BUGBUG good until the next call to find_hook()).
+	// BUGFIX Defer assignment until we copy the string in our argv.
+	// entry->cmd = cmd;
+
 	process = &entry->process;
 
 	child_process_init(process);
@@ -91,6 +96,8 @@ int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, co
 	process->clean_on_exit = 1;
 	process->clean_on_exit_handler = subprocess_exit_handler;
 	process->trace2_child_class = "subprocess";
+
+	entry->cmd = process->args.argv[0];
 
 	err = start_command(process);
 	if (err) {

--- a/sub-process.h
+++ b/sub-process.h
@@ -57,6 +57,12 @@ typedef int(*subprocess_start_fn)(struct subprocess_entry *entry);
 int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, const char *cmd,
 		subprocess_start_fn startfn);
 
+int subprocess_start_argv(struct hashmap *hashmap,
+			  struct subprocess_entry *entry,
+			  int is_git_cmd,
+			  const struct argv_array *argv,
+			  subprocess_start_fn startfn);
+
 /* Kill a subprocess and remove it from the subprocess hashmap. */
 void subprocess_stop(struct hashmap *hashmap, struct subprocess_entry *entry);
 

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -96,4 +96,36 @@ test_expect_success 'clone --sparse' '
 	test_cmp expect dir
 '
 
+test_expect_success 'set enables config' '
+	git init empty-config &&
+	(
+		cd empty-config &&
+		test_commit test file &&
+		test_path_is_missing .git/config.worktree &&
+		test_must_fail git sparse-checkout set nothing &&
+		test_i18ngrep "sparseCheckout = false" .git/config.worktree &&
+		git sparse-checkout set "/*" &&
+		test_i18ngrep "sparseCheckout = true" .git/config.worktree
+	)
+'
+
+test_expect_success 'set sparse-checkout using builtin' '
+	git -C repo sparse-checkout set "/*" "!/*/" "*folder*" &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+		*folder*
+	EOF
+	git -C repo sparse-checkout list >actual &&
+	test_cmp expect actual &&
+	test_cmp expect repo/.git/info/sparse-checkout &&
+	ls repo >dir  &&
+	cat >expect <<-EOF &&
+		a
+		folder1
+		folder2
+	EOF
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -276,4 +276,11 @@ test_expect_success 'revert to old sparse-checkout on empty update' '
 	)
 '
 
+test_expect_success 'fail when lock is taken' '
+	test_when_finished rm -rf repo/.git/info/sparse-checkout.lock &&
+	touch repo/.git/info/sparse-checkout.lock &&
+	test_must_fail git -C repo sparse-checkout set deep 2>err &&
+	test_i18ngrep "File exists" err
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -237,4 +237,15 @@ test_expect_success 'cone mode: init and set' '
 	test_cmp expect dir
 '
 
+test_expect_success 'cone mode: set with nested folders' '
+	git -C repo sparse-checkout set deep deep/deeper1/deepest 2>err &&
+	test_line_count = 0 err &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+		/deep/
+	EOF
+	test_cmp repo/.git/info/sparse-checkout expect
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -128,4 +128,24 @@ test_expect_success 'set sparse-checkout using builtin' '
 	test_cmp expect dir
 '
 
+test_expect_success 'set sparse-checkout using --stdin' '
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+		/folder1/
+		/folder2/
+	EOF
+	git -C repo sparse-checkout set --stdin <expect &&
+	git -C repo sparse-checkout list >actual &&
+	test_cmp expect actual &&
+	test_cmp expect repo/.git/info/sparse-checkout &&
+	ls repo >dir  &&
+	cat >expect <<-EOF &&
+		a
+		folder1
+		folder2
+	EOF
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -83,4 +83,17 @@ test_expect_success 'init with existing sparse-checkout' '
 	test_cmp expect dir
 '
 
+test_expect_success 'clone --sparse' '
+	git clone --sparse repo clone &&
+	git -C clone sparse-checkout list >actual &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+	EOF
+	test_cmp expect actual &&
+	ls clone >dir &&
+	echo a >expect &&
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -42,4 +42,45 @@ test_expect_success 'git sparse-checkout list (populated)' '
 	test_cmp expect list
 '
 
+test_expect_success 'git sparse-checkout init' '
+	git -C repo sparse-checkout init &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+	EOF
+	test_cmp expect repo/.git/info/sparse-checkout &&
+	git -C repo config --list >config &&
+	test_i18ngrep "core.sparsecheckout=true" config &&
+	ls repo >dir  &&
+	echo a >expect &&
+	test_cmp expect dir
+'
+
+test_expect_success 'git sparse-checkout list after init' '
+	git -C repo sparse-checkout list >actual &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+	EOF
+	test_cmp expect actual
+'
+
+test_expect_success 'init with existing sparse-checkout' '
+	echo "*folder*" >> repo/.git/info/sparse-checkout &&
+	git -C repo sparse-checkout init &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+		*folder*
+	EOF
+	test_cmp expect repo/.git/info/sparse-checkout &&
+	ls repo >dir  &&
+	cat >expect <<-EOF &&
+		a
+		folder1
+		folder2
+	EOF
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -148,6 +148,20 @@ test_expect_success 'set sparse-checkout using --stdin' '
 	test_cmp expect dir
 '
 
+test_expect_success 'cone mode: match patterns' '
+	git -C repo config --worktree core.sparseCheckoutCone true &&
+	rm -rf repo/a repo/folder1 repo/folder2 &&
+	git -C repo read-tree -mu HEAD &&
+	git -C repo reset --hard &&
+	ls repo >dir  &&
+	cat >expect <<-EOF &&
+		a
+		folder1
+		folder2
+	EOF
+	test_cmp expect dir
+'
+
 test_expect_success 'sparse-checkout disable' '
 	git -C repo sparse-checkout disable &&
 	test_path_is_missing repo/.git/info/sparse-checkout &&

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -283,4 +283,11 @@ test_expect_success 'fail when lock is taken' '
 	test_i18ngrep "File exists" err
 '
 
+test_expect_success '.gitignore should not warn about cone mode' '
+	git -C repo config --worktree core.sparseCheckoutCone true &&
+	echo "**/bin/*" >repo/.gitignore &&
+	git -C repo reset --hard 2>err &&
+	test_i18ngrep ! "disabling cone patterns" err
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -151,7 +151,8 @@ test_expect_success 'set sparse-checkout using --stdin' '
 test_expect_success 'cone mode: match patterns' '
 	git -C repo config --worktree core.sparseCheckoutCone true &&
 	rm -rf repo/a repo/folder1 repo/folder2 &&
-	git -C repo read-tree -mu HEAD &&
+	git -C repo read-tree -mu HEAD 2>err &&
+	test_i18ngrep ! "disabling cone patterns" err &&
 	git -C repo reset --hard &&
 	ls repo >dir  &&
 	cat >expect <<-EOF &&
@@ -160,6 +161,14 @@ test_expect_success 'cone mode: match patterns' '
 		folder2
 	EOF
 	test_cmp expect dir
+'
+
+test_expect_success 'cone mode: warn on bad pattern' '
+	test_when_finished mv sparse-checkout repo/.git/info/ &&
+	cp repo/.git/info/sparse-checkout . &&
+	echo "!/deep/deeper/*" >>repo/.git/info/sparse-checkout &&
+	git -C repo read-tree -mu HEAD 2>err &&
+	test_i18ngrep "unrecognized negative pattern" err
 '
 
 test_expect_success 'sparse-checkout disable' '

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+test_description='sparse checkout builtin tests'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	git init repo &&
+	(
+		cd repo &&
+		echo "initial" >a &&
+		mkdir folder1 folder2 deep &&
+		mkdir deep/deeper1 deep/deeper2 &&
+		mkdir deep/deeper1/deepest &&
+		cp a folder1 &&
+		cp a folder2 &&
+		cp a deep &&
+		cp a deep/deeper1 &&
+		cp a deep/deeper2 &&
+		cp a deep/deeper1/deepest &&
+		git add . &&
+		git commit -m "initial commit"
+	)
+'
+
+test_expect_success 'git sparse-checkout list (empty)' '
+	git -C repo sparse-checkout list >list 2>err &&
+	test_must_be_empty list &&
+	test_i18ngrep "this worktree is not sparse (sparse-checkout file may not exist)" err
+'
+
+test_expect_success 'git sparse-checkout list (populated)' '
+	test_when_finished rm -f repo/.git/info/sparse-checkout &&
+	cat >repo/.git/info/sparse-checkout <<-EOF &&
+		/folder1/*
+		/deep/
+		**/a
+		!*bin*
+	EOF
+	cp repo/.git/info/sparse-checkout expect &&
+	git -C repo sparse-checkout list >list &&
+	test_cmp expect list
+'
+
+test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -186,4 +186,55 @@ test_expect_success 'sparse-checkout disable' '
 	test_cmp expect dir
 '
 
+test_expect_success 'cone mode: init and set' '
+	git -C repo sparse-checkout init --cone &&
+	git -C repo config --list >config &&
+	test_i18ngrep "core.sparsecheckoutcone=true" config &&
+	ls repo >dir  &&
+	echo a >expect &&
+	test_cmp expect dir &&
+	git -C repo sparse-checkout set deep/deeper1/deepest/ 2>err &&
+	test_line_count = 0 err &&
+	ls repo >dir  &&
+	cat >expect <<-EOF &&
+		a
+		deep
+	EOF
+	test_cmp expect dir &&
+	ls repo/deep >dir  &&
+	cat >expect <<-EOF &&
+		a
+		deeper1
+	EOF
+	test_cmp expect dir &&
+	ls repo/deep/deeper1 >dir  &&
+	cat >expect <<-EOF &&
+		a
+		deepest
+	EOF
+	test_cmp expect dir &&
+	cat >expect <<-EOF &&
+		/*
+		!/*/
+		/deep/
+		!/deep/*/
+		/deep/deeper1/
+		!/deep/deeper1/*/
+		/deep/deeper1/deepest/
+	EOF
+	test_cmp expect repo/.git/info/sparse-checkout &&
+	git -C repo sparse-checkout set --stdin 2>err <<-EOF &&
+		folder1
+		folder2
+	EOF
+	test_line_count = 0 err &&
+	cat >expect <<-EOF &&
+		a
+		folder1
+		folder2
+	EOF
+	ls repo >dir &&
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -148,4 +148,19 @@ test_expect_success 'set sparse-checkout using --stdin' '
 	test_cmp expect dir
 '
 
+test_expect_success 'sparse-checkout disable' '
+	git -C repo sparse-checkout disable &&
+	test_path_is_missing repo/.git/info/sparse-checkout &&
+	git -C repo config --list >config &&
+	test_i18ngrep "core.sparsecheckout=false" config &&
+	ls repo >dir &&
+	cat >expect <<-EOF &&
+		a
+		deep
+		folder1
+		folder2
+	EOF
+	test_cmp expect dir
+'
+
 test_done

--- a/t/t7519/fsmonitor-watchman
+++ b/t/t7519/fsmonitor-watchman
@@ -23,7 +23,8 @@ my ($version, $time) = @ARGV;
 
 if ($version == 1) {
 	# convert nanoseconds to seconds
-	$time = int $time / 1000000000;
+	# subtract one second to make sure watchman will return all changes
+	$time = int ($time / 1000000000) - 1;
 } else {
 	die "Unsupported query-fsmonitor hook version '$version'.\n" .
 	    "Falling back to scanning...\n";
@@ -54,18 +55,12 @@ sub launch_watchman {
 	#
 	# To accomplish this, we're using the "since" generator to use the
 	# recency index to select candidate nodes and "fields" to limit the
-	# output to file names only. Then we're using the "expression" term to
-	# further constrain the results.
-	#
-	# The category of transient files that we want to ignore will have a
-	# creation clock (cclock) newer than $time_t value and will also not
-	# currently exist.
+	# output to file names only.
 
 	my $query = <<"	END";
 		["query", "$git_work_tree", {
 			"since": $time,
-			"fields": ["name"],
-			"expression": ["not", ["allof", ["since", $time, "cclock"], ["not", "exists"]]]
+			"fields": ["name"]
 		}]
 	END
 	

--- a/templates/hooks--fsmonitor-watchman.sample
+++ b/templates/hooks--fsmonitor-watchman.sample
@@ -22,7 +22,8 @@ my ($version, $time) = @ARGV;
 
 if ($version == 1) {
 	# convert nanoseconds to seconds
-	$time = int $time / 1000000000;
+	# subtract one second to make sure watchman will return all changes
+	$time = int ($time / 1000000000) - 1;
 } else {
 	die "Unsupported query-fsmonitor hook version '$version'.\n" .
 	    "Falling back to scanning...\n";
@@ -53,18 +54,12 @@ sub launch_watchman {
 	#
 	# To accomplish this, we're using the "since" generator to use the
 	# recency index to select candidate nodes and "fields" to limit the
-	# output to file names only. Then we're using the "expression" term to
-	# further constrain the results.
-	#
-	# The category of transient files that we want to ignore will have a
-	# creation clock (cclock) newer than $time_t value and will also not
-	# currently exist.
+	# output to file names only.
 
 	my $query = <<"	END";
 		["query", "$git_work_tree", {
 			"since": $time,
-			"fields": ["name"],
-			"expression": ["not", ["allof", ["since", $time, "cclock"], ["not", "exists"]]]
+			"fields": ["name"]
 		}]
 	END
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1407,15 +1407,23 @@ static int clear_ce_flags(struct index_state *istate,
 			  struct pattern_list *pl)
 {
 	static struct strbuf prefix = STRBUF_INIT;
+	char label[100];
+	int rval;
 
 	strbuf_reset(&prefix);
 
-	return clear_ce_flags_1(istate,
+	xsnprintf(label, sizeof(label), "clear_ce_flags(0x%08lx,0x%08lx)",
+		  (unsigned long)select_mask, (unsigned long)clear_mask);
+	trace2_region_enter("unpack_trees", label, the_repository);
+	rval = clear_ce_flags_1(istate,
 				istate->cache,
 				istate->cache_nr,
 				&prefix,
 				select_mask, clear_mask,
 				pl, 0);
+	trace2_region_leave("unpack_trees", label, the_repository);
+
+	return rval;
 }
 
 /*

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1511,7 +1511,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	memset(&pl, 0, sizeof(pl));
 	if (!core_apply_sparse_checkout || !o->update)
 		o->skip_sparse_checkout = 1;
-	if (!o->skip_sparse_checkout) {
+	if (!o->skip_sparse_checkout && !o->pl) {
 		char *sparse = git_pathdup("info/sparse-checkout");
 		pl.use_cone_patterns = core_sparse_checkout_cone;
 		if (add_patterns_from_file_to_list(sparse, "", 0, &pl, NULL) < 0)
@@ -1684,7 +1684,8 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 
 done:
 	trace_performance_leave("unpack_trees");
-	clear_pattern_list(&pl);
+	if (!o->keep_pattern_list)
+		clear_pattern_list(&pl);
 	return ret;
 
 return_failed:

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1482,6 +1482,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		o->skip_sparse_checkout = 1;
 	if (!o->skip_sparse_checkout) {
 		char *sparse = git_pathdup("info/sparse-checkout");
+		pl.use_cone_patterns = core_sparse_checkout_cone;
 		if (add_patterns_from_file_to_list(sparse, "", 0, &pl, NULL) < 0)
 			o->skip_sparse_checkout = 1;
 		else

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1269,7 +1269,8 @@ static int clear_ce_flags_1(struct index_state *istate,
 			    struct strbuf *prefix,
 			    int select_mask, int clear_mask,
 			    struct pattern_list *pl,
-			    enum pattern_match_result default_match);
+			    enum pattern_match_result default_match,
+			    int progress_nr);
 
 /* Whole directory matching */
 static int clear_ce_flags_dir(struct index_state *istate,
@@ -1278,7 +1279,8 @@ static int clear_ce_flags_dir(struct index_state *istate,
 			      char *basename,
 			      int select_mask, int clear_mask,
 			      struct pattern_list *pl,
-			      enum pattern_match_result default_match)
+			      enum pattern_match_result default_match,
+			      int progress_nr)
 {
 	struct cache_entry **cache_end;
 	int dtype = DT_DIR;
@@ -1315,7 +1317,8 @@ static int clear_ce_flags_dir(struct index_state *istate,
 		rc = clear_ce_flags_1(istate, cache, cache_end - cache,
 				      prefix,
 				      select_mask, clear_mask,
-				      pl, ret);
+				      pl, ret,
+				      progress_nr);
 	}
 
 	strbuf_setlen(prefix, prefix->len - 1);
@@ -1342,7 +1345,8 @@ static int clear_ce_flags_1(struct index_state *istate,
 			    struct strbuf *prefix,
 			    int select_mask, int clear_mask,
 			    struct pattern_list *pl,
-			    enum pattern_match_result default_match)
+			    enum pattern_match_result default_match,
+			    int progress_nr)
 {
 	struct cache_entry **cache_end = cache + nr;
 
@@ -1356,8 +1360,11 @@ static int clear_ce_flags_1(struct index_state *istate,
 		int len, dtype;
 		enum pattern_match_result ret;
 
+		display_progress(istate->progress, progress_nr);
+
 		if (select_mask && !(ce->ce_flags & select_mask)) {
 			cache++;
+			progress_nr++;
 			continue;
 		}
 
@@ -1378,20 +1385,26 @@ static int clear_ce_flags_1(struct index_state *istate,
 						       prefix,
 						       prefix->buf + prefix->len - len,
 						       select_mask, clear_mask,
-						       pl, default_match);
+						       pl, default_match,
+						       progress_nr);
 
 			/* clear_c_f_dir eats a whole dir already? */
 			if (processed) {
 				cache += processed;
+				progress_nr += processed;
 				strbuf_setlen(prefix, prefix->len - len);
 				continue;
 			}
 
 			strbuf_addch(prefix, '/');
-			cache += clear_ce_flags_1(istate, cache, cache_end - cache,
-						  prefix,
-						  select_mask, clear_mask, pl,
-						  default_match);
+			processed = clear_ce_flags_1(istate, cache, cache_end - cache,
+						     prefix,
+						     select_mask, clear_mask, pl,
+						     default_match, progress_nr);
+
+			cache += processed;
+			progress_nr += processed;
+
 			strbuf_setlen(prefix, prefix->len - len - 1);
 			continue;
 		}
@@ -1406,19 +1419,27 @@ static int clear_ce_flags_1(struct index_state *istate,
 		if (ret == MATCHED)
 			ce->ce_flags &= ~clear_mask;
 		cache++;
+		progress_nr++;
 	}
+
+	display_progress(istate->progress, progress_nr);
 	return nr - (cache_end - cache);
 }
 
 static int clear_ce_flags(struct index_state *istate,
 			  int select_mask, int clear_mask,
-			  struct pattern_list *pl)
+			  struct pattern_list *pl,
+			  int show_progress)
 {
 	static struct strbuf prefix = STRBUF_INIT;
 	char label[100];
 	int rval;
 
 	strbuf_reset(&prefix);
+	if (show_progress)
+		istate->progress = start_delayed_progress(
+					_("Updating index flags"),
+					istate->cache_nr);
 
 	xsnprintf(label, sizeof(label), "clear_ce_flags(0x%08lx,0x%08lx)",
 		  (unsigned long)select_mask, (unsigned long)clear_mask);
@@ -1428,9 +1449,10 @@ static int clear_ce_flags(struct index_state *istate,
 				istate->cache_nr,
 				&prefix,
 				select_mask, clear_mask,
-				pl, 0);
+				pl, 0, 0);
 	trace2_region_leave("unpack_trees", label, the_repository);
 
+	stop_progress(&istate->progress);
 	return rval;
 }
 
@@ -1439,7 +1461,8 @@ static int clear_ce_flags(struct index_state *istate,
  */
 static void mark_new_skip_worktree(struct pattern_list *pl,
 				   struct index_state *istate,
-				   int select_flag, int skip_wt_flag)
+				   int select_flag, int skip_wt_flag,
+				   int show_progress)
 {
 	int i;
 
@@ -1463,7 +1486,7 @@ static void mark_new_skip_worktree(struct pattern_list *pl,
 	 * 2. Widen worktree according to sparse-checkout file.
 	 * Matched entries will have skip_wt_flag cleared (i.e. "in")
 	 */
-	clear_ce_flags(istate, select_flag, skip_wt_flag, pl);
+	clear_ce_flags(istate, select_flag, skip_wt_flag, pl, show_progress);
 }
 
 static int verify_absent(const struct cache_entry *,
@@ -1525,7 +1548,8 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	 * Sparse checkout loop #1: set NEW_SKIP_WORKTREE on existing entries
 	 */
 	if (!o->skip_sparse_checkout)
-		mark_new_skip_worktree(o->pl, o->src_index, 0, CE_NEW_SKIP_WORKTREE);
+		mark_new_skip_worktree(o->pl, o->src_index, 0,
+				       CE_NEW_SKIP_WORKTREE, o->verbose_update);
 
 	if (!dfc)
 		dfc = xcalloc(1, cache_entry_size(0));
@@ -1590,7 +1614,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		 * If the will have NEW_SKIP_WORKTREE, also set CE_SKIP_WORKTREE
 		 * so apply_sparse_checkout() won't attempt to remove it from worktree
 		 */
-		mark_new_skip_worktree(o->pl, &o->result, CE_ADDED, CE_SKIP_WORKTREE | CE_NEW_SKIP_WORKTREE);
+		mark_new_skip_worktree(o->pl, &o->result,
+				       CE_ADDED, CE_SKIP_WORKTREE | CE_NEW_SKIP_WORKTREE,
+				       o->verbose_update);
 
 		ret = 0;
 		for (i = 0; i < o->result.cache_nr; i++) {

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1547,7 +1547,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 	memset(&pl, 0, sizeof(pl));
 	if (!core_apply_sparse_checkout || !o->update)
 		o->skip_sparse_checkout = 1;
-	if (!o->skip_sparse_checkout) {
+	if (!o->skip_sparse_checkout && !o->pl) {
 		if (core_virtualfilesystem) {
 			o->pl = &pl;
 		} else {

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -59,7 +59,8 @@ struct unpack_trees_options {
 		     quiet,
 		     exiting_early,
 		     show_all_errors,
-		     dry_run;
+		     dry_run,
+		     keep_pattern_list;
 	const char *prefix;
 	int cache_bottom;
 	struct dir_struct *dir;


### PR DESCRIPTION
This is a tentative replay of the work in `features/sparse-checkout-2.23.0` on top of `tentative/vfs-2.24.0`.

I had to update our integration point with partial clone since the "multiple promisor remote" feature completely messed up where we were integrating before.

The range-diff shows a lot of dropped merges, dropped old versions of the sparse-checkout feature (in favor of the latest version of `ds/sparse-cone`), and dropped `fixup!` commits (which have been squashed).

Range-diff:
```
 1:  9430147ca0 <  -:  ---------- list-objects-filter: encapsulate filter components
 2:  7a7c7f4a6d <  -:  ---------- list-objects-filter: put omits set in filter struct
 3:  842b00516a <  -:  ---------- list-objects-filter-options: always supply *errbuf
 4:  e987df5fe6 <  -:  ---------- list-objects-filter: implement composite filters
 5:  f56f764279 <  -:  ---------- list-objects-filter-options: move error check up
 6:  cf9ceb5a12 <  -:  ---------- list-objects-filter-options: make filter_spec a string_list
 7:  c2694952e3 <  -:  ---------- strbuf: give URL-encoding API a char predicate fn
 8:  489fc9ee71 <  -:  ---------- list-objects-filter-options: allow mult. --filter
 9:  5a133e8a7f <  -:  ---------- list-objects-filter-options: clean up use of ALLOC_GROW
10:  90d21f9ebf <  -:  ---------- list-objects-filter-options: make parser void
11:  ab2e063cd1 <  -:  ---------- sparse-checkout: create builtin with 'list' subcommand
12:  35700b34c6 <  -:  ---------- sparse-checkout: create 'init' subcommand
13:  4e8e6c314e <  -:  ---------- clone: add --sparse mode
14:  8913c25d23 <  -:  ---------- sparse-checkout: 'add' subcommand
15:  c08d037ac5 <  -:  ---------- sparse-checkout: create 'disable' subcommand
16:  4aee073949 <  -:  ---------- trace2:experiment: clear_ce_flags_1
17:  6c1b7fbdd5 <  -:  ---------- sparse-checkout: add 'cone' mode
18:  79a042c19c <  -:  ---------- sparse-checkout: use hashmaps for cone patterns
19:  19ad979d90 <  -:  ---------- sparse-checkout: init and add in cone mode
20:  40e22538b7 <  -:  ---------- checkout: fix leftover global constant
21:  3025dbde76 <  -:  ---------- unpack-trees: hash less in cone mode
22:  ab8db61390 <  -:  ---------- treewide: rename 'struct exclude' to 'struct path_pattern'
23:  caa3d55444 <  -:  ---------- treewide: rename 'struct exclude_list' to 'struct pattern_list'
24:  4ff89ee52c <  -:  ---------- treewide: rename 'EXCL_FLAG_' to 'PATTERN_FLAG_'
25:  65edd96aec <  -:  ---------- treewide: rename 'exclude' methods to 'pattern'
26:  468ce99b77 <  -:  ---------- unpack-trees: rename 'is_excluded_from_list()'
27:  d90e0a2f53 <  -:  ---------- fixup! DEPRECATION: warn about 'git checkout -b'
28:  193c35218f <  -:  ---------- fixup! Revert "switch: no worktree status unless real branch switch happens"
29:  043dd4781c <  -:  ---------- fixup! Fix reset when using the sparse-checkout feature.
30:  dbaf3de88e !  1:  77844cabe6 sparse-checkout: create builtin with 'list' subcommand
    @@ Commit message
         builtin will be the preferred mechanism for manipulating the
         sparse-checkout file and syncing the working directory.
     
    -    The `$GIT_DIR/info/sparse-checkout` file defines the skip-
    -    worktree reference bitmap. When Git updates the working
    -    directory, it updates the skip-worktree bits in the index
    -    based on this file and removes or restores files in the
    -    working copy to match.
    -
         The documentation provided is adapted from the "git read-tree"
         documentation with a few edits for clarity in the new context.
         Extra sections are added to hint toward a future change to
    @@ Commit message
     
         Helped-by: Elijah Newren <newren@gmail.com>
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## .gitignore ##
     @@
    @@ Documentation/git-read-tree.txt: support.
      ## Documentation/git-sparse-checkout.txt (new) ##
     @@
     +git-sparse-checkout(1)
    -+=======================
    ++======================
     +
     +NAME
     +----
    @@ Documentation/git-sparse-checkout.txt (new)
     +Initialize and modify the sparse-checkout configuration, which reduces
     +the checkout to a set of directories given by a list of prefixes.
     +
    ++THIS COMMAND IS EXPERIMENTAL. ITS BEHAVIOR, AND THE BEHAVIOR OF OTHER
    ++COMMANDS IN THE PRESENCE OF SPARSE-CHECKOUTS, WILL LIKELY CHANGE IN
    ++THE FUTURE.
    ++
     +
     +COMMANDS
     +--------
    @@ Documentation/git-sparse-checkout.txt (new)
     +
     +
     +SPARSE CHECKOUT
    -+----------------
    ++---------------
     +
     +"Sparse checkout" allows populating the working directory sparsely.
     +It uses the skip-worktree bit (see linkgit:git-update-index[1]) to tell
    @@ Documentation/git-sparse-checkout.txt (new)
     +
     +The `$GIT_DIR/info/sparse-checkout` file is used to define the
     +skip-worktree reference bitmap. When Git updates the working
    -+directory, it resets the skip-worktree bit in the index based on this
    -+file. If an entry
    -+matches a pattern in this file, skip-worktree will not be set on
    -+that entry. Otherwise, skip-worktree will be set.
    -+
    -+Then it compares the new skip-worktree value with the previous one. If
    -+skip-worktree turns from set to unset, it will add the corresponding
    -+file back. If it turns from unset to set, that file will be removed.
    ++directory, it updates the skip-worktree bits in the index based
    ++on this file. The files matching the patterns in the file will
    ++appear in the working directory, and the rest will not.
     +
     +## FULL PATTERN SET
     +
    @@ Documentation/git-sparse-checkout.txt (new)
     +----------------
     +
     +Then you can disable sparse checkout. Sparse checkout support in 'git
    -+read-tree' and similar commands is disabled by default. You need to
    ++checkout' and similar commands is disabled by default. You need to
     +set `core.sparseCheckout` to `true` in order to have sparse checkout
     +support.
     +
    @@ builtin/sparse-checkout.c (new)
     +#include "strbuf.h"
     +
     +static char const * const builtin_sparse_checkout_usage[] = {
    -+	N_("git sparse-checkout [list]"),
    ++	N_("git sparse-checkout list"),
     +	NULL
     +};
     +
    @@ builtin/sparse-checkout.c (new)
     +			   builtin_sparse_checkout_options);
     +}
     
    + ## command-list.txt ##
    +@@ command-list.txt: git-show-index                          plumbinginterrogators
    + git-show-ref                            plumbinginterrogators
    + git-sh-i18n                             purehelpers
    + git-sh-setup                            purehelpers
    ++git-sparse-checkout                     mainporcelain           worktree
    + git-stash                               mainporcelain
    + git-stage                                                               complete
    + git-status                              mainporcelain           info
    +
      ## git.c ##
     @@ git.c: static struct cmd_struct commands[] = {
      	{ "show-branch", cmd_show_branch, RUN_SETUP },
    @@ t/t1091-sparse-checkout-builtin.sh (new)
     +
     +test_expect_success 'git sparse-checkout list (empty)' '
     +	git -C repo sparse-checkout list >list 2>err &&
    -+	test_line_count = 0 list &&
    ++	test_must_be_empty list &&
     +	test_i18ngrep "this worktree is not sparse (sparse-checkout file may not exist)" err
     +'
     +
    @@ t/t1091-sparse-checkout-builtin.sh (new)
     +		**/a
     +		!*bin*
     +	EOF
    ++	cp repo/.git/info/sparse-checkout expect &&
     +	git -C repo sparse-checkout list >list &&
    -+	cat >expect <<-EOF &&
    -+		/folder1/*
    -+		/deep/
    -+		**/a
    -+		!*bin*
    -+	EOF
     +	test_cmp expect list
     +'
     +
     +test_done
    -+
31:  412211f5dd !  2:  7e12ce4c40 sparse-checkout: create 'init' subcommand
    @@ Commit message
         an initial set of patterns to the sparse-checkout file, and update
         their working directory.
     
    -    Using 'git read-tree' to clear directories does not work cleanly
    -    on Windows, so manually delete directories that are tracked by Git
    -    before running read-tree.
    +    Make sure to use the `extensions.worktreeConfig` setting and write
    +    the sparse checkout config to the worktree-specific config file.
    +    This avoids confusing interactions with other worktrees.
     
    -    The use of running another process for 'git read-tree' is likely
    -    suboptimal, but that can be improved in a later change, if valuable.
    +    The use of running another process for 'git read-tree' is sub-
    +    optimal. This will be removed in a later change.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## Documentation/git-sparse-checkout.txt ##
     @@ Documentation/git-sparse-checkout.txt: COMMANDS
    @@ Documentation/git-sparse-checkout.txt: COMMANDS
     +	no other directories, then will remove all directories tracked
     +	by Git. Add patterns to the sparse-checkout file to
     +	repopulate the working directory.
    +++
    ++To avoid interfering with other worktrees, it first enables the
    ++`extensions.worktreeConfig` setting and makes sure to set the
    ++`core.sparseCheckout` setting in the worktree-specific config file.
      
      SPARSE CHECKOUT
    - ----------------
    + ---------------
     
      ## builtin/sparse-checkout.c ##
     @@
      #include "strbuf.h"
      
      static char const * const builtin_sparse_checkout_usage[] = {
    --	N_("git sparse-checkout [list]"),
    -+	N_("git sparse-checkout [init|list]"),
    +-	N_("git sparse-checkout list"),
    ++	N_("git sparse-checkout (init|list)"),
      	NULL
      };
      
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     +	return result;
     +}
     +
    -+static int sc_enable_config(void)
    ++enum sparse_checkout_mode {
    ++	MODE_NO_PATTERNS = 0,
    ++	MODE_ALL_PATTERNS = 1,
    ++};
    ++
    ++static int sc_set_config(enum sparse_checkout_mode mode)
     +{
     +	struct argv_array argv = ARGV_ARRAY_INIT;
     +
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     +		return 1;
     +	}
     +
    -+	argv_array_pushl(&argv, "config", "--worktree", "core.sparseCheckout", "true", NULL);
    ++	argv_array_pushl(&argv, "config", "--worktree", "core.sparseCheckout", NULL);
    ++
    ++	if (mode)
    ++		argv_array_pushl(&argv, "true", NULL);
    ++	else
    ++		argv_array_pushl(&argv, "false", NULL);
     +
     +	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
     +		error(_("failed to enable core.sparseCheckout"));
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     +	FILE *fp;
     +	int res;
     +
    -+	if (sc_enable_config())
    ++	if (sc_set_config(MODE_ALL_PATTERNS))
     +		return 1;
     +
     +	memset(&pl, 0, sizeof(pl));
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     +	}
     +
     +	/* initial mode: all blobs at root */
    -+	fp = fopen(sparse_filename, "w");
    ++	fp = xfopen(sparse_filename, "w");
     +	free(sparse_filename);
     +	fprintf(fp, "/*\n!/*/\n");
     +	fclose(fp);
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'git sparse-checkout lis
     +'
     +
      test_done
    - 
32:  fef41b794a !  3:  2e885711e4 clone: add --sparse mode
    @@ Commit message
         point.
     
         During the 'git sparse-checkout init' call, we must first look
    -    to see if HEAD is valid, or else we will fail while trying to
    -    update the working directory. The first checkout will actually
    -    update the working directory correctly.
    +    to see if HEAD is valid, since 'git clone' does not have a valid
    +    HEAD at the point where it initializes the sparse-checkout. The
    +    following checkout within the clone command will create the HEAD
    +    ref and update the working directory correctly.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## Documentation/git-clone.txt ##
     @@ Documentation/git-clone.txt: SYNOPSIS
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
      	int res;
     +	struct object_id oid;
      
    - 	if (sc_enable_config())
    + 	if (sc_set_config(MODE_ALL_PATTERNS))
      		return 1;
     @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char **argv)
      	fprintf(fp, "/*\n!/*/\n");
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'init with existing spar
     +'
     +
      test_done
    - 
33:  9a78f9ea0f !  4:  c6b249a6e1 sparse-checkout: 'set' subcommand
    @@ Commit message
         extracted from cmd_sparse_checkout() to make it easier to implement
         'add' and/or 'remove' subcommands in the future.
     
    +    If the core.sparseCheckout config setting is disabled, then enable
    +    the config setting in the worktree config. If we set the config
    +    this way and the sparse-checkout fails, then re-disable the config
    +    setting.
    +
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## Documentation/git-sparse-checkout.txt ##
    -@@ Documentation/git-sparse-checkout.txt: COMMANDS
    - 	by Git. Add patterns to the sparse-checkout file to
    - 	repopulate the working directory.
    +@@ Documentation/git-sparse-checkout.txt: To avoid interfering with other worktrees, it first enables the
    + `extensions.worktreeConfig` setting and makes sure to set the
    + `core.sparseCheckout` setting in the worktree-specific config file.
      
     +'set'::
     +	Write a set of patterns to the sparse-checkout file, as given as
     +	a list of arguments following the 'set' subcommand. Update the
    -+	working directory to match the new patterns.
    ++	working directory to match the new patterns. Enable the
    ++	core.sparseCheckout config setting if it is not already enabled.
     +
      SPARSE CHECKOUT
    - ----------------
    + ---------------
      
     
      ## builtin/sparse-checkout.c ##
    @@ builtin/sparse-checkout.c
      #include "strbuf.h"
      
      static char const * const builtin_sparse_checkout_usage[] = {
    --	N_("git sparse-checkout [init|list]"),
    -+	N_("git sparse-checkout [init|list|set] <options>"),
    +-	N_("git sparse-checkout (init|list)"),
    ++	N_("git sparse-checkout (init|list|set) <options>"),
      	NULL
      };
      
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
     +	fclose(fp);
     +	free(sparse_filename);
     +
    -+	clear_pattern_list(pl);
     +	return update_working_directory();
     +}
     +
     +static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
     +{
    ++	static const char *empty_base = "";
     +	int i;
     +	struct pattern_list pl;
    ++	int result;
    ++	int set_config = 0;
     +	memset(&pl, 0, sizeof(pl));
     +
     +	for (i = 1; i < argc; i++)
    -+		add_pattern(argv[i], NULL, 0, &pl, 0);
    ++		add_pattern(argv[i], empty_base, 0, &pl, 0);
    ++
    ++	if (!core_apply_sparse_checkout) {
    ++		sc_set_config(MODE_ALL_PATTERNS);
    ++		core_apply_sparse_checkout = 1;
    ++		set_config = 1;
    ++	}
    ++
    ++	result = write_patterns_and_update(&pl);
    ++
    ++	if (result && set_config)
    ++		sc_set_config(MODE_NO_PATTERNS);
     +
    -+	return write_patterns_and_update(&pl);
    ++	clear_pattern_list(&pl);
    ++	return result;
     +}
     +
      int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'clone --sparse' '
      	test_cmp expect dir
      '
      
    ++test_expect_success 'set enables config' '
    ++	git init empty-config &&
    ++	(
    ++		cd empty-config &&
    ++		test_commit test file &&
    ++		test_path_is_missing .git/config.worktree &&
    ++		test_must_fail git sparse-checkout set nothing &&
    ++		test_i18ngrep "sparseCheckout = false" .git/config.worktree &&
    ++		git sparse-checkout set "/*" &&
    ++		test_i18ngrep "sparseCheckout = true" .git/config.worktree
    ++	)
    ++'
    ++
     +test_expect_success 'set sparse-checkout using builtin' '
     +	git -C repo sparse-checkout set "/*" "!/*/" "*folder*" &&
     +	cat >expect <<-EOF &&
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'clone --sparse' '
     +'
     +
      test_done
    - 
34:  21a0165be7 !  5:  ead918f126 sparse-checkout: add '--stdin' option to set subcommand
    @@ Commit message
         Add a '--stdin' option to instead read patterns over standard in.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## builtin/sparse-checkout.c ##
     @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_list *pl)
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
     +
      static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
      {
    - 	int i;
    + 	static const char *empty_base = "";
    +@@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
      	struct pattern_list pl;
    + 	int result;
    + 	int set_config = 0;
     +
     +	static struct option builtin_sparse_checkout_set_options[] = {
     +		OPT_BOOL(0, "stdin", &set_opts.use_stdin,
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
      	memset(&pl, 0, sizeof(pl));
      
     -	for (i = 1; i < argc; i++)
    --		add_pattern(argv[i], NULL, 0, &pl, 0);
    +-		add_pattern(argv[i], empty_base, 0, &pl, 0);
     +	argc = parse_options(argc, argv, prefix,
     +			     builtin_sparse_checkout_set_options,
     +			     builtin_sparse_checkout_set_usage,
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
     +		while (!strbuf_getline(&line, stdin)) {
     +			size_t len;
     +			char *buf = strbuf_detach(&line, &len);
    -+			add_pattern(buf, buf, len, &pl, 0);
    ++			add_pattern(buf, empty_base, 0, &pl, 0);
     +		}
     +	} else {
     +		for (i = 0; i < argc; i++)
    -+			add_pattern(argv[i], argv[i], strlen(argv[i]), &pl, 0);
    ++			add_pattern(argv[i], empty_base, 0, &pl, 0);
     +	}
      
    - 	return write_patterns_and_update(&pl);
    - }
    + 	if (!core_apply_sparse_checkout) {
    + 		sc_set_config(MODE_ALL_PATTERNS);
     
      ## t/t1091-sparse-checkout-builtin.sh ##
     @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'set sparse-checkout using builtin' '
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'set sparse-checkout usi
     +'
     +
      test_done
    - 
35:  b62b76013f !  6:  043e1a3d9a sparse-checkout: create 'disable' subcommand
    @@ Commit message
         steps for the user.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## Documentation/git-sparse-checkout.txt ##
    -@@ Documentation/git-sparse-checkout.txt: COMMANDS
    - 	a list of arguments following the 'set' subcommand. Update the
    - 	working directory to match the new patterns.
    +@@ Documentation/git-sparse-checkout.txt: To avoid interfering with other worktrees, it first enables the
    + 	working directory to match the new patterns. Enable the
    + 	core.sparseCheckout config setting if it is not already enabled.
      
     +'disable'::
     +	Remove the sparse-checkout file, set `core.sparseCheckout` to
     +	`false`, and restore the working directory to include all files.
     +
      SPARSE CHECKOUT
    - ----------------
    + ---------------
      
    -@@ Documentation/git-sparse-checkout.txt: Then it compares the new skip-worktree value with the previous one. If
    - skip-worktree turns from set to unset, it will add the corresponding
    - file back. If it turns from unset to set, that file will be removed.
    +@@ Documentation/git-sparse-checkout.txt: directory, it updates the skip-worktree bits in the index based
    + on this file. The files matching the patterns in the file will
    + appear in the working directory, and the rest will not.
      
    ++To enable the sparse-checkout feature, run `git sparse-checkout init` to
    ++initialize a simple sparse-checkout file and enable the `core.sparseCheckout`
    ++config setting. Then, run `git sparse-checkout set` to modify the patterns in
    ++the sparse-checkout file.
    ++
     +To repopulate the working directory with all files, use the
     +`git sparse-checkout disable` command.
    -+
    -+Sparse checkout support in 'git checkout' and similar commands is
    -+disabled by default. You need to set `core.sparseCheckout` to `true`
    -+in order to have sparse checkout support.
     +
      ## FULL PATTERN SET
      
    @@ Documentation/git-sparse-checkout.txt: using negative patterns. For example, to
     -----------------
     -
     -Then you can disable sparse checkout. Sparse checkout support in 'git
    --read-tree' and similar commands is disabled by default. You need to
    +-checkout' and similar commands is disabled by default. You need to
     -set `core.sparseCheckout` to `true` in order to have sparse checkout
     -support.
      
    @@ builtin/sparse-checkout.c
      #include "strbuf.h"
      
      static char const * const builtin_sparse_checkout_usage[] = {
    --	N_("git sparse-checkout [init|list|set] <options>"),
    -+	N_("git sparse-checkout [init|list|set|disable] <options>"),
    +-	N_("git sparse-checkout (init|list|set) <options>"),
    ++	N_("git sparse-checkout (init|list|set|disable) <options>"),
      	NULL
      };
      
    -@@ builtin/sparse-checkout.c: static int update_working_directory(void)
    - 	return result;
    - }
    - 
    --static int sc_enable_config(void)
    -+static int sc_set_config(int mode)
    - {
    - 	struct argv_array argv = ARGV_ARRAY_INIT;
    - 
    -@@ builtin/sparse-checkout.c: static int sc_enable_config(void)
    - 		return 1;
    - 	}
    - 
    --	argv_array_pushl(&argv, "config", "--worktree", "core.sparseCheckout", "true", NULL);
    -+	argv_array_pushl(&argv, "config", "--worktree", "core.sparseCheckout", NULL);
    -+
    -+	if (mode)
    -+		argv_array_pushl(&argv, "true", NULL);
    -+	else
    -+		argv_array_pushl(&argv, "false", NULL);
    - 
    - 	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
    - 		error(_("failed to enable core.sparseCheckout"));
    -@@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char **argv)
    - 	int res;
    - 	struct object_id oid;
    - 
    --	if (sc_enable_config())
    -+	if (sc_set_config(1))
    - 		return 1;
    - 
    - 	memset(&pl, 0, sizeof(pl));
     @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
    - 	return write_patterns_and_update(&pl);
    + 	return result;
      }
      
     +static int sparse_checkout_disable(int argc, const char **argv)
    @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char *
     +	char *sparse_filename;
     +	FILE *fp;
     +
    -+	if (sc_set_config(1))
    ++	if (sc_set_config(MODE_ALL_PATTERNS))
     +		die(_("failed to change config"));
     +
     +	sparse_filename = get_sparse_checkout_filename();
    -+	fp = fopen(sparse_filename, "w");
    ++	fp = xfopen(sparse_filename, "w");
     +	fprintf(fp, "/*\n");
     +	fclose(fp);
     +
    @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char *
     +	unlink(sparse_filename);
     +	free(sparse_filename);
     +
    -+	return sc_set_config(0);
    ++	return sc_set_config(MODE_NO_PATTERNS);
     +}
     +
      int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'set sparse-checkout usi
     +'
     +
      test_done
    - 
36:  25642f8df2 !  7:  d97f70b862 trace2: add region in clear_ce_flags
    @@ Commit message
     
         Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## unpack-trees.c ##
     @@ unpack-trees.c: static int clear_ce_flags(struct index_state *istate,
37:  84511255d1 !  8:  95a6be78f3 sparse-checkout: add 'cone' mode
    @@ Commit message
         indicate that we expect the sparse-checkout file to contain a
         more limited set of patterns. This is a separate config setting
         from core.sparseCheckout to avoid breaking older clients by
    -    introcuding a tri-state option.
    +    introducing a tri-state option.
     
         The config option does nothing right now, but will be expanded
         upon in a later commit.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## Documentation/config/core.txt ##
     @@ Documentation/config/core.txt: core.multiPackIndex::
    @@ Documentation/config/core.txt: core.multiPackIndex::
      core.sparseCheckout::
     -	Enable "sparse checkout" feature. See section "Sparse checkout" in
     -	linkgit:git-read-tree[1] for more information.
    -+	Enable "sparse checkout" feature. If "false", then sparse-checkout
    -+	is disabled. If "true", then sparse-checkout is enabled with the full
    -+	.gitignore pattern set. If "cone", then sparse-checkout is enabled with
    -+	a restricted pattern set. See linkgit:git-sparse-checkout[1] for more
    -+	information.
    ++	Enable "sparse checkout" feature. See linkgit:git-sparse-checkout[1]
    ++	for more information.
    ++
    ++core.sparseCheckoutCone::
    ++	Enables the "cone mode" of the sparse checkout feature. When the
    ++	sparse-checkout file contains a limited set of patterns, then this
    ++	mode provides significant performance advantages. See
    ++	linkgit:git-sparse-checkout[1] for more information.
      
      core.abbrev::
      	Set the length object names are abbreviated to.  If
38:  95a3285bc6 !  9:  fa1e8e3adb sparse-checkout: use hashmaps for cone patterns
    @@ Commit message
         Running 'git read-tree -mu HEAD' on this file had the following
         performance:
     
    -            core.sparseCheckout=false: 0.21 s (0.00 s)
    -             core.sparseCheckout=true: 3.75 s (3.50 s)
    -             core.sparseCheckout=cone: 0.23 s (0.01 s)
    +        core.sparseCheckout=false: 0.21 s (0.00 s)
    +         core.sparseCheckout=true: 3.75 s (3.50 s)
    +     core.sparseCheckoutCone=true: 0.23 s (0.01 s)
     
         The times in parentheses above correspond to the time spent
         in the first clear_ce_flags() call, according to the trace2
    @@ Commit message
         While this example is contrived, it demonstrates how these
         patterns can slow the sparse-checkout feature.
     
    +    Helped-by: Eric Wong <e@80x24.org>
    +    Helped-by: Johannes Schindelin <Johannes.Schindelin@gmx.de>
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## dir.c ##
     @@ dir.c: void parse_path_pattern(const char **pattern,
    @@ dir.c: void parse_path_pattern(const char **pattern,
      }
      
     +static int pl_hashmap_cmp(const void *unused_cmp_data,
    -+			  const void *a, const void *b, const void *key)
    ++			  const struct hashmap_entry *a,
    ++			  const struct hashmap_entry *b,
    ++			  const void *key)
     +{
    -+	const struct pattern_entry *ee1 = (const struct pattern_entry *)a;
    -+	const struct pattern_entry *ee2 = (const struct pattern_entry *)b;
    ++	const struct pattern_entry *ee1 =
    ++			container_of(a, struct pattern_entry, ent);
    ++	const struct pattern_entry *ee2 =
    ++			container_of(b, struct pattern_entry, ent);
     +
     +	size_t min_len = ee1->patternlen <= ee2->patternlen
     +			 ? ee1->patternlen
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +	if (!pl->use_cone_patterns)
     +		return;
     +
    -+	if (!strcmp(given->pattern, "/*"))
    ++	if (given->flags & PATTERN_FLAG_NEGATIVE &&
    ++	    given->flags & PATTERN_FLAG_MUSTBEDIR &&
    ++	    !strcmp(given->pattern, "/*")) {
    ++		pl->full_cone = 0;
     +		return;
    ++	}
    ++
    ++	if (!given->flags && !strcmp(given->pattern, "/*")) {
    ++		pl->full_cone = 1;
    ++		return;
    ++	}
     +
     +	if (given->patternlen > 2 &&
     +	    !strcmp(given->pattern + given->patternlen - 2, "/*")) {
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +		translated = xmalloc(sizeof(struct pattern_entry));
     +		translated->pattern = truncated;
     +		translated->patternlen = given->patternlen - 2;
    -+		hashmap_entry_init(translated,
    ++		hashmap_entry_init(&translated->ent,
     +				   memhash(translated->pattern, translated->patternlen));
     +
    -+		if (!hashmap_get(&pl->recursive_hashmap, translated, NULL)) {
    ++		if (!hashmap_get_entry(&pl->recursive_hashmap,
    ++				       translated, ent, NULL)) {
     +			/* We did not see the "parent" included */
     +			warning(_("unrecognized negative pattern: '%s'"),
     +				given->pattern);
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +			goto clear_hashmaps;
     +		}
     +
    -+		hashmap_add(&pl->parent_hashmap, translated);
    -+		hashmap_remove(&pl->recursive_hashmap, translated, &data);
    ++		hashmap_add(&pl->parent_hashmap, &translated->ent);
    ++		hashmap_remove(&pl->recursive_hashmap, &translated->ent, &data);
     +		free(data);
     +		return;
     +	}
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +
     +	translated->pattern = xstrdup(given->pattern);
     +	translated->patternlen = given->patternlen;
    -+	hashmap_entry_init(translated,
    ++	hashmap_entry_init(&translated->ent,
     +			   memhash(translated->pattern, translated->patternlen));
     +
    -+	hashmap_add(&pl->recursive_hashmap, translated);
    ++	hashmap_add(&pl->recursive_hashmap, &translated->ent);
     +
    -+	if (hashmap_get(&pl->parent_hashmap, translated, NULL)) {
    ++	if (hashmap_get_entry(&pl->parent_hashmap, translated, ent, NULL)) {
     +		/* we already included this at the parent level */
     +		warning(_("your sparse-checkout file may have issues: pattern '%s' is repeated"),
     +			given->pattern);
    -+		hashmap_remove(&pl->parent_hashmap, translated, &data);
    ++		hashmap_remove(&pl->parent_hashmap, &translated->ent, &data);
     +		free(data);
     +		free(translated);
     +	}
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +
     +clear_hashmaps:
     +	warning(_("disabling cone pattern matching"));
    -+	hashmap_free(&pl->parent_hashmap, 1);
    -+	hashmap_free(&pl->recursive_hashmap, 1);
    ++	hashmap_free_entries(&pl->parent_hashmap, struct pattern_entry, ent);
    ++	hashmap_free_entries(&pl->recursive_hashmap, struct pattern_entry, ent);
     +	pl->use_cone_patterns = 0;
     +}
     +
    @@ dir.c: void parse_path_pattern(const char **pattern,
     +	/* Check straight mapping */
     +	p.pattern = pattern->buf;
     +	p.patternlen = pattern->len;
    -+	hashmap_entry_init(&p, memhash(p.pattern, p.patternlen));
    -+	return !!hashmap_get(map, &p, NULL);
    ++	hashmap_entry_init(&p.ent, memhash(p.pattern, p.patternlen));
    ++	return !!hashmap_get_entry(map, &p, ent, NULL);
    ++}
    ++
    ++int hashmap_contains_parent(struct hashmap *map,
    ++			    const char *path,
    ++			    struct strbuf *buffer)
    ++{
    ++	char *slash_pos;
    ++
    ++	strbuf_setlen(buffer, 0);
    ++
    ++	if (path[0] != '/')
    ++		strbuf_addch(buffer, '/');
    ++
    ++	strbuf_addstr(buffer, path);
    ++
    ++	slash_pos = strrchr(buffer->buf, '/');
    ++
    ++	while (slash_pos > buffer->buf) {
    ++		strbuf_setlen(buffer, slash_pos - buffer->buf);
    ++
    ++		if (hashmap_contains_path(map, buffer))
    ++			return 1;
    ++
    ++		slash_pos = strrchr(buffer->buf, '/');
    ++	}
    ++
    ++	return 0;
     +}
     +
      void add_pattern(const char *string, const char *base,
    @@ dir.c: static int add_patterns_from_buffer(char *buf, size_t size,
      	int i, lineno = 1;
      	char *entry;
      
    -+	pl->use_cone_patterns = core_sparse_checkout_cone;
     +	hashmap_init(&pl->recursive_hashmap, pl_hashmap_cmp, NULL, 0);
     +	hashmap_init(&pl->parent_hashmap, pl_hashmap_cmp, NULL, 0);
     +
    @@ dir.c: enum pattern_match_result path_matches_pattern_list(
     +		}
     +
     +		return UNDECIDED;
    - 	}
    - 
    --	return UNDECIDED;
    ++	}
    ++
    ++	if (pl->full_cone)
    ++		return MATCHED;
    ++
     +	strbuf_addch(&parent_pathname, '/');
     +	strbuf_add(&parent_pathname, pathname, pathlen);
     +
     +	if (hashmap_contains_path(&pl->recursive_hashmap,
    -+					&parent_pathname)) {
    ++				  &parent_pathname)) {
     +		result = MATCHED;
     +		goto done;
     +	}
    @@ dir.c: enum pattern_match_result path_matches_pattern_list(
     +		/* include every file in root */
     +		result = MATCHED;
     +		goto done;
    -+	}
    -+
    + 	}
    + 
    +-	return UNDECIDED;
     +	strbuf_setlen(&parent_pathname, slash_pos - parent_pathname.buf);
     +
     +	if (hashmap_contains_path(&pl->parent_hashmap, &parent_pathname)) {
    @@ dir.c: enum pattern_match_result path_matches_pattern_list(
     +		goto done;
     +	}
     +
    -+	while (parent_pathname.len) {
    -+		if (hashmap_contains_path(&pl->recursive_hashmap,
    -+					  &parent_pathname)) {
    -+			result = UNDECIDED;
    -+			goto done;
    -+		}
    -+
    -+		slash_pos = strrchr(parent_pathname.buf, '/');
    -+		if (slash_pos == parent_pathname.buf)
    -+			break;
    -+
    -+		strbuf_setlen(&parent_pathname, slash_pos - parent_pathname.buf);
    -+	}
    ++	if (hashmap_contains_parent(&pl->recursive_hashmap,
    ++				    pathname,
    ++				    &parent_pathname))
    ++		result = MATCHED;
     +
     +done:
     +	strbuf_release(&parent_pathname);
    @@ dir.h: struct pattern_list {
     +	 * excludes array above. If non-zero, that check succeeded.
     +	 */
     +	unsigned use_cone_patterns;
    ++	unsigned full_cone;
     +
     +	/*
     +	 * Stores paths where everything starting with those paths
    @@ dir.h: struct pattern_list {
      };
      
      /*
    +@@ dir.h: int is_excluded(struct dir_struct *dir,
    + 		struct index_state *istate,
    + 		const char *name, int *dtype);
    + 
    ++int hashmap_contains_parent(struct hashmap *map,
    ++			    const char *path,
    ++			    struct strbuf *buffer);
    + struct pattern_list *add_pattern_list(struct dir_struct *dir,
    + 				      int group_type, const char *src);
    + int add_patterns_from_file_to_list(const char *fname, const char *base, int baselen,
     
      ## t/t1091-sparse-checkout-builtin.sh ##
     @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'set sparse-checkout using --stdin' '
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'cone mode: match patter
      test_expect_success 'sparse-checkout disable' '
      	git -C repo sparse-checkout disable &&
      	test_path_is_missing repo/.git/info/sparse-checkout &&
    +
    + ## unpack-trees.c ##
    +@@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options
    + 		o->skip_sparse_checkout = 1;
    + 	if (!o->skip_sparse_checkout) {
    + 		char *sparse = git_pathdup("info/sparse-checkout");
    ++		pl.use_cone_patterns = core_sparse_checkout_cone;
    + 		if (add_patterns_from_file_to_list(sparse, "", 0, &pl, NULL) < 0)
    + 			o->skip_sparse_checkout = 1;
    + 		else
39:  995c5b8e2b ! 10:  93f2e4e9df sparse-checkout: init and set in cone mode
    @@ Commit message
         we want to avoid the warning that the patterns do not match
         the cone-mode patterns.
     
    +    Helped-by: Eric Wong <e@80x24.org>
    +    Helped-by: Johannes Schindelin <Johannes.Schindelin@gmx.de>
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## builtin/sparse-checkout.c ##
     @@
    @@ builtin/sparse-checkout.c
     +#include "string-list.h"
      
      static char const * const builtin_sparse_checkout_usage[] = {
    - 	N_("git sparse-checkout [init|list|set|disable] <options>"),
    + 	N_("git sparse-checkout (init|list|set|disable) <options>"),
     @@ builtin/sparse-checkout.c: static int update_working_directory(void)
    - 	return result;
    - }
    + enum sparse_checkout_mode {
    + 	MODE_NO_PATTERNS = 0,
    + 	MODE_ALL_PATTERNS = 1,
    ++	MODE_CONE_PATTERNS = 2,
    + };
      
    -+#define SPARSE_CHECKOUT_NONE 0
    -+#define SPARSE_CHECKOUT_FULL 1
    -+#define SPARSE_CHECKOUT_CONE 2
    -+
    - static int sc_set_config(int mode)
    + static int sc_set_config(enum sparse_checkout_mode mode)
      {
      	struct argv_array argv = ARGV_ARRAY_INIT;
     +	struct argv_array cone_argv = ARGV_ARRAY_INIT;
      
      	if (git_config_set_gently("extensions.worktreeConfig", "true")) {
      		error(_("failed to set extensions.worktreeConfig setting"));
    -@@ builtin/sparse-checkout.c: static int sc_set_config(int mode)
    +@@ builtin/sparse-checkout.c: static int sc_set_config(enum sparse_checkout_mode mode)
      		return 1;
      	}
      
     +	argv_array_pushl(&cone_argv, "config", "--worktree",
     +			 "core.sparseCheckoutCone", NULL);
     +
    -+	if (mode == SPARSE_CHECKOUT_CONE)
    ++	if (mode == MODE_CONE_PATTERNS)
     +		argv_array_push(&cone_argv, "true");
     +	else
     +		argv_array_push(&cone_argv, "false");
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
      	int res;
      	struct object_id oid;
     +	int mode;
    -+
    + 
    +-	if (sc_set_config(MODE_ALL_PATTERNS))
     +	static struct option builtin_sparse_checkout_init_options[] = {
     +		OPT_BOOL(0, "cone", &init_opts.cone_mode,
     +			 N_("initialize the sparse-checkout in cone mode")),
     +		OPT_END(),
     +	};
    - 
    --	if (sc_set_config(1))
    ++
     +	argc = parse_options(argc, argv, NULL,
     +			     builtin_sparse_checkout_init_options,
     +			     builtin_sparse_checkout_init_usage, 0);
     +
    -+	mode = init_opts.cone_mode ? SPARSE_CHECKOUT_CONE : SPARSE_CHECKOUT_FULL;
    ++	mode = init_opts.cone_mode ? MODE_CONE_PATTERNS : MODE_ALL_PATTERNS;
     +
     +	if (sc_set_config(mode))
      		return 1;
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
      
     +static void insert_recursive_pattern(struct pattern_list *pl, struct strbuf *path)
     +{
    -+	struct pattern_entry *e = xmalloc(sizeof(struct pattern_entry));
    ++	struct pattern_entry *e = xmalloc(sizeof(*e));
     +	e->patternlen = path->len;
     +	e->pattern = strbuf_detach(path, NULL);
    -+	hashmap_entry_init(e, memhash(e->pattern, e->patternlen));
    ++	hashmap_entry_init(&e->ent, memhash(e->pattern, e->patternlen));
     +
    -+	hashmap_add(&pl->recursive_hashmap, e);
    ++	hashmap_add(&pl->recursive_hashmap, &e->ent);
     +
     +	while (e->patternlen) {
     +		char *slash = strrchr(e->pattern, '/');
     +		char *oldpattern = e->pattern;
     +		size_t newlen;
     +
    -+		if (!slash)
    ++		if (slash == e->pattern)
     +			break;
     +
     +		newlen = slash - e->pattern;
     +		e = xmalloc(sizeof(struct pattern_entry));
     +		e->patternlen = newlen;
     +		e->pattern = xstrndup(oldpattern, newlen);
    -+		hashmap_entry_init(e, memhash(e->pattern, e->patternlen));
    ++		hashmap_entry_init(&e->ent, memhash(e->pattern, e->patternlen));
     +
    -+		if (!hashmap_get(&pl->parent_hashmap, e, NULL))
    -+			hashmap_add(&pl->parent_hashmap, e);
    ++		if (!hashmap_get_entry(&pl->parent_hashmap, e, ent, NULL))
    ++			hashmap_add(&pl->parent_hashmap, &e->ent);
     +	}
     +}
     +
     +static void write_cone_to_file(FILE *fp, struct pattern_list *pl)
     +{
     +	int i;
    -+	struct pattern_entry *entry;
    ++	struct pattern_entry *pe;
     +	struct hashmap_iter iter;
     +	struct string_list sl = STRING_LIST_INIT_DUP;
     +
    -+	hashmap_iter_init(&pl->parent_hashmap, &iter);
    -+	while ((entry = hashmap_iter_next(&iter)))
    -+		string_list_insert(&sl, entry->pattern);
    ++	hashmap_for_each_entry(&pl->parent_hashmap, &iter, pe, ent)
    ++		string_list_insert(&sl, pe->pattern);
     +
     +	string_list_sort(&sl);
     +	string_list_remove_duplicates(&sl, 0);
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
     +		char *pattern = sl.items[i].string;
     +
     +		if (strlen(pattern))
    -+			fprintf(fp, "/%s/\n!/%s/*/\n", pattern, pattern);
    ++			fprintf(fp, "%s/\n!%s/*/\n", pattern, pattern);
     +	}
     +
     +	string_list_clear(&sl, 0);
     +
    -+	hashmap_iter_init(&pl->recursive_hashmap, &iter);
    -+	while ((entry = hashmap_iter_next(&iter)))
    -+		string_list_insert(&sl, entry->pattern);
    ++	hashmap_for_each_entry(&pl->recursive_hashmap, &iter, pe, ent)
    ++		string_list_insert(&sl, pe->pattern);
     +
     +	string_list_sort(&sl);
     +	string_list_remove_duplicates(&sl, 0);
     +
     +	for (i = 0; i < sl.nr; i++) {
     +		char *pattern = sl.items[i].string;
    -+		fprintf(fp, "/%s/\n", pattern);
    ++		fprintf(fp, "%s/\n", pattern);
     +	}
     +}
     +
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
      	fclose(fp);
      	free(sparse_filename);
      
    -@@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_list *pl)
      	return update_working_directory();
      }
      
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
     +	if (!line->len)
     +		return;
     +
    -+	if (line->buf[0] == '/')
    -+		strbuf_remove(line, 0, 1);
    -+
    -+	if (!line->len)
    -+		return;
    ++	if (line->buf[0] != '/')
    ++		strbuf_insert(line, 0, "/", 1);
     +
     +	insert_recursive_pattern(pl, line);
     +}
    @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char *
     -		while (!strbuf_getline(&line, stdin)) {
     -			size_t len;
     -			char *buf = strbuf_detach(&line, &len);
    --			add_pattern(buf, buf, len, &pl, 0);
    +-			add_pattern(buf, empty_base, 0, &pl, 0);
     +		hashmap_init(&pl.recursive_hashmap, pl_hashmap_cmp, NULL, 0);
     +		hashmap_init(&pl.parent_hashmap, pl_hashmap_cmp, NULL, 0);
     +
    @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char *
      		}
      	} else {
     -		for (i = 0; i < argc; i++)
    --			add_pattern(argv[i], argv[i], strlen(argv[i]), &pl, 0);
    +-			add_pattern(argv[i], empty_base, 0, &pl, 0);
     +		if (set_opts.use_stdin) {
     +			struct strbuf line = STRBUF_INIT;
     +
     +			while (!strbuf_getline(&line, stdin)) {
     +				size_t len;
     +				char *buf = strbuf_detach(&line, &len);
    -+				add_pattern(buf, buf, len, &pl, 0);
    ++				add_pattern(buf, empty_base, 0, &pl, 0);
     +			}
     +		} else {
     +			for (i = 0; i < argc; i++)
    -+				add_pattern(argv[i], argv[i], strlen(argv[i]), &pl, 0);
    ++				add_pattern(argv[i], empty_base, 0, &pl, 0);
     +		}
      	}
      
    - 	return write_patterns_and_update(&pl);
    -@@ builtin/sparse-checkout.c: static int sparse_checkout_disable(int argc, const char **argv)
    - 	char *sparse_filename;
    - 	FILE *fp;
    - 
    --	if (sc_set_config(1))
    -+	if (sc_set_config(SPARSE_CHECKOUT_FULL))
    - 		die(_("failed to change config"));
    - 
    - 	sparse_filename = get_sparse_checkout_filename();
    -@@ builtin/sparse-checkout.c: static int sparse_checkout_disable(int argc, const char **argv)
    - 	unlink(sparse_filename);
    - 	free(sparse_filename);
    - 
    --	return sc_set_config(0);
    -+	return sc_set_config(SPARSE_CHECKOUT_NONE);
    - }
    - 
    - int cmd_sparse_checkout(int argc, const char **argv, const char *prefix)
    + 	if (!core_apply_sparse_checkout) {
     
      ## dir.c ##
     @@ dir.c: void parse_path_pattern(const char **pattern,
    @@ dir.c: void parse_path_pattern(const char **pattern,
      }
      
     -static int pl_hashmap_cmp(const void *unused_cmp_data,
    --			  const void *a, const void *b, const void *key)
    +-			  const struct hashmap_entry *a,
    +-			  const struct hashmap_entry *b,
    +-			  const void *key)
     +int pl_hashmap_cmp(const void *unused_cmp_data,
    -+		   const void *a, const void *b, const void *key)
    ++		   const struct hashmap_entry *a,
    ++		   const struct hashmap_entry *b,
    ++		   const void *key)
      {
    - 	const struct pattern_entry *ee1 = (const struct pattern_entry *)a;
    - 	const struct pattern_entry *ee2 = (const struct pattern_entry *)b;
    + 	const struct pattern_entry *ee1 =
    + 			container_of(a, struct pattern_entry, ent);
     
      ## dir.h ##
     @@ dir.h: int is_excluded(struct dir_struct *dir,
    @@ dir.h: int is_excluded(struct dir_struct *dir,
      		const char *name, int *dtype);
      
     +int pl_hashmap_cmp(const void *unused_cmp_data,
    -+		   const void *a, const void *b, const void *key);
    -+
    - struct pattern_list *add_pattern_list(struct dir_struct *dir,
    - 				      int group_type, const char *src);
    - int add_patterns_from_file_to_list(const char *fname, const char *base, int baselen,
    ++		   const struct hashmap_entry *a,
    ++		   const struct hashmap_entry *b,
    ++		   const void *key);
    + int hashmap_contains_parent(struct hashmap *map,
    + 			    const char *path,
    + 			    struct strbuf *buffer);
     
      ## t/t1091-sparse-checkout-builtin.sh ##
     @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'sparse-checkout disable' '
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'sparse-checkout disable
     +		a
     +		deep
     +	EOF
    ++	test_cmp expect dir &&
     +	ls repo/deep >dir  &&
     +	cat >expect <<-EOF &&
     +		a
     +		deeper1
     +	EOF
    ++	test_cmp expect dir &&
     +	ls repo/deep/deeper1 >dir  &&
     +	cat >expect <<-EOF &&
     +		a
    @@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'sparse-checkout disable
     +'
     +
      test_done
    - 
40:  1d4321488e ! 11:  b2522a9757 unpack-trees: hash less in cone mode
    @@ Commit message
         value.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## dir.c ##
     @@ dir.c: enum pattern_match_result path_matches_pattern_list(
      
      	if (hashmap_contains_path(&pl->recursive_hashmap,
    - 					&parent_pathname)) {
    + 				  &parent_pathname)) {
     -		result = MATCHED;
     +		result = MATCHED_RECURSIVE;
      		goto done;
      	}
      
     @@ dir.c: enum pattern_match_result path_matches_pattern_list(
    - 	while (parent_pathname.len) {
    - 		if (hashmap_contains_path(&pl->recursive_hashmap,
    - 					  &parent_pathname)) {
    --			result = UNDECIDED;
    -+			result = MATCHED_RECURSIVE;
    - 			goto done;
    - 		}
    + 	if (hashmap_contains_parent(&pl->recursive_hashmap,
    + 				    pathname,
    + 				    &parent_pathname))
    +-		result = MATCHED;
    ++		result = MATCHED_RECURSIVE;
      
    + done:
    + 	strbuf_release(&parent_pathname);
     
      ## dir.h ##
     @@ dir.h: enum pattern_match_result {
41:  f89c75bfae <  -:  ---------- fixup! unpack-trees: hash less in cone mode
42:  7be46af2d7 <  -:  ---------- fixup! Merge branch 'sparse-checkout/v1'
43:  73b100d11d <  -:  ---------- fixup! sparse-checkout: use hashmaps for cone patterns
44:  3a07dd6671 ! 12:  705f31cb7b unpack-trees: add progress to clear_ce_flags()
    @@ Commit message
         clear_ce_flags() method to write progress.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## cache.h ##
     @@ cache.h: static inline unsigned int canon_mode(unsigned int mode)
45:  cb32d7e620 ! 13:  4326bc1811 read-tree: show progress by default
    @@ Commit message
         benefit from progress indicators when a user runs these commands.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## builtin/read-tree.c ##
     @@ builtin/read-tree.c: int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
46:  577e7fa8f3 <  -:  ---------- sparse-checkout: sanitize for nested folders
47:  f58c8f42e4 <  -:  ---------- fsmonitor: don't fill bitmap with entries to be removed
 -:  ---------- > 14:  f9e96bf90e sparse-checkout: sanitize for nested folders
56:  ab65de39f7 ! 15:  efd9c53b6d sparse-checkout: update working directory in-process
    @@ Metadata
      ## Commit message ##
         sparse-checkout: update working directory in-process
     
    +    The sparse-checkout builtin used 'git read-tree -mu HEAD' to update the
    +    skip-worktree bits in the index and to update the working directory.
    +    This extra process is overly complex, and prone to failure. It also
    +    requires that we write our changes to the sparse-checkout file before
    +    trying to update the index.
    +
    +    Remove this extra process call by creating a direct call to
    +    unpack_trees() in the same way 'git read-tree -mu HEAD' does. In
    +    addition, provide an in-memory list of patterns so we can avoid
    +    reading from the sparse-checkout file. This allows us to test a
    +    proposed change to the file before writing to it.
    +
    +    An earlier version of this patch included a bug when the 'set' command
    +    failed due to the "Sparse checkout leaves no entry on working directory"
    +    error. It would not rollback the index.lock file, so the replay of the
    +    old sparse-checkout specification would fail. A test in t1091 now
    +    covers that scenario.
    +
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## builtin/read-tree.c ##
     @@ builtin/read-tree.c: int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
    @@ builtin/sparse-checkout.c
     +#include "unpack-trees.h"
      
      static char const * const builtin_sparse_checkout_usage[] = {
    - 	N_("git sparse-checkout [init|list|set|disable] <options>"),
    + 	N_("git sparse-checkout (init|list|set|disable) <options>"),
     @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char **argv)
      	return 0;
      }
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     -	if (run_command_v_opt(argv.argv, RUN_GIT_CMD)) {
     -		error(_("failed to update index with new sparse-checkout paths"));
     -		result = 1;
    +-	}
     +	if (repo_read_index_unmerged(r))
     +		die(_("You need to resolve your current index first"));
     +
    @@ builtin/sparse-checkout.c: static int sparse_checkout_list(int argc, const char
     +	if (!result) {
     +		prime_cache_tree(r, r->index, tree);
     +		write_locked_index(r->index, &lock_file, COMMIT_LOCK);
    - 	}
    ++	} else
    ++		rollback_lock_file(&lock_file);
      
     -	argv_array_clear(&argv);
      	return result;
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
      			     builtin_sparse_checkout_init_options,
      			     builtin_sparse_checkout_init_usage, 0);
      
    --	mode = init_opts.cone_mode ? SPARSE_CHECKOUT_CONE : SPARSE_CHECKOUT_FULL;
    +-	mode = init_opts.cone_mode ? MODE_CONE_PATTERNS : MODE_ALL_PATTERNS;
     +	if (init_opts.cone_mode) {
    -+		mode = SPARSE_CHECKOUT_CONE;
    ++		mode = MODE_CONE_PATTERNS;
     +		core_sparse_checkout_cone = 1;
     +	} else
    -+		mode = SPARSE_CHECKOUT_FULL;
    ++		mode = MODE_ALL_PATTERNS;
      
      	if (sc_set_config(mode))
      		return 1;
    @@ builtin/sparse-checkout.c: static int sparse_checkout_init(int argc, const char
      }
      
      static void insert_recursive_pattern(struct pattern_list *pl, struct strbuf *path)
    - {
    --	struct pattern_entry *e = xmalloc(sizeof(struct pattern_entry));
    -+	struct pattern_entry *e = xmalloc(sizeof(*e));
    -+
    - 	e->patternlen = path->len;
    - 	e->pattern = strbuf_detach(path, NULL);
    - 	hashmap_entry_init(e, memhash(e->pattern, e->patternlen));
     @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_list *pl)
      {
      	char *sparse_filename;
      	FILE *fp;
    -+	int result = update_working_directory(pl);
    ++	int result;
    ++
    ++	result = update_working_directory(pl);
     +
     +	if (result) {
     +		clear_pattern_list(pl);
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
      		write_patterns_to_file(fp, pl);
      
      	fclose(fp);
    --	free(sparse_filename);
    ++
    + 	free(sparse_filename);
    ++	clear_pattern_list(pl);
      
    -+	free(sparse_filename);
    - 	clear_pattern_list(pl);
     -	return update_working_directory();
    -+
     +	return 0;
      }
      
      static void strbuf_to_cone_pattern(struct strbuf *line, struct pattern_list *pl)
    -@@ builtin/sparse-checkout.c: static void strbuf_to_cone_pattern(struct strbuf *line, struct pattern_list *pl)
    - 	if (line->buf[0] == '/')
    - 		strbuf_remove(line, 0, 1);
    - 
    --	if (!line->len)
    --		return;
    --
    - 	insert_recursive_pattern(pl, line);
    - }
    - 
    -@@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
    - {
    - 	int i;
    - 	struct pattern_list pl;
    -+	static const char *empty_base = "";
    - 
    - 	static struct option builtin_sparse_checkout_set_options[] = {
    - 		OPT_BOOL(0, "stdin", &set_opts.use_stdin,
     @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
      		struct strbuf line = STRBUF_INIT;
      		hashmap_init(&pl.recursive_hashmap, pl_hashmap_cmp, NULL, 0);
    @@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char *
      
      		if (set_opts.use_stdin) {
      			while (!strbuf_getline(&line, stdin))
    -@@ builtin/sparse-checkout.c: static int sparse_checkout_set(int argc, const char **argv, const char *prefix)
    - 			while (!strbuf_getline(&line, stdin)) {
    - 				size_t len;
    - 				char *buf = strbuf_detach(&line, &len);
    --				add_pattern(buf, buf, len, &pl, 0);
    -+				add_pattern(buf, empty_base, 0, &pl, 0);
    - 			}
    - 		} else {
    - 			for (i = 0; i < argc; i++)
    --				add_pattern(argv[i], argv[i], strlen(argv[i]), &pl, 0);
    -+				add_pattern(argv[i], empty_base, 0, &pl, 0);
    - 		}
    - 	}
    - 
     @@ builtin/sparse-checkout.c: static int sparse_checkout_disable(int argc, const char **argv)
      	fprintf(fp, "/*\n");
      	fclose(fp);
      
     -	if (update_working_directory())
     +	core_apply_sparse_checkout = 1;
    -+	core_sparse_checkout_cone = 0;
     +	if (update_working_directory(NULL))
      		die(_("error while refreshing working directory"));
      
      	unlink(sparse_filename);
     
      ## t/t1091-sparse-checkout-builtin.sh ##
    -@@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'cone mode: init and set' '
    - 		a
    - 		deep
    - 	EOF
    -+	test_cmp dir expect &&
    - 	ls repo/deep >dir  &&
    - 	cat >expect <<-EOF &&
    - 		a
    - 		deeper1
    - 	EOF
    -+	test_cmp dir expect &&
    - 	ls repo/deep/deeper1 >dir  &&
    - 	cat >expect <<-EOF &&
    - 		a
    +@@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'cone mode: set with nested folders' '
    + 	test_cmp repo/.git/info/sparse-checkout expect
    + '
    + 
    ++test_expect_success 'revert to old sparse-checkout on bad update' '
    ++	echo update >repo/deep/deeper2/a &&
    ++	cp repo/.git/info/sparse-checkout expect &&
    ++	test_must_fail git -C repo sparse-checkout set deep/deeper1 2>err &&
    ++	test_i18ngrep "Cannot update sparse checkout" err &&
    ++	test_cmp repo/.git/info/sparse-checkout expect &&
    ++	ls repo/deep >dir &&
    ++	cat >expect <<-EOF &&
    ++		a
    ++		deeper1
    ++		deeper2
    ++	EOF
    ++	test_cmp dir expect
    ++'
    ++
    ++test_expect_success 'revert to old sparse-checkout on empty update' '
    ++	git init empty-test &&
    ++	(
    ++		echo >file &&
    ++		git add file &&
    ++		git commit -m "test" &&
    ++		test_must_fail git sparse-checkout set nothing 2>err &&
    ++		test_i18ngrep "Sparse checkout leaves no entry on working directory" err &&
    ++		test_i18ngrep ! ".git/index.lock" err &&
    ++		git sparse-checkout set file
    ++	)
    ++'
    ++
    + test_done
     
      ## unpack-trees.c ##
     @@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options
    @@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpac
      		o->skip_sparse_checkout = 1;
     -	if (!o->skip_sparse_checkout) {
     +	if (!o->skip_sparse_checkout && !o->pl) {
    - 		if (core_virtualfilesystem) {
    - 			o->pl = &pl;
    - 		} else {
    + 		char *sparse = git_pathdup("info/sparse-checkout");
    + 		pl.use_cone_patterns = core_sparse_checkout_cone;
    + 		if (add_patterns_from_file_to_list(sparse, "", 0, &pl, NULL) < 0)
     @@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options
      
      done:
    @@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpac
     -	clear_pattern_list(&pl);
     +	if (!o->keep_pattern_list)
     +		clear_pattern_list(&pl);
    - 	trace2_data_intmax("unpack_trees", NULL, "unpack_trees/nr_unpack_entries",
    - 			   (intmax_t)(get_nr_unpack_entry() - nr_unpack_entry_at_start));
    - 	trace2_region_leave("unpack_trees", "unpack_trees", NULL);
    + 	return ret;
    + 
    + return_failed:
     
      ## unpack-trees.h ##
     @@ unpack-trees.h: struct unpack_trees_options {
60:  c963314c01 ! 16:  a879c5bfb5 sparse-checkout: write using lockfile
    @@ Commit message
         ways.
     
         Signed-off-by: Derrick Stolee <dstolee@microsoft.com>
    +    Signed-off-by: Junio C Hamano <gitster@pobox.com>
     
      ## builtin/sparse-checkout.c ##
     @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_list *pl)
      {
      	char *sparse_filename;
      	FILE *fp;
    --	int result = update_working_directory(pl);
     +	int fd;
     +	struct lock_file lk = LOCK_INIT;
    -+	int result;
    + 	int result;
    + 
    + 	result = update_working_directory(pl);
      
     +	sparse_filename = get_sparse_checkout_filename();
     +	fd = hold_lock_file_for_update(&lk, sparse_filename,
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
      
     -	sparse_filename = get_sparse_checkout_filename();
     -	fp = fopen(sparse_filename, "w");
    -+	fp = fdopen(fd, "w");
    ++	fp = xfdopen(fd, "w");
      
      	if (core_sparse_checkout_cone)
      		write_cone_to_file(fp, pl);
    @@ builtin/sparse-checkout.c: static int write_patterns_and_update(struct pattern_l
      
      	free(sparse_filename);
      	clear_pattern_list(pl);
    +
    + ## t/t1091-sparse-checkout-builtin.sh ##
    +@@ t/t1091-sparse-checkout-builtin.sh: test_expect_success 'revert to old sparse-checkout on empty update' '
    + 	)
    + '
    + 
    ++test_expect_success 'fail when lock is taken' '
    ++	test_when_finished rm -rf repo/.git/info/sparse-checkout.lock &&
    ++	touch repo/.git/info/sparse-checkout.lock &&
    ++	test_must_fail git -C repo sparse-checkout set deep 2>err &&
    ++	test_i18ngrep "File exists" err
    ++'
    ++
    + test_done
 -:  ---------- > 17:  20e7bd3da4 sparse-checkout: cone mode should not interact with .gitignore
73:  bfc76dc9e0 = 18:  3641e26973 fsmonitor: fix watchman integration
48:  aeedc362a2 = 19:  5a5aefda1d credential: set trace2_child_class for credential manager children
49:  3598c80600 = 20:  fc9c77fe77 sub-process: do not borrow cmd pointer from caller
50:  51f82404dd ! 21:  3019adb067 sub-process: add subprocess_start_argv()
    @@ sub-process.c
     +#include "quote.h"
      
      int cmd2process_cmp(const void *unused_cmp_data,
    - 		    const void *entry,
    + 		    const struct hashmap_entry *eptr,
     @@ sub-process.c: int subprocess_start(struct hashmap *hashmap, struct subprocess_entry *entry, co
      	return 0;
      }
    @@ sub-process.c: int subprocess_start(struct hashmap *hashmap, struct subprocess_e
     +		return err;
     +	}
     +
    -+	hashmap_entry_init(entry, strhash(entry->cmd));
    ++	hashmap_entry_init(&entry->ent, strhash(entry->cmd));
     +
     +	err = startfn(entry);
     +	if (err) {
    @@ sub-process.c: int subprocess_start(struct hashmap *hashmap, struct subprocess_e
     +		return err;
     +	}
     +
    -+	hashmap_add(hashmap, entry);
    ++	hashmap_add(hashmap, &entry->ent);
     +	return 0;
     +}
     +
51:  e64a86d9e1 = 22:  15d8415ded sha1-file: add function to update existing loose object cache
52:  ed87030bd6 = 23:  8259260346 packfile: add install_packed_git_and_mru()
53:  3a1b48822a = 24:  abfc0a4022 index-pack: avoid immediate object fetch while parsing packfile
54:  80ead377e6 ! 25:  706d2aec7a gvfs-helper: create tool to fetch objects using the GVFS Protocol
    @@ Documentation/config/core.txt: core.gvfs::
     +	TODO
     +
      core.sparseCheckout::
    - 	Enable "sparse checkout" feature. If "false", then sparse-checkout
    - 	is disabled. If "true", then sparse-checkout is enabled with the full
    + 	Enable "sparse checkout" feature. See linkgit:git-sparse-checkout[1]
    + 	for more information.
     
      ## Documentation/config/gvfs.txt (new) ##
     @@
    @@ Makefile: $(REMOTE_CURL_PRIMARY): remote-curl.o http.o http-walker.o GIT-LDFLAGS
      	$(QUIET_AR)$(RM) $@ && $(AR) $(ARFLAGS) $@ $^
      
     
    - ## builtin/index-pack.c ##
    -@@ builtin/index-pack.c: static void fix_unresolved_deltas(struct hashfile *f)
    - 		sorted_by_pos[i] = &ref_deltas[i];
    - 	QSORT(sorted_by_pos, nr_ref_deltas, delta_pos_compare);
    - 
    --	if (repository_format_partial_clone) {
    -+	if (repository_format_partial_clone || core_use_gvfs_helper) {
    - 		/*
    - 		 * Prefetch the delta bases.
    - 		 */
    -
      ## cache.h ##
     @@ cache.h: extern int precomposed_unicode;
      extern int protect_hfs;
    @@ cache.h: extern int precomposed_unicode;
     +extern const char *gvfs_cache_server_url;
     +extern const char *gvfs_shared_cache_pathname;
      
    - int core_apply_sparse_checkout;
    - int core_sparse_checkout_cone;
    + extern int core_apply_sparse_checkout;
    + extern int core_sparse_checkout_cone;
     
      ## config.c ##
     @@
    @@ config.c: int git_default_config(const char *var, const char *value, void *cb)
      	return 0;
      }
     
    - ## diff.c ##
    -@@ diff.c: static void add_if_missing(struct repository *r,
    - void diffcore_std(struct diff_options *options)
    - {
    - 	if (options->repo == the_repository &&
    --	    repository_format_partial_clone) {
    -+	    (repository_format_partial_clone || core_use_gvfs_helper)) {
    - 		/*
    - 		 * Prefetch the diff pairs that are about to be flushed.
    - 		 */
    -
      ## environment.c ##
     @@ environment.c: int protect_hfs = PROTECT_HFS_DEFAULT;
      #endif
    @@ environment.c: int protect_hfs = PROTECT_HFS_DEFAULT;
      /*
       * The character that begins a commented line in user-editable file
     
    - ## fetch-object.c ##
    -@@
    - #include "strbuf.h"
    - #include "transport.h"
    - #include "fetch-object.h"
    -+#include "gvfs-helper-client.h"
    - 
    - static void fetch_refs(const char *remote_name, struct ref *ref)
    - {
    -@@ fetch-object.c: void fetch_objects(const char *remote_name, const struct object_id *oids,
    - 	struct ref *ref = NULL;
    - 	int i;
    - 
    -+	if (core_use_gvfs_helper) {
    -+		enum ghc__created ghc = GHC__CREATED__NOTHING;
    -+
    -+		ghc__queue_oid_array(oids, oid_nr);
    -+		ghc__drain_queue(&ghc);
    -+		return;
    -+	}
    -+
    - 	for (i = 0; i < oid_nr; i++) {
    - 		struct ref *new_ref = alloc_ref(oid_to_hex(&oids[i]));
    - 		oidcpy(&new_ref->old_oid, &oids[i]);
    -
      ## gvfs-helper-client.c (new) ##
     @@
     +#include "cache.h"
    -+#include "commit.h"
     +#include "argv-array.h"
     +#include "trace2.h"
    -+#include "progress.h"
     +#include "oidset.h"
    -+#include "revision.h"
    -+#include "list-objects.h"
    -+#include "list-objects-filter.h"
    -+#include "list-objects-filter-options.h"
     +#include "object.h"
     +#include "object-store.h"
    -+#include "bisect.h"
     +#include "gvfs-helper-client.h"
     +#include "sub-process.h"
     +#include "sigchain.h"
    @@ gvfs-helper.c (new)
     +	return ec;
     +}
     
    + ## promisor-remote.c ##
    +@@
    + #include "promisor-remote.h"
    + #include "config.h"
    + #include "transport.h"
    ++#include "gvfs-helper-client.h"
    + 
    + static char *repository_format_partial_clone;
    + static const char *core_partial_clone_filter_default;
    +@@ promisor-remote.c: static int fetch_objects(const char *remote_name,
    + 	struct ref *ref = NULL;
    + 	int i;
    + 
    ++
    + 	for (i = 0; i < oid_nr; i++) {
    + 		struct ref *new_ref = alloc_ref(oid_to_hex(&oids[i]));
    + 		oidcpy(&new_ref->old_oid, &oids[i]);
    +@@ promisor-remote.c: struct promisor_remote *promisor_remote_find(const char *remote_name)
    + 
    + int has_promisor_remote(void)
    + {
    +-	return !!promisor_remote_find(NULL);
    ++	return core_use_gvfs_helper || !!promisor_remote_find(NULL);
    + }
    + 
    + static int remove_fetched_oids(struct repository *repo,
    +@@ promisor-remote.c: int promisor_remote_get_direct(struct repository *repo,
    + 	int to_free = 0;
    + 	int res = -1;
    + 
    ++	if (core_use_gvfs_helper) {
    ++		enum gh_client__created ghc = GHC__CREATED__NOTHING;
    ++
    ++		trace2_data_intmax("bug", the_repository, "fetch_objects/gvfs-helper", oid_nr);
    ++		gh_client__queue_oid_array(oids, oid_nr);
    ++		return gh_client__drain_queue(&ghc);
    ++	}
    ++
    + 	promisor_remote_init();
    + 
    + 	for (r = promisors; r; r = r->next) {
    +
      ## sha1-file.c ##
     @@
      #include "sigchain.h"
    @@ sha1-file.c: int oid_object_info_extended(struct repository *r, const struct obj
      				if (!read_object_process(oid))
      					goto retry;
      			}
    -
    - ## unpack-trees.c ##
    -@@ unpack-trees.c: static int check_updates(struct unpack_trees_options *o)
    - 		load_gitmodules_file(index, &state);
    - 
    - 	enable_delayed_checkout(&state);
    --	if (repository_format_partial_clone && o->update && !o->dry_run) {
    -+	if ((repository_format_partial_clone || core_use_gvfs_helper) &&
    -+	    o->update && !o->dry_run) {
    - 		/*
    - 		 * Prefetch the objects that are to be checked out in the loop
    - 		 * below.
55:  a9e428fb23 = 26:  73d2d384fd gvfs-helper: fix race condition when creating loose object dirs
57:  fa5c5118f3 <  -:  ---------- sparse-checkout: allow cone-type patterns for full tree
58:  33afd5ed5a <  -:  ---------- sparse-checkout: back out a change with conflicts
59:  15ede03e7a <  -:  ---------- fixup! sparse-checkout: init and set in cone mode
61:  5d39b08ded <  -:  ---------- fixup! gvfs-helper: create tool to fetch objects using the GVFS Protocol
62:  205244f13c ! 27:  7f68d1da5f sha1-file: create shared-cache directory if it doesn't exist
    @@ cache.h: extern int protect_ntfs;
     -extern const char *gvfs_shared_cache_pathname;
     +extern struct strbuf gvfs_shared_cache_pathname;
      
    - int core_apply_sparse_checkout;
    - int core_sparse_checkout_cone;
    + extern int core_apply_sparse_checkout;
    + extern int core_sparse_checkout_cone;
     
      ## config.c ##
     @@ config.c: static int git_default_gvfs_config(const char *var, const char *value)
63:  6317a4e5ed = 28:  c478dfbc2c gvfs-helper-client: rename ghs__ symbols to gh_server__
64:  529fbc44be = 29:  1c31a8c12e gvfs-helper-client: rename ghs__chosen_odb to gh_client__chosen_odb for clarity
65:  52eb2b630d ! 30:  16e40b32af gvfs-helper-client: rename ghc__ symbols to gh_client__ for clarity
    @@ Commit message
     
         Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
     
    - ## fetch-object.c ##
    -@@ fetch-object.c: void fetch_objects(const char *remote_name, const struct object_id *oids,
    - 	int i;
    - 
    - 	if (core_use_gvfs_helper) {
    --		enum ghc__created ghc = GHC__CREATED__NOTHING;
    -+		enum gh_client__created ghc = GHC__CREATED__NOTHING;
    - 
    --		ghc__queue_oid_array(oids, oid_nr);
    --		ghc__drain_queue(&ghc);
    -+		gh_client__queue_oid_array(oids, oid_nr);
    -+		gh_client__drain_queue(&ghc);
    - 		return;
    - 	}
    - 
    -
      ## gvfs-helper-client.c ##
     @@
      #include "quote.h"
66:  f996ff75aa <  -:  ---------- gvfs-helper: better handling of network errors
68:  e0ff373d83 ! 31:  617fd0555e fixup! gvfs-helper: better handling of network errors
    @@ Metadata
     Author: Jeff Hostetler <jeffhost@microsoft.com>
     
      ## Commit message ##
    -    fixup! gvfs-helper: better handling of network errors
    +    gvfs-helper: better handling of network errors
    +
    +    Add trace2 message for CURL and HTTP errors.
    +
    +    Fix typo reporting network error code back to gvfs-helper-client.
     
         Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
     
      ## gvfs-helper.c ##
    +@@ gvfs-helper.c: static void gh__response_status__set_from_slot(
    + 		strbuf_addf(&status->error_message, "%s (curl)",
    + 			    curl_easy_strerror(status->curl_code));
    + 		status->ec = GH__ERROR_CODE__CURL_ERROR;
    ++
    ++		trace2_data_string("gvfs-helper", NULL,
    ++				   "error/curl", status->error_message.buf);
    + 	} else {
    + 		strbuf_addf(&status->error_message, "HTTP %ld Unexpected",
    + 			    status->response_code);
    + 		status->ec = GH__ERROR_CODE__HTTP_UNEXPECTED_CODE;
    ++
    ++		trace2_data_string("gvfs-helper", NULL,
    ++				   "error/http", status->error_message.buf);
    + 	}
    + 
    + 	if (status->ec != GH__ERROR_CODE__OK)
     @@ gvfs-helper.c: static enum gh__error_code do_sub_cmd__get(int argc, const char **argv)
      }
      
    @@ gvfs-helper.c: static enum gh__error_code do_server_subprocess_get(void)
      			goto cleanup;
      		}
      
    --	ec = status.ec;
     +	/*
     +	 * We only use status.ec to tell the client whether the request
     +	 * was complete, incomplete, or had IO errors.  We DO NOT return
67:  74c49a1c4e = 32:  891a51b40c gvfs-helper-client: properly update loose cache with fetched OID
69:  b9ef9f40de <  -:  ---------- sparse-checkout: update locking pattern
70:  bd71c8d79b = 33:  df4a8db155 gvfs-helper: V2 robust retry and throttling
71:  5c65e9a00a = 34:  ae0c9ccdfe gvfs-helper: expose gvfs/objects GET and POST semantics
72:  6e92f6a4d8 ! 35:  740de11def gvfs-helper: dramatically reduce progress noise
    @@ gvfs-helper.c: static void setup_gvfs_objects_progress(struct gh__request_params
      }
      
      /*
    +
    + ## unpack-trees.c ##
    +@@ unpack-trees.c: int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options
    + 	memset(&pl, 0, sizeof(pl));
    + 	if (!core_apply_sparse_checkout || !o->update)
    + 		o->skip_sparse_checkout = 1;
    +-	if (!o->skip_sparse_checkout) {
    ++	if (!o->skip_sparse_checkout && !o->pl) {
    + 		if (core_virtualfilesystem) {
    + 			o->pl = &pl;
    + 		} else {
 -:  ---------- > 36:  8cf9286267 gvfs-helper-client.h: define struct object_id
```