### PR TITLE
diff: skip batch object download when possible

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -4630,6 +4630,11 @@ void diff_setup_done(struct diff_options *options)
 	if (!options->use_color || external_diff())
 		options->color_moved = 0;
 
+	if (!(options->output_format & ~(DIFF_FORMAT_NAME |
+					 DIFF_FORMAT_RAW)) &&
+	    !options->detect_rename)
+		options->skip_batch_download_objects = 1;
+
 	FREE_AND_NULL(options->parseopts);
 }
 
@@ -6504,7 +6509,9 @@ static void add_if_missing(struct repository *r,
 
 void diffcore_std(struct diff_options *options)
 {
-	if (options->repo == the_repository && has_promisor_remote()) {
+	if (!options->skip_batch_download_objects &&
+	    options->repo == the_repository &&
+	    has_promisor_remote()) {
 		/*
 		 * Prefetch the diff pairs that are about to be flushed.
 		 */

--- a/diff.h
+++ b/diff.h
@@ -281,6 +281,7 @@ struct diff_options {
 	int show_rename_progress;
 	int dirstat_permille;
 	int setup;
+	int skip_batch_download_objects;
 
 	/* Number of hexdigits to abbreviate raw format output to. */
 	int abbrev;


### PR DESCRIPTION
When computing changed-path Bloom filters or performing a name-only
diff, we do not need the blob contents before completing the diff
values. Thus, we do not need to download a pack containing the blobs
we do not have on-disk before completing our diff calculation.

This prevents downloading every blob in a partial clone during
"git log --raw --no-rename" and "git diff --no-rename --name-only"
commands.