### PR TITLE
gvfs-helper: handle pack-file after single POST request

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1119,7 +1119,9 @@ static void gh__run_one_slot(struct active_request_slot *slot,
 		stop_progress(&params->progress);
 
 	if (status->ec == GH__ERROR_CODE__OK && params->b_write_to_file) {
-		if (params->b_is_post && params->object_count > 1)
+		if (params->b_is_post &&
+		    !strcmp(status->content_type.buf,
+			    "application/x-git-packfile"))
 			install_packfile(params, status);
 		else
 			install_loose(params, status);
@@ -2200,10 +2202,10 @@ static void do_req(const char *url_base,
 		if (params->tempfile)
 			delete_tempfile(&params->tempfile);
 
-		if (params->b_is_post && params->object_count > 1)
+		if (params->b_is_post)
 			create_tempfile_for_packfile(params, status);
-		else
-			create_tempfile_for_loose(params, status);
+
+		create_tempfile_for_loose(params, status);
 
 		if (!params->tempfile || status->ec != GH__ERROR_CODE__OK)
 			return;


### PR DESCRIPTION
If our POST request includes a commit ID, then the the remote will
send a pack-file containing the commit and all trees reachable from
its root tree. With the current implementation, this causes a
failure since we call install_loose() when asking for one object.

Modify the condition to check for install_pack() when the response
type changes.
