### PR TITLE
"gvfs-helper prefetch" during "git fetch"

### DIFF
--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -659,6 +659,10 @@ core.gvfs::
 		is first accessed and brought down to the client. Git.exe can't
 		currently tell the first access vs subsequent accesses so this
 		flag just blocks them from occurring at all.
+	GVFS_PREFETCH_DURING_FETCH::
+		Bit value 128
+		While performing a `git fetch` command, use the gvfs-helper to
+		perform a "prefetch" of commits and trees.
 --
 
 core.useGvfsHelper::

--- a/Documentation/fetch-options.txt
+++ b/Documentation/fetch-options.txt
@@ -250,6 +250,11 @@ endif::git-pull[]
 	'git-pull' the --ff-only option will still check for forced updates
 	before attempting a fast-forward update. See linkgit:git-config[1].
 
+--no-update-remote-refs::
+	By default, git updates the `refs/remotes/` refspace with the refs
+	advertised by the remotes during a `git fetch` command. With this
+	option, those refs will be ignored.
+
 -4::
 --ipv4::
 	Use IPv4 addresses only, ignoring IPv6 addresses.

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -27,6 +27,8 @@
 #include "branch.h"
 #include "promisor-remote.h"
 #include "commit-graph.h"
+#include "gvfs.h"
+#include "gvfs-helper-client.h"
 
 #define FORCED_UPDATES_DELAY_WARNING_IN_MS (10 * 1000)
 
@@ -1823,6 +1825,9 @@ int cmd_fetch(int argc, const char **argv, const char *prefix)
 	}
 
 	fetch_if_missing = 0;
+
+	if (core_gvfs & GVFS_PREFETCH_DURING_FETCH)
+		gh_client__prefetch(0, NULL);
 
 	if (remote) {
 		if (filter_options.choice || has_promisor_remote())

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -79,6 +79,7 @@ static struct refspec refmap = REFSPEC_INIT_FETCH;
 static struct list_objects_filter_options filter_options;
 static struct string_list server_options = STRING_LIST_INIT_DUP;
 static struct string_list negotiation_tip = STRING_LIST_INIT_NODUP;
+static int update_remote_refs = 1;
 
 static int git_fetch_config(const char *k, const char *v, void *cb)
 {
@@ -200,6 +201,8 @@ static struct option builtin_fetch_options[] = {
 		 N_("run 'gc --auto' after fetching")),
 	OPT_BOOL(0, "show-forced-updates", &fetch_show_forced_updates,
 		 N_("check for forced-updates on all updated branches")),
+	OPT_BOOL(0, "update-remote-refs", &update_remote_refs,
+		 N_("update the refs/remotes/ refspace")),
 	OPT_END()
 };
 
@@ -744,6 +747,9 @@ static int update_local_ref(struct ref *ref,
 	struct branch *current_branch = branch_get(NULL);
 	const char *pretty_ref = prettify_refname(ref->name);
 	int fast_forward = 0;
+
+	if (!update_remote_refs && starts_with(ref->name, "refs/remotes/"))
+		return 0;
 
 	type = oid_object_info(the_repository, &ref->new_oid, NULL);
 	if (type < 0)

--- a/gvfs.h
+++ b/gvfs.h
@@ -17,6 +17,7 @@
 #define GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT       (1 << 3)
 #define GVFS_FETCH_SKIP_REACHABILITY_AND_UPLOADPACK (1 << 4)
 #define GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS      (1 << 6)
+#define GVFS_PREFETCH_DURING_FETCH		    (1 << 7)
 
 void gvfs_load_config_value(const char *value);
 int gvfs_config_is_set(int mask);


### PR DESCRIPTION
This is a follow-up to #227.

1. When a new flag is added to our Git config, we can run `gvfs-helper prefetch` inside of our `git fetch` calls. This will help ensure we have updated commits and trees even if the background prefetches have fallen behind (or are not running).

2. With a new `--no-update-remote-refs` we can avoid updating the `refs/remotes` namespace. This will allow us to run `git fetch --all --no-update-remote-refs +refs/heads/*:refs/hidden/*` and we will get the new refs into a local folder (that doesn't appear anywhere). The most important thing is that users will still see when their remote refs update.