### PR TITLE
Fix the CI/PR build failures in the "Documentation" job

### DIFF
--- a/ci/test-documentation.sh
+++ b/ci/test-documentation.sh
@@ -7,6 +7,7 @@
 
 filter_log () {
 	sed -e '/^GIT_VERSION = /d' \
+	    -e "/constant Gem::ConfigMap is deprecated/d" \
 	    -e '/^    \* new asciidoc flags$/d' \
 	    -e '/stripped namespace before processing/d' \
 	    -e '/Attributed.*IDs for element/d' \


### PR DESCRIPTION
This is a companion to git/git#707 and will fix e.g. the PR build failure in microsoft/git#244.