### PR TITLE
remote-https: do not call fetch-pack if using gvfs helper

### DIFF
--- a/remote-curl.c
+++ b/remote-curl.c
@@ -1046,6 +1046,9 @@ static int fetch_git(struct discovery *heads,
 	struct argv_array args = ARGV_ARRAY_INIT;
 	struct strbuf rpc_result = STRBUF_INIT;
 
+	if (core_use_gvfs_helper)
+		return 0;
+
 	argv_array_pushl(&args, "fetch-pack", "--stateless-rpc",
 			 "--stdin", "--lock-pack", NULL);
 	if (options.followtags)


### PR DESCRIPTION
The `gvfs-helper` is supposed to avoid calling `git fetch-pack` by downloading objects through the GVFS protocol instead. For some reason, some `git fetch` calls still end up calling `git fetch-pack` which gets a complaint from the remote because it does not support that kind of fetch.

Put a hard stop in the `fetch_git()` method to prevent this process run.