### PR TITLE
[VFS] Merge updates from 2.24.0.windows.2

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -580,7 +580,7 @@ proc updatecommits {} {
 	set fd [open [concat | git log --no-color -z --pretty=raw $show_notes \
 			--parents --boundary $args --stdin \
 			"<<[join [concat $revs "--" \
-				[escape_filter_paths
+				[escape_filter_paths \
 					$vfilelimit($view)]] "\\n"]"] r]
     } err]} {
 	error_popup "[mc "Error executing git log:"] $err"

--- a/http.c
+++ b/http.c
@@ -1064,6 +1064,9 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
 	char *normalized_url;
 	struct urlmatch_config config = { STRING_LIST_INIT_DUP };
 
+	if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+		die("curl_global_init failed");
+
 	config.section = "http";
 	config.key = NULL;
 	config.collect_fn = http_options;
@@ -1103,9 +1106,6 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
 		}
 	}
 #endif
-
-	if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
-		die("curl_global_init failed");
 
 	http_proactive_auth = proactive_auth;
 

--- a/http.c
+++ b/http.c
@@ -150,7 +150,7 @@ static unsigned long empty_auth_useless =
 
 static struct curl_slist *pragma_header;
 static struct curl_slist *no_pragma_header;
-static struct curl_slist *extra_http_headers;
+static struct string_list extra_http_headers = STRING_LIST_INIT_DUP;
 
 static struct active_request_slot *active_queue_head;
 
@@ -414,11 +414,9 @@ static int http_options(const char *var, const char *value, void *cb)
 		if (!value) {
 			return config_error_nonbool(var);
 		} else if (!*value) {
-			curl_slist_free_all(extra_http_headers);
-			extra_http_headers = NULL;
+			string_list_clear(&extra_http_headers, 0);
 		} else {
-			extra_http_headers =
-				curl_slist_append(extra_http_headers, value);
+			string_list_append(&extra_http_headers, value);
 		}
 		return 0;
 	}
@@ -1064,9 +1062,6 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
 	char *normalized_url;
 	struct urlmatch_config config = { STRING_LIST_INIT_DUP };
 
-	if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
-		die("curl_global_init failed");
-
 	config.section = "http";
 	config.key = NULL;
 	config.collect_fn = http_options;
@@ -1106,6 +1101,9 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
 		}
 	}
 #endif
+
+	if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+		die("curl_global_init failed");
 
 	http_proactive_auth = proactive_auth;
 
@@ -1202,8 +1200,7 @@ void http_cleanup(void)
 #endif
 	curl_global_cleanup();
 
-	curl_slist_free_all(extra_http_headers);
-	extra_http_headers = NULL;
+	string_list_clear(&extra_http_headers, 0);
 
 	curl_slist_free_all(pragma_header);
 	pragma_header = NULL;
@@ -1627,10 +1624,11 @@ int run_one_slot(struct active_request_slot *slot,
 
 struct curl_slist *http_copy_default_headers(void)
 {
-	struct curl_slist *headers = NULL, *h;
+	struct curl_slist *headers = NULL;
+	const struct string_list_item *item;
 
-	for (h = extra_http_headers; h; h = h->next)
-		headers = curl_slist_append(headers, h->data);
+	for_each_string_list_item(item, &extra_http_headers)
+		headers = curl_slist_append(headers, item->string);
 
 	return headers;
 }


### PR DESCRIPTION
There were a few regressions in `v2.24.0.windows.1` that are updated in `v2.24.0.windows.2`.

@dscho requested that I rebase the `vfs-2.24.0` branch on top, but I disagree and think a merge is best.

1. When we rebase next, the `v2.24.0.windows.2` commit will be reachable from `v2.25.0.windows.1` so the commits will be dropped easily.

2. If we rebase, then we need to recreate the `features/sparse-checkout-2.24.0` branch. That's not actually a rebase but instead a merge of `ds/sparse-cone` from upstream and recreation of commits from `features/sparse-checkout-2.23.0`. That process would be a _little_ easier now, but that first merge will still be rough.

So, here is a simple merge taking the updates.