### PR TITLE
Improving "git add ." performance

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -504,8 +504,8 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 	die_path_inside_submodule(&the_index, &pathspec);
 
 	enable_fscache(0);
-	/* We do not really re-read the index but update the up-to-date flags */
-	preload_index(&the_index, &pathspec, 0);
+	refresh_index(&the_index, REFRESH_QUIET|REFRESH_UNMERGED,  &pathspec,
+		      NULL, NULL);
 
 	if (add_new_files) {
 		int baselen;

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -518,7 +518,10 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 		}
 
 		/* This picks up the paths that are not tracked */
+		trace2_region_enter("add", "fill_directory", NULL);
 		baselen = fill_directory(&dir, &the_index, &pathspec);
+		trace2_region_leave("add", "fill_directory", NULL);
+
 		if (pathspec.nr)
 			seen = prune_directory(&dir, &pathspec, baselen);
 	}
@@ -567,13 +570,21 @@ int cmd_add(int argc, const char **argv, const char *prefix)
 
 	plug_bulk_checkin();
 
-	if (add_renormalize)
+	if (add_renormalize) {
+		trace2_region_enter("add", "renormalize_tracked_files", NULL);
 		exit_status |= renormalize_tracked_files(&pathspec, flags);
-	else
+		trace2_region_leave("add", "renormalize_tracked_files", NULL);
+	} else {
+		trace2_region_enter("add", "add_files_to_cache", NULL);
 		exit_status |= add_files_to_cache(prefix, &pathspec, flags);
+		trace2_region_leave("add", "add_files_to_cache", NULL);
+	}
 
-	if (add_new_files)
+	if (add_new_files) {
+		trace2_region_enter("add", "add_files", NULL);
 		exit_status |= add_files(&dir, flags);
+		trace2_region_leave("add", "add_files", NULL);
+	}
 
 	if (chmod_arg && pathspec.nr)
 		chmod_pathspec(&pathspec, chmod_arg[0]);

--- a/dir.c
+++ b/dir.c
@@ -2480,7 +2480,15 @@ static struct untracked_cache_dir *validate_untracked_cache(struct dir_struct *d
 	 * use cache on just a subset of the worktree. pathspec
 	 * support could make the matter even worse.
 	 */
-	if (base_len || (pathspec && pathspec->nr))
+	if (base_len || (pathspec && pathspec->nr > 1))
+		return NULL;
+
+	/*
+	 * Allow single entry pathspecs if the pathspec has no effect on
+	 * matching (e.g. 'git add .' from the root of the repo)
+	 */
+	if (pathspec && pathspec->nr == 1 &&
+	    !strcmp(pathspec->items[0].original, "."))
 		return NULL;
 
 	/* Different set of flags may produce different results */


### PR DESCRIPTION
This is based on the commits from #199 that still pass the tests.

I'm using this PR to track the changes and create an installer so I can run PerfView traces.

On our target enlistment with a clean fsmonitor hook, here are the timings:

* `git add .`: 8s
* `git add -p`: 3s

If we just hydrated the ~700,000 files in the sparse-checkout, then `git add .` takes 53 seconds, as the fsmonitor reports every file as changed since the last timestamp.

I removed the "before" timings as they are not that different. Perhaps our other performance improvements have made this be less of an issue already.