### PR TITLE
Thread-safe pkt-line

### DIFF
--- a/pkt-line.c
+++ b/pkt-line.c
@@ -409,16 +409,23 @@ char *packet_read_line(int fd, int *len_p)
 				  packet_buffer, sizeof(packet_buffer));
 }
 
-int packet_read_line_gently(int fd, int *dst_len, char **dst_line)
+int packet_read_line_gently_r(int fd, int *dst_len, char **dst_line,
+			      char *buffer, size_t buffer_size)
 {
 	int len = packet_read(fd, NULL, NULL,
-			      packet_buffer, sizeof(packet_buffer),
+			      buffer, buffer_size,
 			      PACKET_READ_CHOMP_NEWLINE|PACKET_READ_GENTLE_ON_EOF);
 	if (dst_len)
 		*dst_len = len;
 	if (dst_line)
-		*dst_line = (len > 0) ? packet_buffer : NULL;
+		*dst_line = (len > 0) ? buffer : NULL;
 	return len;
+}
+
+int packet_read_line_gently(int fd, int *dst_len, char **dst_line)
+{
+	return packet_read_line_gently_r(fd, dst_len, dst_line,
+					 packet_buffer, sizeof(packet_buffer));
 }
 
 char *packet_read_line_buf(char **src, size_t *src_len, int *dst_len)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -239,7 +239,7 @@ void packet_buf_write_len(struct strbuf *buf, const char *data, size_t len)
 
 int write_packetized_from_fd(int fd_in, int fd_out)
 {
-	static char buf[LARGE_PACKET_DATA_MAX];
+	char buf[LARGE_PACKET_DATA_MAX];
 	int err = 0;
 	ssize_t bytes_to_write;
 

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -9,7 +9,14 @@
  */
 char packet_buffer[LARGE_PACKET_MAX];
 
+/*
+ * Warning: `packet_trace_prefix` and the static variables `in_pack`
+ * and `sideband` inside of `packet_trace()` make packet tracing not
+ * safe for threaded or concurrent operations.
+ * TODO Eventually, we should revisit this.
+ */
 static const char *packet_trace_prefix = "git";
+
 static struct trace_key trace_packet = TRACE_KEY_INIT(PACKET);
 static struct trace_key trace_pack = TRACE_KEY_INIT(PACKFILE);
 

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -152,19 +152,21 @@ static void format_packet(struct strbuf *out, const char *prefix,
 static int packet_write_fmt_1(int fd, int gently, const char *prefix,
 			      const char *fmt, va_list args)
 {
-	static struct strbuf buf = STRBUF_INIT;
+	struct strbuf buf = STRBUF_INIT;
+	int err = 0;
 
-	strbuf_reset(&buf);
 	format_packet(&buf, prefix, fmt, args);
 	if (write_in_full(fd, buf.buf, buf.len) < 0) {
 		if (!gently) {
 			check_pipe(errno);
 			die_errno(_("packet write with format failed"));
 		}
-		return error(_("packet write with format failed"));
+		err = error(_("packet write with format failed"));
 	}
 
-	return 0;
+	strbuf_release(&buf);
+
+	return err;
 }
 
 void packet_write_fmt(int fd, const char *fmt, ...)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -397,10 +397,16 @@ static char *packet_read_line_generic_r(int fd,
 	return (len > 0) ? buffer : NULL;
 }
 
-char *packet_read_line(int fd, int *len_p)
+char *packet_read_line_r(int fd, int *len_p, char *buffer, size_t buffer_size)
 {
 	return packet_read_line_generic_r(fd, NULL, NULL, len_p,
-					  packet_buffer, sizeof(packet_buffer));
+					  buffer, buffer_size);
+}
+
+char *packet_read_line(int fd, int *len_p)
+{
+	return packet_read_line_r(fd, len_p,
+				  packet_buffer, sizeof(packet_buffer));
 }
 
 int packet_read_line_gently(int fd, int *dst_len, char **dst_line)

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -191,7 +191,7 @@ int packet_write_fmt_gently(int fd, const char *fmt, ...)
 
 int packet_write_gently(const int fd_out, const char *buf, size_t size)
 {
-	static char packet_write_buffer[LARGE_PACKET_MAX];
+	char packet_write_buffer[LARGE_PACKET_MAX];
 	size_t packet_size;
 
 	if (size > sizeof(packet_write_buffer) - 4)

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -100,6 +100,11 @@ enum packet_read_status packet_read_with_status(int fd, char **src_buffer,
  * packet is written to it.
  */
 char *packet_read_line(int fd, int *size);
+/*
+ * Version of `packet_read_line()` that uses a supplied buffer
+ * rather than a static buffer.
+ */
+char *packet_read_line_r(int fd, int *size, char *buffer, size_t buffer_size);
 
 /*
  * Convenience wrapper for packet_read that sets the PACKET_READ_GENTLE_ON_EOF

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -116,6 +116,12 @@ char *packet_read_line_r(int fd, int *size, char *buffer, size_t buffer_size);
  * length of the packet is written to it.
  */
 int packet_read_line_gently(int fd, int *size, char **dst_line);
+/*
+ * Version of `packet_read_line_gently()` that uses a supplied buffer
+ * rather than a static buffer.
+ */
+int packet_read_line_gently_r(int fd, int *size, char **dst_line,
+			      char *buffer, size_t buffer_size);
 
 /*
  * Same as packet_read_line, but read from a buf rather than a descriptor;

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -202,6 +202,12 @@ enum packet_read_status packet_reader_peek(struct packet_reader *reader);
 #define DEFAULT_PACKET_MAX 1000
 #define LARGE_PACKET_MAX 65520
 #define LARGE_PACKET_DATA_MAX (LARGE_PACKET_MAX - 4)
+
+/*
+ * Warning: `packet_buffer` is public and directly referenced from many
+ * source files.  This makes threaded use of packet_ routines unsafe.
+ * TODO Eventually, we should phase this out with a proper API.
+ */
 extern char packet_buffer[LARGE_PACKET_MAX];
 
 struct packet_writer {


### PR DESCRIPTION
This was part of @jeffhostetler's parallel checkout work.

I don't actually think that we _need_ all of these patches (just "pkt-line: use stack rather than static buffer in packet_write_gently()", I think), but it'd be good to just get all of that integrated.

Biggest question right now: should we upstream this right away? I guess we should, eh?