### PR TITLE
gvfs-helper: dramatically reduce progress noise

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2528,17 +2528,11 @@ static void setup_gvfs_objects_progress(struct gh__request_params *params,
 		return;
 
 	if (params->b_is_post && params->object_count > 1) {
-		strbuf_addf(&params->progress_base_phase2_msg,
-			    "Requesting packfile %ld/%ld with %ld objects",
-			    num, den, params->object_count);
 		strbuf_addf(&params->progress_base_phase3_msg,
 			    "Receiving packfile %ld/%ld with %ld objects",
 			    num, den, params->object_count);
-	} else {
-		strbuf_addf(&params->progress_base_phase3_msg,
-			    "Receiving %ld/%ld loose object",
-			    num, den);
 	}
+	/* If requesting only one object, then do not show progress */
 }
 
 /*


### PR DESCRIPTION
During development, it was very helpful to see the gvfs-helper do its
work to request a pack-file or download a loose object. When these
messages appear during normal use, it leads to a very noisy terminal
output.

Remove all progress indicators when downloading loose objects. We know
that these can be numbered in the thousands in certain kinds of history
calls, and would litter the terminal output with noise. This happens
during 'git fetch' or 'git pull' as well when the tip commits are
checked for the new refs.

Remove the "Requesting packfile with %ld objects" message, as this
operation is very fast. We quickly follow up with the more valuable
"Receiving packfile %ld%ld with %ld objects". When a large "git
checkout" causes many pack-file downloads, it is good to know that Git
is asking for data from the server.

cc: @mjcheetham