### PR TITLE
deserialize-status: silently fallback if we cannot read cache file

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -211,12 +211,18 @@ static int opt_parse_deserialize(const struct option *opt, const char *arg, int 
 			free(deserialize_path);
 			deserialize_path = xstrdup(arg);
 		}
-		if (deserialize_path && *deserialize_path
-		    && (wt_status_deserialize_access(deserialize_path, R_OK) != 0))
-			die("cannot find serialization file '%s'",
-			    deserialize_path);
-
-		do_explicit_deserialize = 1;
+		if (!deserialize_path || !*deserialize_path)
+			do_explicit_deserialize = 1; /* read stdin */
+		else if (wt_status_deserialize_access(deserialize_path, R_OK) == 0)
+			do_explicit_deserialize = 1; /* can read from this file */
+		else {
+			/*
+			 * otherwise, silently fallback to the normal
+			 * collection scan
+			 */
+			do_implicit_deserialize = 0;
+			do_explicit_deserialize = 0;
+		}
 	}
 
 	return 0;

--- a/t/t7524-serialized-status.sh
+++ b/t/t7524-serialized-status.sh
@@ -426,4 +426,20 @@ test_expect_success 'ensure deserialize -v does not crash' '
 	grep -q "deserialize/reject:args/verbose" verbose_test.log_v
 '
 
+test_expect_success 'fallback when implicit' '
+	git init implicit_fallback_test &&
+	git -C implicit_fallback_test -c status.deserializepath=foobar status
+'
+
+test_expect_success 'fallback when explicit' '
+	git init explicit_fallback_test &&
+	git -C explicit_fallback_test status --deserialize=foobar
+'
+
+test_expect_success 'deserialize from stdin' '
+	git init stdin_test &&
+	git -C stdin_test status --serialize >serialized_status.dat &&
+	cat serialize_status.dat | git -C stdin_test status --deserialize
+'
+
 test_done


### PR DESCRIPTION
Teach Git to not throw a fatal error when an explicitly-specified
status-cache file (`git status --deserialize=<foo>`) could not be
found or opened for reading and silently fallback to a traditional
scan.

This matches the behavior when the status-cache file is implicitly
given via a config setting.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>
