### PR TITLE
Avoiding returning null without closing the file

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -380,11 +380,13 @@ static struct commit_graph *load_commit_graph_chain(struct repository *r,
 	fp = fopen(chain_name, "r");
 	stat_res = stat(chain_name, &st);
 	free(chain_name);
-
-	if (!fp ||
-	    stat_res ||
-	    st.st_size <= the_hash_algo->hexsz)
+	if (!fp) 
 		return NULL;
+	if (stat_res ||
+	    st.st_size <= the_hash_algo->hexsz){
+		fclose(fp);
+		return NULL;
+	}
 
 	count = st.st_size / (the_hash_algo->hexsz + 1);
 	oids = xcalloc(count, sizeof(struct object_id));

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -380,11 +380,12 @@ static struct commit_graph *load_commit_graph_chain(struct repository *r,
 	fp = fopen(chain_name, "r");
 	stat_res = stat(chain_name, &st);
 	free(chain_name);
-
-	if (!fp ||
-	    stat_res ||
-	    st.st_size <= the_hash_algo->hexsz)
+	if (!fp) return NULL;
+	if (stat_res ||
+	    st.st_size <= the_hash_algo->hexsz){
+		fclose(fp);
 		return NULL;
+	}
 
 	count = st.st_size / (the_hash_algo->hexsz + 1);
 	oids = xcalloc(count, sizeof(struct object_id));

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -380,7 +380,8 @@ static struct commit_graph *load_commit_graph_chain(struct repository *r,
 	fp = fopen(chain_name, "r");
 	stat_res = stat(chain_name, &st);
 	free(chain_name);
-	if (!fp) return NULL;
+	if (!fp) 
+		return NULL;
 	if (stat_res ||
 	    st.st_size <= the_hash_algo->hexsz){
 		fclose(fp);


### PR DESCRIPTION
Avoiding returning null without closing the file
