### PR TITLE
status: fix crash in `git status --deserialize --verbose` (based on v2.26)

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1592,6 +1592,22 @@ int cmd_status(int argc, const char **argv, const char *prefix)
 	 */
 	try_deserialize = (!do_serialize &&
 			   (do_implicit_deserialize || do_explicit_deserialize));
+
+	/*
+	 * Disable deserialize when verbose is set because it causes us to
+	 * print diffs for each modified file, but that requires us to have
+	 * the index loaded and we don't want to do that (at least not now for
+	 * this seldom used feature).  My fear is that would further tangle
+	 * the merge conflict with upstream.
+	 *
+	 * TODO Reconsider this in the future.
+	 */
+	if (try_deserialize && verbose) {
+		trace2_data_string("status", the_repository, "deserialize/reject",
+				   "args/verbose");
+		try_deserialize = 0;
+	}
+
 	if (try_deserialize)
 		goto skip_init;
 	/*

--- a/t/t7524-serialized-status.sh
+++ b/t/t7524-serialized-status.sh
@@ -387,4 +387,43 @@ EOF
 
 '
 
+test_expect_success 'ensure deserialize -v does not crash' '
+
+	git init verbose_test &&
+	touch verbose_test/a &&
+	touch verbose_test/b &&
+	touch verbose_test/c &&
+	git -C verbose_test add a b c &&
+	git -C verbose_test commit -m abc &&
+
+	echo green >>verbose_test/a &&
+	git -C verbose_test add a &&
+	echo red_1 >>verbose_test/b &&
+	echo red_2 >verbose_test/dirt &&
+
+	git -C verbose_test status    >output.ref &&
+	git -C verbose_test status -v >output.ref_v &&
+
+	git -C verbose_test --no-optional-locks status --serialize=../verbose_test.dat      >output.ser.long &&
+	git -C verbose_test --no-optional-locks status --serialize=../verbose_test.dat_v -v >output.ser.long_v &&
+
+	# Verify that serialization does not affect the status output itself.
+	test_i18ncmp output.ref   output.ser.long &&
+	test_i18ncmp output.ref_v output.ser.long_v &&
+
+	GIT_TRACE2_PERF="$(pwd)"/verbose_test.log \
+	git -C verbose_test status --deserialize=../verbose_test.dat >output.des.long &&
+
+	# Verify that normal deserialize was actually used and produces the same result.
+	test_i18ncmp output.ser.long output.des.long &&
+	grep -q "deserialize/result:ok" verbose_test.log &&
+
+	GIT_TRACE2_PERF="$(pwd)"/verbose_test.log_v \
+	git -C verbose_test status --deserialize=../verbose_test.dat_v -v >output.des.long_v &&
+
+	# Verify that vebose mode produces the same result because verbose was rejected.
+	test_i18ncmp output.ser.long_v output.des.long_v &&
+	grep -q "deserialize/reject:args/verbose" verbose_test.log_v
+'
+
 test_done

--- a/wt-status-deserialize.c
+++ b/wt-status-deserialize.c
@@ -690,6 +690,7 @@ static int wt_deserialize_fd(const struct wt_status *cmd_s, struct wt_status *de
 	/*
 	 * Copy over display-related fields from the current command.
 	 */
+	des_s->repo = cmd_s->repo;
 	des_s->verbose = cmd_s->verbose;
 	/* amend */
 	/* whence */


### PR DESCRIPTION
Fix crash in `git status -v` when using the serialization cache.

This PR replaces https://github.com/microsoft/git/pull/258 and is based upon v2.26, rather than v2.25 where it was originally reported.
