### PR TITLE
Implement a simple IPC mechanism in preparation for the internal FSMonitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -736,6 +736,7 @@ TEST_BUILTINS_OBJS += test-serve-v2.o
 TEST_BUILTINS_OBJS += test-sha1.o
 TEST_BUILTINS_OBJS += test-sha256.o
 TEST_BUILTINS_OBJS += test-sigchain.o
+TEST_BUILTINS_OBJS += test-simple-ipc.o
 TEST_BUILTINS_OBJS += test-strcmp-offset.o
 TEST_BUILTINS_OBJS += test-string-list.o
 TEST_BUILTINS_OBJS += test-submodule-config.o

--- a/Makefile
+++ b/Makefile
@@ -987,6 +987,7 @@ LIB_OBJS += sha1-name.o
 LIB_OBJS += shallow.o
 LIB_OBJS += sideband.o
 LIB_OBJS += sigchain.o
+LIB_OBJS += simple-ipc.o
 LIB_OBJS += split-index.o
 LIB_OBJS += stable-qsort.o
 LIB_OBJS += strbuf.o

--- a/convert.c
+++ b/convert.c
@@ -899,7 +899,7 @@ static int apply_multi_file_filter(const char *path, const char *src, size_t len
 	if (fd >= 0)
 		err = write_packetized_from_fd(fd, process->in);
 	else
-		err = write_packetized_from_buf(src, len, process->in);
+		err = write_packetized_from_buf(src, len, process->in, 1);
 	if (err)
 		goto done;
 

--- a/convert.c
+++ b/convert.c
@@ -916,7 +916,7 @@ static int apply_multi_file_filter(const char *path, const char *src, size_t len
 		if (err)
 			goto done;
 
-		err = read_packetized_to_strbuf(process->out, &nbuf) < 0;
+		err = read_packetized_to_strbuf(process->out, &nbuf, 0) < 0;
 		if (err)
 			goto done;
 

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -254,7 +254,8 @@ int write_packetized_from_fd(int fd_in, int fd_out)
 	return err;
 }
 
-int write_packetized_from_buf(const char *src_in, size_t len, int fd_out)
+int write_packetized_from_buf(const char *src_in, size_t len, int fd_out,
+			      int flush_at_end)
 {
 	int err = 0;
 	size_t bytes_written = 0;
@@ -270,7 +271,7 @@ int write_packetized_from_buf(const char *src_in, size_t len, int fd_out)
 		err = packet_write_gently(fd_out, src_in + bytes_written, bytes_to_write);
 		bytes_written += bytes_to_write;
 	}
-	if (!err)
+	if (!err && flush_at_end)
 		err = packet_flush_gently(fd_out);
 	return err;
 }

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -291,8 +291,11 @@ static int get_packet_data(int fd, char **src_buf, size_t *src_size,
 		*src_size -= ret;
 	} else {
 		ret = read_in_full(fd, dst, size);
-		if (ret < 0)
+		if (ret < 0) {
+			if (options & PACKET_READ_NEVER_DIE)
+				return error_errno(_("read error"));
 			die_errno(_("read error"));
+		}
 	}
 
 	/* And complain if we didn't get enough bytes to satisfy the read. */
@@ -300,6 +303,8 @@ static int get_packet_data(int fd, char **src_buf, size_t *src_size,
 		if (options & PACKET_READ_GENTLE_ON_EOF)
 			return -1;
 
+		if (options & PACKET_READ_NEVER_DIE)
+			return error(_("the remote end hung up unexpectedly"));
 		die(_("the remote end hung up unexpectedly"));
 	}
 
@@ -328,6 +333,9 @@ enum packet_read_status packet_read_with_status(int fd, char **src_buffer,
 	len = packet_length(linelen);
 
 	if (len < 0) {
+		if (options & PACKET_READ_NEVER_DIE)
+			return error(_("protocol error: bad line length "
+				       "character: %.4s"), linelen);
 		die(_("protocol error: bad line length character: %.4s"), linelen);
 	} else if (!len) {
 		packet_trace("0000", 4, 0);
@@ -338,12 +346,19 @@ enum packet_read_status packet_read_with_status(int fd, char **src_buffer,
 		*pktlen = 0;
 		return PACKET_READ_DELIM;
 	} else if (len < 4) {
+		if (options & PACKET_READ_NEVER_DIE)
+			return error(_("protocol error: bad line length %d"),
+				     len);
 		die(_("protocol error: bad line length %d"), len);
 	}
 
 	len -= 4;
-	if ((unsigned)len >= size)
+	if ((unsigned)len >= size) {
+		if (options & PACKET_READ_NEVER_DIE)
+			return error(_("protocol error: bad line length %d"),
+				     len);
 		die(_("protocol error: bad line length %d"), len);
+	}
 
 	if (get_packet_data(fd, src_buffer, src_len, buffer, len, options) < 0) {
 		*pktlen = -1;

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -426,7 +426,7 @@ char *packet_read_line_buf(char **src, size_t *src_len, int *dst_len)
 	return packet_read_line_generic(-1, src, src_len, dst_len);
 }
 
-ssize_t read_packetized_to_strbuf(int fd_in, struct strbuf *sb_out)
+ssize_t read_packetized_to_strbuf(int fd_in, struct strbuf *sb_out, int options)
 {
 	int packet_len;
 
@@ -442,7 +442,7 @@ ssize_t read_packetized_to_strbuf(int fd_in, struct strbuf *sb_out)
 			 * that there is already room for the extra byte.
 			 */
 			sb_out->buf + sb_out->len, LARGE_PACKET_DATA_MAX+1,
-			PACKET_READ_GENTLE_ON_EOF);
+			options | PACKET_READ_GENTLE_ON_EOF);
 		if (packet_len <= 0)
 			break;
 		sb_out->len += packet_len;

--- a/pkt-line.c
+++ b/pkt-line.c
@@ -189,7 +189,7 @@ int packet_write_fmt_gently(int fd, const char *fmt, ...)
 
 int packet_write_gently(const int fd_out, const char *buf, size_t size)
 {
-	static char packet_write_buffer[LARGE_PACKET_MAX];
+	char packet_write_buffer[LARGE_PACKET_MAX];
 	size_t packet_size;
 
 	if (size > sizeof(packet_write_buffer) - 4)

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -68,10 +68,14 @@ int write_packetized_from_buf(const char *src_in, size_t len, int fd_out);
  *
  * If options contains PACKET_READ_DIE_ON_ERR_PACKET, it dies when it sees an
  * ERR packet.
+ *
+ * With `PACKET_READ_NEVER_DIE`, no errors are allowed to trigger die() (except
+ * an ERR packet, when `PACKET_READ_DIE_ON_ERR_PACKET` is in effect).
  */
 #define PACKET_READ_GENTLE_ON_EOF     (1u<<0)
 #define PACKET_READ_CHOMP_NEWLINE     (1u<<1)
 #define PACKET_READ_DIE_ON_ERR_PACKET (1u<<2)
+#define PACKET_READ_NEVER_DIE         (1u<<3)
 int packet_read(int fd, char **src_buffer, size_t *src_len, char
 		*buffer, unsigned size, int options);
 

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -33,7 +33,8 @@ int packet_flush_gently(int fd);
 int packet_write_fmt_gently(int fd, const char *fmt, ...) __attribute__((format (printf, 2, 3)));
 int packet_write_gently(const int fd_out, const char *buf, size_t size);
 int write_packetized_from_fd(int fd_in, int fd_out);
-int write_packetized_from_buf(const char *src_in, size_t len, int fd_out);
+int write_packetized_from_buf(const char *src_in, size_t len, int fd_out,
+			      int flush_at_end);
 
 /*
  * Read a packetized line into the buffer, which must be at least size bytes

--- a/pkt-line.h
+++ b/pkt-line.h
@@ -125,8 +125,12 @@ char *packet_read_line_buf(char **src_buf, size_t *src_len, int *size);
 
 /*
  * Reads a stream of variable sized packets until a flush packet is detected.
+ *
+ * The options are augmented by PACKET_READ_GENTLE_ON_EOF and passed to
+ * packet_read.
  */
-ssize_t read_packetized_to_strbuf(int fd_in, struct strbuf *sb_out);
+ssize_t read_packetized_to_strbuf(int fd_in, struct strbuf *sb_out,
+				  int options);
 
 /*
  * Receive multiplexed output stream over git native protocol.

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -1,0 +1,185 @@
+#include "cache.h"
+#include "simple-ipc.h"
+#include "strbuf.h"
+#include "pkt-line.h"
+
+#ifdef GIT_WINDOWS_NATIVE
+static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
+{
+	int off = 0;
+	struct strbuf realpath = STRBUF_INIT;
+
+	if (!strbuf_realpath(&realpath, path, 0))
+		return error(_("could not normalize '%s'"), path);
+
+	off = swprintf(wpath, alloc, L"\\\\.\\pipe\\");
+	if (xutftowcs(wpath + off, realpath.buf, alloc - off) < 0)
+		return error(_("could not determine pipe path for '%s'"),
+			     realpath.buf);
+
+	/* Handle drive prefix */
+	if (wpath[off] && wpath[off + 1] == L':') {
+		wpath[off + 1] = L'_';
+		off += 2;
+	}
+
+	for (; wpath[off]; off++)
+		if (wpath[off] == L'/')
+			wpath[off] = L'\\';
+
+	strbuf_release(&realpath);
+	return 0;
+}
+
+struct ipc_handle_client_data {
+	struct ipc_command_listener *server;
+	HANDLE pipe;
+};
+
+static int reply(void *reply_data, const char *response, size_t len)
+{
+	int fd = *(int *)reply_data;
+
+	return write_packetized_from_buf(response, len, fd, 0);
+}
+
+static DWORD WINAPI ipc_handle_client(LPVOID param)
+{
+	struct ipc_handle_client_data *data = param;
+	struct strbuf buf = STRBUF_INIT;
+	HANDLE process = GetCurrentProcess(), handle;
+	int ret = 0, fd;
+
+	/*
+	 * First duplicate the handle, then wrap it in a file descriptor, so
+	 * that we can use pkt-line on it.
+	 */
+	if (!DuplicateHandle(process, data->pipe, process, &handle, 0, FALSE,
+			     DUPLICATE_SAME_ACCESS)) {
+		errno = err_win_to_posix(GetLastError());
+		return -1;
+	}
+
+	fd = _open_osfhandle((intptr_t)handle, O_RDWR|O_BINARY);
+	if (fd < 0) {
+		errno = err_win_to_posix(GetLastError());
+		CloseHandle(handle);
+		return -1;
+	}
+
+	ret = read_packetized_to_strbuf(fd, &buf, PACKET_READ_NEVER_DIE);
+	if (ret >= 0) {
+		ret = data->server->handle_client(data->server,
+						  buf.buf, reply, &fd);
+		packet_flush_gently(fd);
+		if (ret == SIMPLE_IPC_QUIT)
+			data->server->active = 0;
+	}
+	strbuf_release(&buf);
+	FlushFileBuffers(data->pipe);
+	DisconnectNamedPipe(data->pipe);
+	return ret;
+}
+
+int ipc_listen_for_commands(struct ipc_command_listener *server)
+{
+	struct ipc_handle_client_data data = { server };
+
+	if (initialize_pipe_name(server->path, server->pipe_path,
+				 ARRAY_SIZE(server->pipe_path)) < 0)
+		return -1;
+
+	data.pipe = CreateNamedPipeW(server->pipe_path,
+		PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND,
+		PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
+		PIPE_UNLIMITED_INSTANCES, 1024, 1024, 0, NULL);
+	if (data.pipe == INVALID_HANDLE_VALUE)
+		return error(_("could not create pipe '%s'"),
+				server->path);
+
+	server->active = 1;
+	trace2_region_enter("simple-ipc", "listen", the_repository);
+	while (server->active) {
+		int ret;
+
+		if (!ConnectNamedPipe(data.pipe, NULL) &&
+		    GetLastError() != ERROR_PIPE_CONNECTED) {
+			error(_("could not connect to client (%ld)"),
+			      GetLastError());
+			continue;
+		}
+
+		ret = ipc_handle_client(&data);
+		if (ret == SIMPLE_IPC_QUIT)
+			break;
+
+		if (ret == -1)
+			error("could not handle client");
+	}
+
+	CloseHandle(data.pipe);
+
+	trace2_region_leave("simple-ipc", "listen", the_repository);
+	return 0;
+}
+
+int ipc_send_command(const char *path, const char *message, struct strbuf *answer)
+{
+	wchar_t wpath[MAX_PATH];
+	HANDLE pipe = INVALID_HANDLE_VALUE;
+	DWORD mode = PIPE_READMODE_BYTE;
+	int ret = 0, fd = -1;
+
+	if (initialize_pipe_name(path, wpath, ARRAY_SIZE(wpath)) < 0) {
+		ret = -1;
+		goto leave_send_command;
+	}
+
+	for (;;) {
+		pipe = CreateFileW(wpath, GENERIC_READ | GENERIC_WRITE,
+			0, NULL, OPEN_EXISTING, 0, NULL);
+		if (pipe != INVALID_HANDLE_VALUE)
+			break;
+		if (GetLastError() != ERROR_PIPE_BUSY) {
+			ret = error(_("could not open %s (%ld)"),
+				    path, GetLastError());
+			goto leave_send_command;
+		}
+
+		if (!WaitNamedPipeW(wpath, 5000)) {
+			ret = error(_("timed out: %s"), path);
+			goto leave_send_command;
+		}
+	}
+
+	if (!SetNamedPipeHandleState(pipe, &mode, NULL, NULL)) {
+		ret = error(_("could not switch pipe to byte mode: %s"), path);
+		goto leave_send_command;
+	}
+
+	fd = _open_osfhandle((intptr_t)pipe, O_RDWR|O_BINARY);
+	if (fd < 0) {
+		ret = -1;
+		goto leave_send_command;
+	}
+
+	if (write_packetized_from_buf(message, strlen(message), fd, 1) < 0) {
+		ret = error(_("could not send '%s' (%ld)"), message,
+			    GetLastError());
+		goto leave_send_command;
+	}
+	FlushFileBuffers(pipe);
+
+	if (answer)
+		ret = read_packetized_to_strbuf(fd, answer,
+						PACKET_READ_NEVER_DIE);
+	trace2_data_string("simple-ipc", the_repository, "answer", answer->buf);
+
+leave_send_command:
+	if (fd < 0)
+		CloseHandle(pipe);
+	else
+		close(fd);
+	return ret < 0 ? -1 : 0;
+}
+#endif

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -189,10 +189,12 @@ int ipc_send_command(const char *path, const char *message, struct strbuf *answe
 	}
 	FlushFileBuffers(pipe);
 
-	if (answer)
+	if (answer) {
 		ret = read_packetized_to_strbuf(fd, answer,
 						PACKET_READ_NEVER_DIE);
-	trace2_data_string("simple-ipc", the_repository, "answer", answer->buf);
+		if (ret < 0)
+			error_errno(_("IPC read error"));
+	}
 
 leave_send_command:
 	if (fd < 0)

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -182,4 +182,155 @@ leave_send_command:
 		close(fd);
 	return ret < 0 ? -1 : 0;
 }
+#elif !defined(NO_UNIX_SOCKETS)
+#include "unix-socket.h"
+#include "sigchain.h"
+
+static void set_socket_blocking_flag(int fd, int make_nonblocking)
+{
+	int flags;
+
+	flags = fcntl(fd, F_GETFL, NULL);
+
+	if (flags < 0)
+		die(_("fcntl failed"));
+
+	if (make_nonblocking)
+		flags |= O_NONBLOCK;
+	else
+		flags &= ~O_NONBLOCK;
+
+	if (fcntl(fd, F_SETFL, flags) < 0)
+		die(_("fcntl failed"));
+}
+
+static int reply(void *reply_data, const char *response, size_t len)
+{
+	int fd = *(int *)reply_data;
+
+	return write_packetized_from_buf(response, len, fd, 0);
+}
+
+/* in ms */
+#define LISTEN_TIMEOUT 50000
+#define RESPONSE_TIMEOUT 1000
+
+static struct string_list listener_paths = STRING_LIST_INIT_DUP;
+static int atexit_registered;
+
+static void unlink_listener_path(void)
+{
+	int i;
+
+	for (i = 0; i < listener_paths.nr; i++)
+		unlink(listener_paths.items[i].string);
+
+	string_list_clear(&listener_paths, 0);
+}
+
+int ipc_listen_for_commands(struct ipc_command_listener *listener)
+{
+	int ret = 0, fd;
+
+	fd = unix_stream_listen(listener->path);
+	if (fd < 0)
+		return error_errno(_("could not set up socket for %s"),
+				   listener->path);
+
+	if (!atexit_registered) {
+		atexit(unlink_listener_path);
+		atexit_registered = 1;
+	}
+	string_list_append(&listener_paths, listener->path);
+
+	trace2_region_enter("simple-ipc", "listen", the_repository);
+	listener->active = 1;
+	while (listener->active) {
+		struct pollfd pollfd;
+		int result, client_fd;
+		struct strbuf buf = STRBUF_INIT;
+
+		/* Wait for a request */
+		pollfd.fd = fd;
+		pollfd.events = POLLIN;
+		result = poll(&pollfd, 1, LISTEN_TIMEOUT);
+		if (result < 0) {
+			if (errno == EINTR)
+				/*
+				 * This can lead to an overlong keepalive,
+				 * but that is better than a premature exit.
+				 */
+				continue;
+			trace2_region_leave("simple-ipc", "listen", the_repository);
+			return error_errno(_("poll() failed"));
+		} else if (result == 0)
+			/* timeout */
+			continue;
+
+		client_fd = accept(fd, NULL, NULL);
+		if (client_fd < 0)
+			/*
+			 * An error here is unlikely -- it probably
+			 * indicates that the connecting process has
+			 * already dropped the connection.
+			 */
+			continue;
+
+		/*
+		 * Our connection to the client is blocking since a client
+		 * can always be killed by SIGINT or similar.
+		 */
+		set_socket_blocking_flag(client_fd, 0);
+
+		strbuf_reset(&buf);
+		result = read_packetized_to_strbuf(client_fd, &buf,
+						   PACKET_READ_NEVER_DIE);
+
+		if (result > 0) {
+			/* ensure string termination */
+			ret = listener->handle_client(listener, buf.buf, reply,
+						      &client_fd);
+			packet_flush_gently(client_fd);
+			if (ret == SIMPLE_IPC_QUIT) {
+				listener->active = 0;
+				close(client_fd);
+				strbuf_release(&buf);
+				break;
+			}
+		} else {
+			/*
+			 * No command from client.  Probably it's just a
+			 * liveness check or client error.  Just close up.
+			 */
+		}
+		close(client_fd);
+	}
+
+	close(fd);
+	trace2_region_leave("simple-ipc", "listen", the_repository);
+	return ret == SIMPLE_IPC_QUIT ? 0 : ret;
+}
+
+int ipc_send_command(const char *path, const char *message,
+		     struct strbuf *answer)
+{
+	int fd = unix_stream_connect(path);
+	int ret = 0;
+
+	sigchain_push(SIGPIPE, SIG_IGN);
+	if (fd < 0 ||
+	    write_packetized_from_buf(message, strlen(message), fd, 1) < 0)
+		ret = -1;
+	else if (answer) {
+		if (read_packetized_to_strbuf(fd, answer,
+					      PACKET_READ_NEVER_DIE) < 0)
+			ret = error_errno(_("could not read packet from '%s'"),
+					  path);
+	}
+
+	if (fd >= 0)
+		close(fd);
+	sigchain_pop(SIGPIPE);
+	return ret;
+}
 #endif

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -31,6 +31,22 @@ static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 	return 0;
 }
 
+static int is_active(wchar_t *pipe_path)
+{
+	return WaitNamedPipeW(pipe_path, 1) ||
+		GetLastError() != ERROR_FILE_NOT_FOUND;
+}
+
+int ipc_is_active(const char *path)
+{
+	wchar_t pipe_path[MAX_PATH];
+
+	if (initialize_pipe_name(path, pipe_path, ARRAY_SIZE(pipe_path)) < 0)
+		return 0;
+
+	return is_active(pipe_path);
+}
+
 struct ipc_handle_client_data {
 	struct ipc_command_listener *server;
 	HANDLE pipe;
@@ -88,6 +104,9 @@ int ipc_listen_for_commands(struct ipc_command_listener *server)
 	if (initialize_pipe_name(server->path, server->pipe_path,
 				 ARRAY_SIZE(server->pipe_path)) < 0)
 		return -1;
+
+	if (is_active(server->pipe_path))
+		return error(_("server already running at %s"), server->path);
 
 	data.pipe = CreateNamedPipeW(server->pipe_path,
 		PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND,
@@ -186,6 +205,18 @@ leave_send_command:
 #include "unix-socket.h"
 #include "sigchain.h"
 
+static int is_active(const char *path)
+{
+	struct stat st;
+
+	return !lstat(path, &st) && (st.st_mode & S_IFMT) == S_IFSOCK;
+}
+
+int ipc_is_active(const char *path)
+{
+	return is_active(path);
+}
+
 static void set_socket_blocking_flag(int fd, int make_nonblocking)
 {
 	int flags;
@@ -231,6 +262,9 @@ static void unlink_listener_path(void)
 int ipc_listen_for_commands(struct ipc_command_listener *listener)
 {
 	int ret = 0, fd;
+
+	if (is_active(listener->path))
+		return error(_("server already running at %s"), listener->path);
 
 	fd = unix_stream_listen(listener->path);
 	if (fd < 0)

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -621,10 +621,11 @@ static int is_active(const char *path)
 	// TODO So doesn't this just test that the server had in the
 	// TODO past been active??
 
-	return !lstat(path, &st) && (st.st_mode & S_IFMT) == S_IFSOCK;
+	return !lstat(path, &st) && (st.st_mode & S_IFMT) == S_IFSOCK ?
+		IPC_STATE__ACTIVE : IPC_STATE__NOT_ACTIVE;
 }
 
-int ipc_is_active(const char *path)
+enum IPC_ACTIVE_STATE ipc_is_active(const char *path)
 {
 	return is_active(path);
 }

--- a/simple-ipc.c
+++ b/simple-ipc.c
@@ -2,6 +2,7 @@
 #include "simple-ipc.h"
 #include "strbuf.h"
 #include "pkt-line.h"
+#include "thread-utils.h"
 
 #ifdef GIT_WINDOWS_NATIVE
 static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
@@ -9,13 +10,20 @@ static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 	int off = 0;
 	struct strbuf realpath = STRBUF_INIT;
 
+	// TODO Should these 2 errors cases also set `errno` ?
+	// TODO Should this layer print error messages ?
+
 	if (!strbuf_realpath(&realpath, path, 0))
-		return error(_("could not normalize '%s'"), path);
+		return error(_("could not normalize path '%s'"), path);
 
 	off = swprintf(wpath, alloc, L"\\\\.\\pipe\\");
 	if (xutftowcs(wpath + off, realpath.buf, alloc - off) < 0)
 		return error(_("could not determine pipe path for '%s'"),
 			     realpath.buf);
+
+	// TODO Note that items within the NPFS don't have to follow
+	// TODO Win32/NTFS pathname rules, so this munging may not
+	// TODO be necessary.
 
 	/* Handle drive prefix */
 	if (wpath[off] && wpath[off + 1] == L':') {
@@ -31,46 +39,48 @@ static int initialize_pipe_name(const char *path, wchar_t *wpath, size_t alloc)
 	return 0;
 }
 
-static int is_active(wchar_t *pipe_path)
+// TODO revisit the naming of this.  It basically verifies that a named
+// TODO pipe with this pathname exists.  It doesn't verify that *our*
+// TODO daemon is listening on it.
+//
+// TODO Would this be clearer if it was:
+// TOOD    return (WaitNamedPipeW() || GetLastError() == ERROR_SEM_TIMEOUT);
+//
+static enum IPC_ACTIVE_STATE is_active(wchar_t *pipe_path)
 {
-	return WaitNamedPipeW(pipe_path, 1) ||
-		GetLastError() != ERROR_FILE_NOT_FOUND;
+	if (WaitNamedPipeW(pipe_path, 1) ||
+	    GetLastError() != ERROR_FILE_NOT_FOUND)
+		return IPC_STATE__ACTIVE;
+	else
+		return IPC_STATE__NOT_ACTIVE;
 }
 
-int ipc_is_active(const char *path)
+enum IPC_ACTIVE_STATE ipc_is_active(const char *path)
 {
 	wchar_t pipe_path[MAX_PATH];
 
+	// TODO Should this fail harder if they give us a bogus path ?
+	// TODO As it is, a client with a bogus path could spin wait
+	// TODO forever waiting for a server to start because it can't
+	// TODO tell that from a valid path with no server.
+
 	if (initialize_pipe_name(path, pipe_path, ARRAY_SIZE(pipe_path)) < 0)
-		return 0;
+		return IPC_STATE__INVALID_PATH;
 
 	return is_active(pipe_path);
 }
 
-struct ipc_handle_client_data {
-	struct ipc_command_listener *server;
-	HANDLE pipe;
-};
-
-static int reply(void *reply_data, const char *response, size_t len)
+/*
+ * Duplicate the given pipe handle and wrap it in a file descriptor so
+ * that we can use pkt-line on it.
+ */
+static int dup_fd_from_pipe(const HANDLE pipe)
 {
-	int fd = *(int *)reply_data;
+	HANDLE process = GetCurrentProcess();
+	HANDLE handle;
+	int fd;
 
-	return write_packetized_from_buf(response, len, fd, 0);
-}
-
-static DWORD WINAPI ipc_handle_client(LPVOID param)
-{
-	struct ipc_handle_client_data *data = param;
-	struct strbuf buf = STRBUF_INIT;
-	HANDLE process = GetCurrentProcess(), handle;
-	int ret = 0, fd;
-
-	/*
-	 * First duplicate the handle, then wrap it in a file descriptor, so
-	 * that we can use pkt-line on it.
-	 */
-	if (!DuplicateHandle(process, data->pipe, process, &handle, 0, FALSE,
+	if (!DuplicateHandle(process, pipe, process, &handle, 0, FALSE,
 			     DUPLICATE_SAME_ACCESS)) {
 		errno = err_win_to_posix(GetLastError());
 		return -1;
@@ -83,125 +93,521 @@ static DWORD WINAPI ipc_handle_client(LPVOID param)
 		return -1;
 	}
 
-	ret = read_packetized_to_strbuf(fd, &buf, PACKET_READ_NEVER_DIE);
-	if (ret >= 0) {
-		ret = data->server->handle_client(data->server,
-						  buf.buf, reply, &fd);
-		packet_flush_gently(fd);
-		if (ret == SIMPLE_IPC_QUIT)
-			data->server->active = 0;
+	return fd;
+}
+
+//////////////////////////////////////////////////////////////////
+
+static const char *MAGIC_SERVER_REPLY_DATA = "T_Reply_T";
+static const char *MAGIC_SERVER_THREAD_DATA = "T_Thread_T";
+static const char *MAGIC_SERVER_DATA = "T_Server_T";
+
+struct ipc_server_reply_data {
+	const char *magic;
+	int fd;
+	struct ipc_server_thread_data *server_thread_data;
+};
+
+struct ipc_server_thread_data {
+	const char *magic;
+	struct ipc_server_thread_data *next_thread;
+	struct ipc_server_data *server_data;
+	int thread_nr;
+	pthread_t pthread_id;
+	HANDLE hPipe;
+};
+
+struct ipc_server_data {
+	const char *magic;
+	ipc_server_application_cb *application_cb;
+	void *application_data;
+	HANDLE hEventStopRequested;
+	struct strbuf buf_path;
+	wchar_t wpath[MAX_PATH];
+	struct ipc_server_thread_data *thread_list;
+};
+
+enum connect_result {
+	CR_CONNECTED = 0,
+	CR_CONNECT_PENDING,
+	CR_CONNECT_ERROR,
+	CR_WAIT_ERROR,
+	CR_SHUTDOWN,
+};
+
+static enum connect_result queue_overlapped_connect(
+	struct ipc_server_thread_data *server_thread_data,
+	OVERLAPPED *lpo)
+{
+	if (ConnectNamedPipe(server_thread_data->hPipe, lpo))
+		goto failed;
+
+	switch (GetLastError()) {
+	case ERROR_IO_PENDING:
+		return CR_CONNECT_PENDING;
+
+	case ERROR_PIPE_CONNECTED:
+		SetEvent(lpo->hEvent);
+		return CR_CONNECTED;
+
+	default:
+		break;
 	}
+
+failed:
+	error(_("ConnectNamedPipe failed for '%s' (%lu)"),
+	      server_thread_data->server_data->buf_path.buf,
+	      GetLastError());
+	return CR_CONNECT_ERROR;
+}
+
+static enum connect_result wait_for_connection(
+	struct ipc_server_thread_data *server_thread_data,
+	OVERLAPPED *lpo)
+{
+	enum connect_result r;
+	HANDLE waitHandles[2];
+	DWORD dwWaitResult;
+
+	r = queue_overlapped_connect(server_thread_data, lpo);
+	if (r != CR_CONNECT_PENDING)
+		return r;
+
+	waitHandles[0] = server_thread_data->server_data->hEventStopRequested;
+	waitHandles[1] = lpo->hEvent;
+
+	dwWaitResult = WaitForMultipleObjects(2, waitHandles, FALSE, INFINITE);
+	switch (dwWaitResult) {
+	case WAIT_OBJECT_0 + 0:
+		trace2_printf("ipc-server[%s]: received stop event",
+			      server_thread_data->server_data->buf_path.buf);
+		return CR_SHUTDOWN;
+
+	case WAIT_OBJECT_0 + 1:
+//		trace2_printf("ipc-server[%s]: received connection",
+//			      server_thread_data->server_data->buf_path.buf);
+		ResetEvent(lpo->hEvent);
+		return CR_CONNECTED;
+
+	default:
+		return CR_WAIT_ERROR;
+	}
+}
+
+static ipc_server_reply_cb do_io_reply;
+
+static int do_io_reply(struct ipc_server_reply_data *reply_data,
+		       const char *response, size_t response_len)
+{
+	if (reply_data->magic != MAGIC_SERVER_REPLY_DATA)
+		BUG("reply_cb called with wrong instance data");
+
+	return write_packetized_from_buf(response, response_len,
+					 reply_data->fd, 0);
+}
+
+/*
+ * Receive the request/command from the client and pass it to the
+ * registered request-callback.  The request-callback will compose
+ * a response and call our reply-callback to send it to the client.
+ */
+static int do_io(struct ipc_server_thread_data *server_thread_data)
+{
+	struct strbuf buf = STRBUF_INIT;
+	struct ipc_server_reply_data reply_data;
+	int ret = 0;
+
+	reply_data.magic = MAGIC_SERVER_REPLY_DATA;
+	reply_data.server_thread_data = server_thread_data;
+
+	reply_data.fd = dup_fd_from_pipe(server_thread_data->hPipe);
+	if (reply_data.fd < 0)
+		return error(_("could not create fd from pipe for '%s'"),
+			     server_thread_data->server_data->buf_path.buf);
+
+	ret = read_packetized_to_strbuf(reply_data.fd, &buf,
+					PACKET_READ_NEVER_DIE);
+	if (ret >= 0) {
+//		trace2_printf("simple-ipc: %s", buf.buf);
+
+		ret = server_thread_data->server_data->application_cb(
+			server_thread_data->server_data->application_data,
+			buf.buf, do_io_reply, &reply_data);
+
+		packet_flush_gently(reply_data.fd);
+
+		FlushFileBuffers((HANDLE)_get_osfhandle((reply_data.fd)));
+	}
+	else {
+		/*
+		 * The client probably disconnected/shutdown before it
+		 * could send a well-formed message.  Ignore it.
+		 */
+		trace2_printf("ipc-server[%s]: read_packetized failed",
+			      server_thread_data->server_data->buf_path.buf);
+	}
+
 	strbuf_release(&buf);
-	FlushFileBuffers(data->pipe);
-	DisconnectNamedPipe(data->pipe);
+	close(reply_data.fd);
+
 	return ret;
 }
 
-int ipc_listen_for_commands(struct ipc_command_listener *server)
+/*
+ * Handle IPC request and response with this connected client.  And reset
+ * the pipe to prepare for the next client.
+ */
+static int use_connection(struct ipc_server_thread_data *server_thread_data)
 {
-	struct ipc_handle_client_data data = { server };
+	int ret;
 
-	if (initialize_pipe_name(server->path, server->pipe_path,
-				 ARRAY_SIZE(server->pipe_path)) < 0)
-		return -1;
+	ret = do_io(server_thread_data);
 
-	if (is_active(server->pipe_path))
-		return error(_("server already running at %s"), server->path);
+	FlushFileBuffers(server_thread_data->hPipe);
+	DisconnectNamedPipe(server_thread_data->hPipe);
 
-	data.pipe = CreateNamedPipeW(server->pipe_path,
-		PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND,
-		PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT,
-		PIPE_UNLIMITED_INSTANCES, 1024, 1024, 0, NULL);
-	if (data.pipe == INVALID_HANDLE_VALUE)
-		return error(_("could not create pipe '%s'"),
-				server->path);
+	return ret;
+}
 
-	server->active = 1;
-	trace2_region_enter("simple-ipc", "listen", the_repository);
-	while (server->active) {
-		int ret;
+static void *server_thread_proc(void *_server_thread_data)
+{
+	struct ipc_server_thread_data *server_thread_data = _server_thread_data;
+	HANDLE hEventConnected = INVALID_HANDLE_VALUE;
+	OVERLAPPED oConnect;
+	enum connect_result cr;
+	int ret;
 
-		if (!ConnectNamedPipe(data.pipe, NULL) &&
-		    GetLastError() != ERROR_PIPE_CONNECTED) {
-			error(_("could not connect to client (%ld)"),
-			      GetLastError());
-			continue;
-		}
+	assert(server_thread_data->hPipe != INVALID_HANDLE_VALUE);
 
-		ret = ipc_handle_client(&data);
-		if (ret == SIMPLE_IPC_QUIT)
+	trace2_thread_start("ipc-server");
+	trace2_data_string("ipc-server", NULL, "pipe",
+			   server_thread_data->server_data->buf_path.buf);
+
+	hEventConnected = CreateEventW(NULL, TRUE, FALSE, NULL);
+
+	memset(&oConnect, 0, sizeof(oConnect));
+	oConnect.hEvent = hEventConnected;
+
+	while (1) {
+		cr = wait_for_connection(server_thread_data, &oConnect);
+
+		switch (cr) {
+		case CR_SHUTDOWN:
+			goto finished;
+
+		case CR_CONNECTED:
+			ret = use_connection(server_thread_data);
+			if (ret == SIMPLE_IPC_QUIT) {
+				ipc_server_stop_async(
+					server_thread_data->server_data);
+				goto finished;
+			}
+			if (ret > 0) {
+				/*
+				 * Ignore (transient) IO errors with this
+				 * client and reset for the next client.
+				 */
+			}
 			break;
 
-		if (ret == -1)
-			error("could not handle client");
+		case CR_CONNECT_PENDING:
+			/* By construction, this should not happen. */
+			BUG("ipc-server[%s]: unexpeced CR_CONNECT_PENDING",
+			    server_thread_data->server_data->buf_path.buf);
+
+		case CR_CONNECT_ERROR:
+		case CR_WAIT_ERROR:
+			/*
+			 * TODO These are theoretical errors at this point.
+			 * TODO Should this shutdown the server (and all the
+			 * TODO other threads) or just reset this pipe instance?
+			 */
+			DisconnectNamedPipe(server_thread_data->hPipe);
+			break;
+
+		default:
+			BUG("unandled case after wait_for_connection");
+		}
 	}
 
-	CloseHandle(data.pipe);
+finished:
+	CloseHandle(server_thread_data->hPipe);
+	CloseHandle(hEventConnected);
 
-	trace2_region_leave("simple-ipc", "listen", the_repository);
+	trace2_thread_exit();
+	return NULL;
+}
+
+static HANDLE create_new_pipe(wchar_t *wpath, int is_first)
+{
+	HANDLE hPipe;
+	DWORD dwOpenMode, dwPipeMode;
+	LPSECURITY_ATTRIBUTES lpsa = NULL;
+
+	dwOpenMode = PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND |
+		FILE_FLAG_OVERLAPPED;
+
+	dwPipeMode = PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT |
+		PIPE_REJECT_REMOTE_CLIENTS;
+
+	if (is_first) {
+		dwOpenMode |= FILE_FLAG_FIRST_PIPE_INSTANCE;
+
+		/* TODO consider setting security attributes. */
+	}
+
+	hPipe = CreateNamedPipeW(wpath, dwOpenMode, dwPipeMode,
+				 PIPE_UNLIMITED_INSTANCES, 1024, 1024, 0, lpsa);
+
+	return hPipe;
+}
+
+int ipc_server_run_async(struct ipc_server_data **returned_server_data,
+			 const char *path, int nr_threads,
+			 ipc_server_application_cb *application_cb,
+			 void *application_data)
+{
+	struct ipc_server_data *server_data;
+	wchar_t wpath[MAX_PATH];
+	HANDLE hPipeFirst = INVALID_HANDLE_VALUE;
+	int k;
+	int ret = 0;
+
+	*returned_server_data = NULL;
+
+	ret = initialize_pipe_name(path, wpath, ARRAY_SIZE(wpath));
+	if (ret < 0)
+		return ret;
+
+	hPipeFirst = create_new_pipe(wpath, 1);
+	if (hPipeFirst == INVALID_HANDLE_VALUE)
+		return error(_("server already running on '%s'"), path);
+
+	server_data = xcalloc(1, sizeof(*server_data));
+	server_data->magic = MAGIC_SERVER_DATA;
+	server_data->application_cb = application_cb;
+	server_data->application_data = application_data;
+	server_data->hEventStopRequested = CreateEvent(NULL, TRUE, FALSE, NULL);
+	strbuf_init(&server_data->buf_path, 0);
+	strbuf_addstr(&server_data->buf_path, path);
+	wcscpy(server_data->wpath, wpath);
+
+	if (nr_threads < 1)
+		nr_threads = 1;
+
+	for (k = 0; k < nr_threads; k++) {
+		struct ipc_server_thread_data *std;
+
+		std = xcalloc(1, sizeof(*std));
+		std->magic = MAGIC_SERVER_THREAD_DATA;
+		std->server_data = server_data;
+		std->thread_nr = k;
+		std->hPipe = INVALID_HANDLE_VALUE;
+
+		std->hPipe = (k == 0)
+			? hPipeFirst
+			: create_new_pipe(server_data->wpath, 0);
+
+		if (std->hPipe == INVALID_HANDLE_VALUE) {
+			/*
+			 * If we've reached a pipe instance limit for
+			 * this path, just use fewer threads.
+			 */
+			free(std);
+			break;
+		}
+
+		if (pthread_create(&std->pthread_id, NULL,
+				   server_thread_proc, std)) {
+			/*
+			 * Likewise, if we're out of threads, just use
+			 * fewer threads than requested.
+			 */
+			CloseHandle(std->hPipe);
+			free(std);
+			break;
+		}
+
+		std->next_thread = server_data->thread_list;
+		server_data->thread_list = std;
+	}
+
+	*returned_server_data = server_data;
 	return 0;
 }
 
-int ipc_send_command(const char *path, const char *message, struct strbuf *answer)
+int ipc_server_stop_async(struct ipc_server_data *server_data)
+{
+	if (!server_data)
+		return 0;
+
+	trace2_printf("EEE: Stopping '%s'", server_data->buf_path.buf);
+
+	/*
+	 * Gently tell all of the ipc_server threads to shutdown.
+	 * This will be seen the next time they are idle (and waiting
+	 * for a connection).
+	 *
+	 * We DO NOT attempt to force them to drop an active connection.
+	 *
+	 * TODO Should we have a force-now option?
+	 */
+	SetEvent(server_data->hEventStopRequested);
+	return 0;
+}
+
+int ipc_server_await(struct ipc_server_data *server_data)
+{
+	DWORD dwWaitResult;
+
+	if (!server_data)
+		return 0;
+
+	dwWaitResult = WaitForSingleObject(server_data->hEventStopRequested, INFINITE);
+	if (dwWaitResult != WAIT_OBJECT_0)
+		return error(_("wait for hEvent failed for '%s'"),
+			     server_data->buf_path.buf);
+
+	while (server_data->thread_list) {
+		struct ipc_server_thread_data *std = server_data->thread_list;
+
+		pthread_join(std->pthread_id, NULL);
+
+		server_data->thread_list = std->next_thread;
+		free(std);
+	}
+
+	return 0;
+}
+
+int ipc_server_run(const char *path, int nr_threads,
+		   ipc_server_application_cb *application_cb,
+		   void *application_data)
+{
+	struct ipc_server_data *server_data = NULL;
+	int ret;
+
+	ret = ipc_server_run_async(&server_data, path, nr_threads,
+				   application_cb, application_data);
+	if (ret)
+		return ret;
+
+	ret = ipc_server_await(server_data);
+
+	ipc_server_free(server_data);
+
+	return ret;
+}
+
+void ipc_server_free(struct ipc_server_data *server_data)
+{
+	// TODO Free server_data
+}
+
+//////////////////////////////////////////////////////////////////
+
+static int connect_to_server(const char *path, const wchar_t *wpath,
+			     DWORD timeout_ms, HANDLE *phPipe)
+{
+	DWORD t_start_ms, t_waited_ms;
+
+	while (1) {
+		*phPipe  = CreateFileW(wpath, GENERIC_READ | GENERIC_WRITE,
+				       0, NULL, OPEN_EXISTING, 0, NULL);
+		if (*phPipe != INVALID_HANDLE_VALUE)
+			return 0;
+
+		if (GetLastError() != ERROR_PIPE_BUSY) {
+			/*
+			 * We expect ERROR_FILE_NOT_FOUND when the server is not
+			 * running, but other errors are possible here.
+			 */
+			return error(_("could not open pipe '%s' (gle %ld)"),
+				     path, GetLastError());
+		}
+
+		t_start_ms = (DWORD)(getnanotime() / 1000000);
+
+		if (!WaitNamedPipeW(wpath, timeout_ms)) {
+			if (GetLastError() == ERROR_SEM_TIMEOUT)
+				return error(_("pipe is busy '%s'"), path);
+
+			return error(_("could not open '%s' (gle %ld)"),
+				     path, GetLastError());
+		}
+
+		/*
+		 * A pipe server instance became available.  Race other client
+		 * processes to connect to it.
+		 *
+		 * But first decrement our overall timeout so that we don't
+		 * starve if we keep losing the race.  But also guard against
+		 * special NPMWAIT_ values (0 and -1).
+		 */
+		t_waited_ms = (DWORD)(getnanotime() / 1000000) - t_start_ms;
+
+		timeout_ms -= t_waited_ms;
+		if (timeout_ms < 1)
+			timeout_ms = 1;
+	}
+}
+
+/*
+ * The default connection timeout for Windows clients.
+ *
+ * This is not currently part of the ipc_ API (nor the config settings)
+ * because of differences between Windows and other platforms.
+ *
+ * This value was chosen at random.
+ */
+#define WINDOWS_CONNECTION_TIMEOUT_MS (30000)
+
+int ipc_client_send_command(const char *path, const char *message,
+			    struct strbuf *answer)
 {
 	wchar_t wpath[MAX_PATH];
-	HANDLE pipe = INVALID_HANDLE_VALUE;
+	HANDLE hPipe = INVALID_HANDLE_VALUE;
 	DWORD mode = PIPE_READMODE_BYTE;
-	int ret = 0, fd = -1;
+	int fd = -1;
 
-	if (initialize_pipe_name(path, wpath, ARRAY_SIZE(wpath)) < 0) {
-		ret = -1;
-		goto leave_send_command;
+	strbuf_setlen(answer, 0);
+
+	if (initialize_pipe_name(path, wpath, ARRAY_SIZE(wpath)) < 0)
+		return -1;
+
+	if (connect_to_server(path, wpath, WINDOWS_CONNECTION_TIMEOUT_MS,
+			      &hPipe))
+		return -1;
+
+	if (!SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {
+		CloseHandle(hPipe);
+		return error(_("could not switch pipe to byte mode '%s'"),
+			     path);
 	}
 
-	for (;;) {
-		pipe = CreateFileW(wpath, GENERIC_READ | GENERIC_WRITE,
-			0, NULL, OPEN_EXISTING, 0, NULL);
-		if (pipe != INVALID_HANDLE_VALUE)
-			break;
-		if (GetLastError() != ERROR_PIPE_BUSY) {
-			ret = error(_("could not open %s (%ld)"),
-				    path, GetLastError());
-			goto leave_send_command;
-		}
-
-		if (!WaitNamedPipeW(wpath, 5000)) {
-			ret = error(_("timed out: %s"), path);
-			goto leave_send_command;
-		}
-	}
-
-	if (!SetNamedPipeHandleState(pipe, &mode, NULL, NULL)) {
-		ret = error(_("could not switch pipe to byte mode: %s"), path);
-		goto leave_send_command;
-	}
-
-	fd = _open_osfhandle((intptr_t)pipe, O_RDWR|O_BINARY);
+	fd = _open_osfhandle((intptr_t)hPipe, O_RDWR|O_BINARY);
 	if (fd < 0) {
-		ret = -1;
-		goto leave_send_command;
+		CloseHandle(hPipe);
+		return error(_("could not create fd for pipe handle '%s'"),
+			     path);
 	}
+
+	hPipe = INVALID_HANDLE_VALUE; /* fd owns it now */
 
 	if (write_packetized_from_buf(message, strlen(message), fd, 1) < 0) {
-		ret = error(_("could not send '%s' (%ld)"), message,
-			    GetLastError());
-		goto leave_send_command;
-	}
-	FlushFileBuffers(pipe);
-
-	if (answer) {
-		ret = read_packetized_to_strbuf(fd, answer,
-						PACKET_READ_NEVER_DIE);
-		if (ret < 0)
-			error_errno(_("IPC read error"));
-	}
-
-leave_send_command:
-	if (fd < 0)
-		CloseHandle(pipe);
-	else
 		close(fd);
-	return ret < 0 ? -1 : 0;
+		return error(_("could not send IPC to '%s'"), path);
+	}
+
+	FlushFileBuffers((HANDLE)_get_osfhandle(fd));
+
+	if (read_packetized_to_strbuf(fd, answer, PACKET_READ_NEVER_DIE) < 0) {
+		close(fd);
+		return error(_("could not read IPC response on '%s'"), path);
+	}
+
+	close(fd);
+	return 0;
 }
 #elif !defined(NO_UNIX_SOCKETS)
 #include "unix-socket.h"
@@ -210,6 +616,10 @@ leave_send_command:
 static int is_active(const char *path)
 {
 	struct stat st;
+
+	// TODO Can't UDS exist on disk without an active listener ??
+	// TODO So doesn't this just test that the server had in the
+	// TODO past been active??
 
 	return !lstat(path, &st) && (st.st_mode & S_IFMT) == S_IFSOCK;
 }

--- a/simple-ipc.h
+++ b/simple-ipc.h
@@ -1,0 +1,40 @@
+#ifndef GIT_IPC_H
+#define GIT_IPC_H
+
+#if defined(GIT_WINDOWS_NATIVE)
+#define SUPPORTS_SIMPLE_IPC
+#endif
+
+/* Return this from `handle_client()` to stop listening. */
+#define SIMPLE_IPC_QUIT -2
+
+typedef int (*ipc_reply_fn_t)(void *reply_data, const char *answer, size_t len);
+struct ipc_command_listener;
+typedef int (*ipc_handle_client_fn_t)(struct ipc_command_listener *data,
+				      const char *command,
+				      ipc_reply_fn_t reply, void *reply_data);
+struct ipc_command_listener {
+	/* The path to identify the server; typically lives inside .git/ */
+	const char *path;
+#ifdef GIT_WINDOWS_NATIVE
+	wchar_t pipe_path[MAX_PATH];
+#endif
+	int active;
+	ipc_handle_client_fn_t handle_client;
+};
+
+/*
+ * Open an Inter-Process Communication server.
+ *
+ * These two functions implement very simplistic communication between two
+ * processes. The communication channel is identified by a `path` that may or
+ * may not be a _real_ path.
+ *
+ * The communication is very simple: the client sends a plain-text message and
+ * the server sends back a plain-text answer, then the communication is closed.
+ */
+int ipc_listen_for_commands(struct ipc_command_listener *data);
+int ipc_send_command(const char *path, const char *message,
+		     struct strbuf *answer);
+
+#endif

--- a/simple-ipc.h
+++ b/simple-ipc.h
@@ -1,7 +1,7 @@
 #ifndef GIT_IPC_H
 #define GIT_IPC_H
 
-#if defined(GIT_WINDOWS_NATIVE)
+#if defined(GIT_WINDOWS_NATIVE) || !defined(NO_UNIX_SOCKETS)
 #define SUPPORTS_SIMPLE_IPC
 #endif
 

--- a/simple-ipc.h
+++ b/simple-ipc.h
@@ -36,5 +36,6 @@ struct ipc_command_listener {
 int ipc_listen_for_commands(struct ipc_command_listener *data);
 int ipc_send_command(const char *path, const char *message,
 		     struct strbuf *answer);
+int ipc_is_active(const char *path);
 
 #endif

--- a/simple-ipc.h
+++ b/simple-ipc.h
@@ -1,41 +1,115 @@
 #ifndef GIT_IPC_H
 #define GIT_IPC_H
 
+/*
+ * "Simple IPC" implements a simple communication mechanism between one or
+ * more (foreground) Git clients and an existing (background) "ipc-server".
+ * It provides a communication foundation, but does not know about any
+ * "application" built upon it.
+ *
+ * Communication occurs over named pipes on Windows and Unix Domain Sockets
+ * on other platforms.  Rendezvous is via an application-specific pipe or
+ * socket `path`.  (Platform-specific code will normalize this path.)
+ *
+ * Communication uses pkt-line format, but that detail is hidden from both
+ * the client and server portions of the application.
+ *
+ * With Simple IPC:
+ * [] A client (process) connects to an existing server (process).
+ * [] The client sends a single command/request message to the server.
+ * [] The server responds with a single response message.
+ * [] Both sides close the pipe or socket.
+ */
+
 #if defined(GIT_WINDOWS_NATIVE) || !defined(NO_UNIX_SOCKETS)
 #define SUPPORTS_SIMPLE_IPC
 #endif
 
-/* Return this from `handle_client()` to stop listening. */
+/* Return this from your `application_cb()` to shutdown the ipc-server. */
 #define SIMPLE_IPC_QUIT -2
 
-typedef int (*ipc_reply_fn_t)(void *reply_data, const char *answer, size_t len);
-struct ipc_command_listener;
-typedef int (*ipc_handle_client_fn_t)(struct ipc_command_listener *data,
-				      const char *command,
-				      ipc_reply_fn_t reply, void *reply_data);
-struct ipc_command_listener {
-	/* The path to identify the server; typically lives inside .git/ */
-	const char *path;
-#ifdef GIT_WINDOWS_NATIVE
-	wchar_t pipe_path[MAX_PATH];
-#endif
-	int active;
-	ipc_handle_client_fn_t handle_client;
+struct ipc_server_data;
+struct ipc_server_reply_data;
+
+typedef int (ipc_server_reply_cb)(struct ipc_server_reply_data *,
+				  const char *response,
+				  size_t response_len);
+
+typedef int (ipc_server_application_cb)(void *application_data,
+					const char *request,
+					ipc_server_reply_cb *reply_cb,
+					struct ipc_server_reply_data *reply_data);
+
+enum IPC_ACTIVE_STATE {
+	IPC_STATE__ACTIVE = 0,
+	IPC_STATE__NOT_ACTIVE = 1,
+	IPC_STATE__INVALID_PATH = 2,
 };
 
 /*
- * Open an Inter-Process Communication server.
- *
- * These two functions implement very simplistic communication between two
- * processes. The communication channel is identified by a `path` that may or
- * may not be a _real_ path.
- *
- * The communication is very simple: the client sends a plain-text message and
- * the server sends back a plain-text answer, then the communication is closed.
+ * Inspect the filesystem to determine if a server is running on this
+ * named pipe or socket (without actually sending a message) by testing
+ * the availability and/or existence of the pipe or socket.
  */
-int ipc_listen_for_commands(struct ipc_command_listener *data);
-int ipc_send_command(const char *path, const char *message,
-		     struct strbuf *answer);
-int ipc_is_active(const char *path);
+enum IPC_ACTIVE_STATE ipc_is_active(const char *path);
+
+/*
+ * Used by the client to synchronously send a message to the server and
+ * receive a response.
+ *
+ * Returns 0 when successful.
+ *
+ * Calls error() and returns non-zero otherwise.
+ */
+int ipc_client_send_command(const char *path, const char *message,
+			    struct strbuf *answer);
+
+/*
+ * Synchronously run an `ipc-server` instance in the current process.  (This
+ * is a thread pool running in the background to service client connections.)
+ *
+ * Returns 0 if the server ran successfully (server threads were started
+ * and cleanly stopped).
+ *
+ * Calls error() and returns non-zero otherwise.
+ *
+ * When a client message is received, the application-specific
+ * `application_cb` will be called (on a random thread) to handle the
+ * message.  The callback will be given a `reply_cb` to use to send
+ * return data to the client.  The `reply_cb` can be called multiple
+ * times for chunking purposes.  Any reply is optional.
+ *
+ */
+int ipc_server_run(const char *path, int nr_threads,
+		   ipc_server_application_cb *application_cb,
+		   void *application_data);
+
+/*
+ * Asynchronously starts an `ipc-server` instance in the current process.
+ * A background thread pool is created to process client connections.
+ *
+ * Returns 0 and the address of the server instance if the server was
+ * successfully started.
+ */
+int ipc_server_run_async(struct ipc_server_data **returned_server_data,
+			 const char *path, int nr_threads,
+			 ipc_server_application_cb *application_cb,
+			 void *application_data);
+
+/*
+ * Asynchronously signal the threads in this `ipc-server` to stop.
+ * This call will return immediately.
+ */
+int ipc_server_stop_async(struct ipc_server_data *server_data);
+
+/*
+ * Synchronously wait for the server to be signalled and all of the
+ * server threads have been joined.
+ *
+ * Returns 0 if the server was cleanly stopped.
+ */
+int ipc_server_await(struct ipc_server_data *server_data);
+
+void ipc_server_free(struct ipc_server_data *server_data);
 
 #endif

--- a/t/helper/test-simple-ipc.c
+++ b/t/helper/test-simple-ipc.c
@@ -43,6 +43,21 @@ int cmd__simple_ipc(int argc, const char **argv)
 	if (argc == 2 && !strcmp(argv[1], "SUPPORTS_SIMPLE_IPC"))
 		return 0;
 
+	if (argc == 2 && !strcmp(argv[1], "is-active")) {
+		/*
+		 * The test script will start the daemon in the background,
+		 * meaning that it might not be fully set up by the time we are
+		 * verifying that the IPC is active. So let's keep trying for
+		 * up to 2.5 seconds.
+		 */
+		for (i = 0; i < 50; i++)
+			if (ipc_is_active(path))
+				return 0;
+			else
+				sleep_millisec(50);
+		return 1;
+	}
+
 	if (argc == 2 && !strcmp(argv[1], "daemon")) {
 		struct ipc_command_listener data = {
 			.path = path,

--- a/t/helper/test-simple-ipc.c
+++ b/t/helper/test-simple-ipc.c
@@ -1,0 +1,84 @@
+/*
+ * test-simple-ipc.c: verify that the Inter-Process Communication works.
+ */
+
+#include "test-tool.h"
+#include "cache.h"
+#include "strbuf.h"
+#include "simple-ipc.h"
+
+#ifndef SUPPORTS_SIMPLE_IPC
+int cmd__simple_ipc(int argc, const char **argv)
+{
+	die("simple IPC not available on this platform");
+}
+#else
+static int test_handle_client(struct ipc_command_listener *listener,
+			      const char *command,
+			      int (*reply)(void *data,
+					   const char *answer, size_t len),
+			      void *reply_data)
+{
+	const char *answer, *unhandled = "unhandled command: ";
+
+	if (!strcmp(command, "quit")) {
+		return SIMPLE_IPC_QUIT;
+	}
+
+	if (!strcmp(command, "ping"))
+		answer = "pong";
+	else if (reply(reply_data, unhandled, strlen(unhandled)) < 0)
+		return -1;
+	else
+		answer = command;
+
+	return reply(reply_data, answer, strlen(answer));
+}
+
+int cmd__simple_ipc(int argc, const char **argv)
+{
+	const char *path = "ipc-test";
+	int i;
+
+	if (argc == 2 && !strcmp(argv[1], "SUPPORTS_SIMPLE_IPC"))
+		return 0;
+
+	if (argc == 2 && !strcmp(argv[1], "daemon")) {
+		struct ipc_command_listener data = {
+			.path = path,
+			.handle_client = test_handle_client,
+		};
+		return !!ipc_listen_for_commands(&data);
+	}
+
+	if ((argc == 2 || argc == 3) && !strcmp(argv[1], "send")) {
+		const char *command = argc > 2 ? argv[2] : "(no command)";
+		struct strbuf buf = STRBUF_INIT;
+
+		/*
+		 * The test script will start the daemon in the background,
+		 * meaning that it might not be fully set up by the time we are
+		 * trying to send a message to it. So let's wait up to 2.5
+		 * seconds, in 50ms increments, to send it.
+		 */
+		for (i = 0; i < 50; i++)
+			if (!ipc_send_command(path, command, &buf)) {
+				printf("%s\n", buf.buf);
+				strbuf_release(&buf);
+
+				return 0;
+			} else if (!strcmp("quit", command) &&
+				   (errno == ENOENT || errno == ECONNRESET))
+				return 0;
+			else if (errno != ENOENT)
+				die_errno("failed to send '%s' to '%s'",
+					  command, path);
+			else
+				sleep_millisec(50);
+
+		die("noone home at '%s'?", path);
+	}
+
+	die("Unhandled argv[1]: '%s'", argv[1]);
+}
+#endif

--- a/t/helper/test-simple-ipc.c
+++ b/t/helper/test-simple-ipc.c
@@ -6,6 +6,8 @@
 #include "cache.h"
 #include "strbuf.h"
 #include "simple-ipc.h"
+#include "parse-options.h"
+#include "thread-utils.h"
 
 #ifndef SUPPORTS_SIMPLE_IPC
 int cmd__simple_ipc(int argc, const char **argv)
@@ -13,86 +15,464 @@ int cmd__simple_ipc(int argc, const char **argv)
 	die("simple IPC not available on this platform");
 }
 #else
-static int test_handle_client(struct ipc_command_listener *listener,
-			      const char *command,
-			      int (*reply)(void *data,
-					   const char *answer, size_t len),
-			      void *reply_data)
+
+/*
+ * The test daemon defines an "application callback" that supports a
+ * series of commands (see `test_app_cb()`).
+ *
+ * Unknown commands are caught here and we send an error message back
+ * to the client process.
+ */
+static int app__unhandled_command(const char *command,
+				  ipc_server_reply_cb *reply_cb,
+				  struct ipc_server_reply_data *reply_data)
 {
-	const char *answer, *unhandled = "unhandled command: ";
+	struct strbuf buf = STRBUF_INIT;
+	int ret;
+
+	strbuf_addf(&buf, "unhandled command: %s", command);
+	ret = reply_cb(reply_data, buf.buf, buf.len);
+	strbuf_release(&buf);
+
+	return ret;
+}
+
+/*
+ * Reply with a single very large buffer.  This is to ensure that
+ * long response are properly handled -- whether the chunking occurs
+ * in the kernel or in the (probably pkt-line) layer.
+ */
+#define BIG_ROWS (10000)
+static int app__big_command(ipc_server_reply_cb *reply_cb,
+			    struct ipc_server_reply_data *reply_data)
+{
+	struct strbuf buf = STRBUF_INIT;
+	int row;
+	int ret;
+
+	for (row = 0; row < BIG_ROWS; row++)
+		strbuf_addf(&buf, "big: %.75d\n", row);
+
+	ret = reply_cb(reply_data, buf.buf, buf.len);
+	strbuf_release(&buf);
+
+	return ret;
+}
+
+/*
+ * Reply with a series of lines.  This is to ensure that we can incrementally
+ * compute the response and chunk it to the client.
+ */
+#define CHUNK_ROWS (10000)
+static int app__chunk_command(ipc_server_reply_cb *reply_cb,
+			      struct ipc_server_reply_data *reply_data)
+{
+	struct strbuf buf = STRBUF_INIT;
+	int row;
+	int ret;
+
+	for (row = 0; row < CHUNK_ROWS; row++) {
+		strbuf_setlen(&buf, 0);
+		strbuf_addf(&buf, "big: %.75d\n", row);
+		ret = reply_cb(reply_data, buf.buf, buf.len);
+	}
+
+	strbuf_release(&buf);
+
+	return ret;
+}
+
+/*
+ * Slowly reply with a series of lines.  This is to model an expensive to
+ * compute chunked response (which might happen if this callback is running
+ * in a thread and is fighting for a lock with other threads).
+ */
+#define SLOW_ROWS     (1000)
+#define SLOW_DELAY_MS (10)
+static int app__slow_command(ipc_server_reply_cb *reply_cb,
+			     struct ipc_server_reply_data *reply_data)
+{
+	struct strbuf buf = STRBUF_INIT;
+	int row;
+	int ret;
+
+	for (row = 0; row < SLOW_ROWS; row++) {
+		strbuf_setlen(&buf, 0);
+		strbuf_addf(&buf, "big: %.75d\n", row);
+		ret = reply_cb(reply_data, buf.buf, buf.len);
+		sleep_millisec(SLOW_DELAY_MS);
+	}
+
+	strbuf_release(&buf);
+
+	return ret;
+}
+
+/*
+ * The client sent a command followed by a (possibly very) large buffer.
+ */
+static int app__sendbytes_command(const char *received,
+				  ipc_server_reply_cb *reply_cb,
+				  struct ipc_server_reply_data *reply_data)
+{
+	struct strbuf buf_resp = STRBUF_INIT;
+	const char *p = "?";
+	int len_ballast = 0;
+	int k;
+	int errs = 0;
+	int ret;
+
+	if (skip_prefix(received, "sendbytes ", &p))
+		len_ballast = strlen(p);
+
+	/*
+	 * Verify that the ballast is n copies of a single letter.
+	 * And that the multi-threaded IO layer didn't cross the streams.
+	 */
+	for (k = 1; k < len_ballast; k++)
+		if (p[k] != p[0])
+			errs++;
+
+	if (errs)
+		strbuf_addf(&buf_resp, "errs:%d\n", errs);
+	else
+		strbuf_addf(&buf_resp, "rcvd:%c%08d\n", p[0], len_ballast);
+
+	ret = reply_cb(reply_data, buf_resp.buf, buf_resp.len);
+
+	strbuf_release(&buf_resp);
+
+	return ret;
+}
+
+/*
+ * An arbitrary fixed address to verify that the application instance
+ * data is handled properly.
+ */
+static int my_app_data = 42;
+
+static ipc_server_application_cb test_app_cb;
+
+/*
+ * This is "application callback" that sits on top of the "ipc-server".
+ * It completely defines the set of command verbs supported by this
+ * application.
+ */
+static int test_app_cb(void *application_data,
+		       const char *command,
+		       ipc_server_reply_cb *reply_cb,
+		       struct ipc_server_reply_data *reply_data)
+{
+	/*
+	 * Verify that we received the application-data that we passed
+	 * when we started the ipc-server.  (We have several layers of
+	 * callbacks calling callbacks and it's easy to get things mixed
+	 * up (especially when some are "void*").)
+	 */
+	if (application_data != (void*)&my_app_data)
+		BUG("application_cb: application_data pointer wrong");
 
 	if (!strcmp(command, "quit")) {
+		/*
+		 * Tell ipc-server to hangup with an empty reply.
+		 */
 		return SIMPLE_IPC_QUIT;
 	}
 
-	if (!strcmp(command, "ping"))
-		answer = "pong";
-	else if (reply(reply_data, unhandled, strlen(unhandled)) < 0)
-		return -1;
-	else
-		answer = command;
+	if (!strcmp(command, "ping")) {
+		const char *answer = "pong";
+		return reply_cb(reply_data, answer, strlen(answer));
+	}
 
-	return reply(reply_data, answer, strlen(answer));
+	if (!strcmp(command, "big"))
+		return app__big_command(reply_cb, reply_data);
+
+	if (!strcmp(command, "chunk"))
+		return app__chunk_command(reply_cb, reply_data);
+
+	if (!strcmp(command, "slow"))
+		return app__slow_command(reply_cb, reply_data);
+
+	if (starts_with(command, "sendbytes "))
+		return app__sendbytes_command(command, reply_cb, reply_data);
+
+	return app__unhandled_command(command, reply_cb, reply_data);
+}
+
+/*
+ * This process will run as a simple-ipc server and listen for IPC commands
+ * from client processes.
+ */
+static int daemon__run_server(const char *path, int argc, const char **argv)
+{
+	int nr_threads = 5;
+
+	const char * const daemon_usage[] = {
+		N_("test-helper simple-ipc daemon [<options>"),
+		NULL
+	};
+	struct option daemon_options[] = {
+		OPT_INTEGER(0, "threads", &nr_threads,
+			    N_("number of threads in server thread pool")),
+		OPT_END()
+	};
+
+	argc = parse_options(argc, argv, NULL, daemon_options, daemon_usage, 0);
+
+	if (nr_threads < 1)
+		nr_threads = 1;
+
+	/*
+	 * Synchronously run the ipc-server.  We don't need any application
+	 * instance data, so pass an arbitrary pointer (that we'll later
+	 * verify made the round trip).
+	 */
+	return ipc_server_run(path, nr_threads, test_app_cb,
+			      (void*)&my_app_data);
+}
+
+/*
+ * This process will run a quick probe to see if a simple-ipc server
+ * is active on this path.
+ *
+ * Returns 0 if the server is alive.
+ */
+static int client__probe_server(const char *path)
+{
+	enum IPC_ACTIVE_STATE s;
+	int i;
+
+	/*
+	 * The test script will start the daemon in the background,
+	 * meaning that it might not be fully set up by the time we are
+	 * verifying that the IPC is active. So let's keep trying for
+	 * up to 2.5 seconds (but only if we were able to normalize
+	 * the path).
+	 */
+	for (i = 0; i < 50; i++) {
+		s = ipc_is_active(path);
+		switch (s) {
+		case IPC_STATE__ACTIVE:
+			return 0;
+
+		case IPC_STATE__INVALID_PATH:
+			/* Error message has already been printed. */
+			return -1;
+
+		case IPC_STATE__NOT_ACTIVE:
+		default:
+			sleep_millisec(50);
+			break;
+		}
+	}
+
+	return error("no server listening at '%s'?", path);
+}
+
+/*
+ * Send an IPC command to an already-running server daemon and print the
+ * response.
+ *
+ * argv[2] contains a simple (1 word) command verb that `test_app_cb()`
+ * (in the daemon process) will understand.
+ */
+static int client__send_ipc(int argc, const char **argv, const char *path)
+{
+	const char *command = argc > 2 ? argv[2] : "(no command)";
+	struct strbuf buf = STRBUF_INIT;
+	int is_quit = !strcmp("quit", command);
+
+	if (!ipc_client_send_command(path, command, &buf)) {
+		printf("%s\n", buf.buf);
+		fflush(stdout);
+		strbuf_release(&buf);
+
+		return 0;
+	}
+
+	if (is_quit && (errno == ENOENT || errno == ECONNRESET))
+		return 0;
+
+	return error("failed to send '%s' to '%s'", command, path);
+}
+
+/*
+ * Send an IPC command followed by ballast to confirm that a large
+ * message can be sent and that the kernel or pkt-line layers will
+ * properly chunk it and that the daemon receives the entire message.
+ */
+static int do_sendbytes(int bytecount, char byte, const char *path)
+{
+	struct strbuf buf_send = STRBUF_INIT;
+	struct strbuf buf_resp = STRBUF_INIT;
+
+	strbuf_addstr(&buf_send, "sendbytes ");
+	strbuf_addchars(&buf_send, byte, bytecount);
+
+	if (!ipc_client_send_command(path, buf_send.buf, &buf_resp)) {
+		strbuf_rtrim(&buf_resp);
+		printf("sent:%c%08d %s\n", byte, bytecount, buf_resp.buf);
+		fflush(stdout);
+		strbuf_release(&buf_send);
+		strbuf_release(&buf_resp);
+
+		return 0;
+	}
+
+	return error("client failed to sendbytes(%d, '%c') to '%s'",
+		     bytecount, byte, path);
+}
+
+/*
+ * Send an IPC command with ballast to an already-running server daemon.
+ */
+static int client__sendbytes(int argc, const char **argv, const char *path)
+{
+	int bytecount = 1024;
+	char *string = "x";
+	const char * const sendbytes_usage[] = {
+		N_("test-helper simple-ipc sendbytes [<options>]"),
+		NULL
+	};
+	struct option sendbytes_options[] = {
+		OPT_INTEGER(0, "bytecount", &bytecount, N_("number of bytes")),
+		OPT_STRING(0, "byte", &string, N_("byte"), N_("ballast")),
+		OPT_END()
+	};
+
+	argc = parse_options(argc, argv, NULL, sendbytes_options, sendbytes_usage, 0);
+
+	return do_sendbytes(bytecount, string[0], path);
+}
+
+struct multiple_thread_data {
+	pthread_t pthread_id;
+	struct multiple_thread_data *next;
+	const char *path;
+	int bytecount;
+	int batchsize;
+	int sum_errors;
+	char letter;
+};
+
+static void *multiple_thread_proc(void *_multiple_thread_data)
+{
+	struct multiple_thread_data *d = _multiple_thread_data;
+	int k;
+
+	trace2_thread_start("multiple");
+
+	for (k = 0; k < d->batchsize; k++)
+		if (do_sendbytes(d->bytecount + k, d->letter, d->path))
+			d->sum_errors++;
+
+	trace2_thread_exit();
+	return NULL;
+}
+
+/*
+ * Start a client-side thread pool.  Each thread sends a series of
+ * IPC requests.  Each request is on a new connection to the server.
+ */
+static int client__multiple(int argc, const char **argv, const char *path)
+{
+	struct multiple_thread_data *list = NULL;
+	int k;
+	int nr_threads = 5;
+	int bytecount = 1;
+	int batchsize = 10;
+	int sum_join_errors = 0;
+	int sum_thread_errors = 0;
+	const char * const multiple_usage[] = {
+		N_("test-helper simple-ipc multiple [<options>]"),
+		NULL
+	};
+	struct option multiple_options[] = {
+		OPT_INTEGER(0, "bytecount", &bytecount, N_("number of bytes")),
+		OPT_INTEGER(0, "threads", &nr_threads, N_("number of threads")),
+		OPT_INTEGER(0, "batchsize", &batchsize, N_("number of requests per thread")),
+		OPT_END()
+	};
+
+	argc = parse_options(argc, argv, NULL, multiple_options, multiple_usage, 0);
+
+	if (bytecount < 1)
+		bytecount = 1;
+	if (nr_threads < 1)
+		nr_threads = 1;
+	if (batchsize < 1)
+		batchsize = 1;
+
+	for (k = 0; k < nr_threads; k++) {
+		struct multiple_thread_data *d = xcalloc(1, sizeof(*d));
+		d->next = list;
+		d->path = path;
+		d->bytecount = bytecount + batchsize*(k/26);
+		d->batchsize = batchsize;
+		d->sum_errors = 0;
+		d->letter = 'A' + (k % 26);
+
+		if (pthread_create(&d->pthread_id, NULL, multiple_thread_proc, d)) {
+			warning("failed to create thread[%d] skipping remainder", k);
+			free(d);
+			break;
+		}
+
+		list = d;
+	}
+
+	while (list) {
+		struct multiple_thread_data *d = list;
+
+		if (pthread_join(d->pthread_id, NULL))
+			sum_join_errors++;
+
+		sum_thread_errors += d->sum_errors;
+
+		list = d->next;
+		free(d);
+	}
+
+	if (sum_join_errors || sum_thread_errors)
+		return error(_("client thread errors (%d, %d)"),
+			     sum_join_errors, sum_thread_errors);
+
+	return 0;
 }
 
 int cmd__simple_ipc(int argc, const char **argv)
 {
 	const char *path = "ipc-test";
-	int i;
 
 	if (argc == 2 && !strcmp(argv[1], "SUPPORTS_SIMPLE_IPC"))
 		return 0;
 
-	if (argc == 2 && !strcmp(argv[1], "is-active")) {
-		/*
-		 * The test script will start the daemon in the background,
-		 * meaning that it might not be fully set up by the time we are
-		 * verifying that the IPC is active. So let's keep trying for
-		 * up to 2.5 seconds.
-		 */
-		for (i = 0; i < 50; i++)
-			if (ipc_is_active(path))
-				return 0;
-			else
-				sleep_millisec(50);
+	/* Use '!!' on all dispatch functions to map from `error()` style
+	 * (returns -1) style to `test_must_fail` style (expects 1) and
+	 * get less confusing shell error messages.
+	 */
+
+	if (argc == 2 && !strcmp(argv[1], "is-active"))
+		return !!client__probe_server(path);
+
+	if (argc >= 2 && !strcmp(argv[1], "daemon"))
+		return !!daemon__run_server(path, argc, argv);
+
+	/*
+	 * Client commands follow.  Ensure a server is running before
+	 * going any further.
+	 */
+	if (client__probe_server(path))
 		return 1;
-	}
 
-	if (argc == 2 && !strcmp(argv[1], "daemon")) {
-		struct ipc_command_listener data = {
-			.path = path,
-			.handle_client = test_handle_client,
-		};
-		return !!ipc_listen_for_commands(&data);
-	}
+	if ((argc == 2 || argc == 3) && !strcmp(argv[1], "send"))
+		return !!client__send_ipc(argc, argv, path);
 
-	if ((argc == 2 || argc == 3) && !strcmp(argv[1], "send")) {
-		const char *command = argc > 2 ? argv[2] : "(no command)";
-		struct strbuf buf = STRBUF_INIT;
+	if (argc >= 2 && !strcmp(argv[1], "sendbytes"))
+		return !!client__sendbytes(argc, argv, path);
 
-		/*
-		 * The test script will start the daemon in the background,
-		 * meaning that it might not be fully set up by the time we are
-		 * trying to send a message to it. So let's wait up to 2.5
-		 * seconds, in 50ms increments, to send it.
-		 */
-		for (i = 0; i < 50; i++)
-			if (!ipc_send_command(path, command, &buf)) {
-				printf("%s\n", buf.buf);
-				strbuf_release(&buf);
-
-				return 0;
-			} else if (!strcmp("quit", command) &&
-				   (errno == ENOENT || errno == ECONNRESET))
-				return 0;
-			else if (errno != ENOENT)
-				die_errno("failed to send '%s' to '%s'",
-					  command, path);
-			else
-				sleep_millisec(50);
-
-		die("noone home at '%s'?", path);
-	}
+	if (argc >= 2 && !strcmp(argv[1], "multiple"))
+		return !!client__multiple(argc, argv, path);
 
 	die("Unhandled argv[1]: '%s'", argv[1]);
 }

--- a/t/helper/test-tool.c
+++ b/t/helper/test-tool.c
@@ -63,6 +63,7 @@ static struct test_cmd cmds[] = {
 	{ "sha1", cmd__sha1 },
 	{ "sha256", cmd__sha256 },
 	{ "sigchain", cmd__sigchain },
+	{ "simple-ipc", cmd__simple_ipc },
 	{ "strcmp-offset", cmd__strcmp_offset },
 	{ "string-list", cmd__string_list },
 	{ "submodule-config", cmd__submodule_config },

--- a/t/helper/test-tool.h
+++ b/t/helper/test-tool.h
@@ -53,6 +53,7 @@ int cmd__sha1(int argc, const char **argv);
 int cmd__oid_array(int argc, const char **argv);
 int cmd__sha256(int argc, const char **argv);
 int cmd__sigchain(int argc, const char **argv);
+int cmd__simple_ipc(int argc, const char **argv);
 int cmd__strcmp_offset(int argc, const char **argv);
 int cmd__string_list(int argc, const char **argv);
 int cmd__submodule_config(int argc, const char **argv);

--- a/t/t0052-simple-ipc.sh
+++ b/t/t0052-simple-ipc.sh
@@ -22,6 +22,11 @@ test_expect_success 'start simple command server' '
 	test_atexit stop_simple_IPC_server
 '
 
+test_expect_success 'servers cannot share the same path' '
+	test_must_fail test-tool simple-ipc daemon &&
+	test-tool simple-ipc is-active
+'
+
 test_expect_success 'simple command server' '
 	test-tool simple-ipc send ping >actual &&
 	echo pong >expect &&
@@ -30,6 +35,7 @@ test_expect_success 'simple command server' '
 
 test_expect_success '`quit` works' '
 	test-tool simple-ipc send quit &&
+	test_must_fail test-tool simple-ipc is-active &&
 	test_must_fail test-tool simple-ipc send ping
 '
 

--- a/t/t0052-simple-ipc.sh
+++ b/t/t0052-simple-ipc.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+test_description='simple command server'
+
+. ./test-lib.sh
+
+test-tool simple-ipc SUPPORTS_SIMPLE_IPC || {
+	skip_all='simple IPC not supported on this platform'
+	test_done
+}
+
+stop_simple_IPC_server () {
+	test -n "$SIMPLE_IPC_PID" || return 0
+
+	kill "$SIMPLE_IPC_PID" &&
+	SIMPLE_IPC_PID=
+}
+
+test_expect_success 'start simple command server' '
+	{ test-tool simple-ipc daemon & } &&
+	SIMPLE_IPC_PID=$! &&
+	test_atexit stop_simple_IPC_server
+'
+
+test_expect_success 'simple command server' '
+	test-tool simple-ipc send ping >actual &&
+	echo pong >expect &&
+	test_cmp expect actual
+'
+
+test_expect_success '`quit` works' '
+	test-tool simple-ipc send quit &&
+	test_must_fail test-tool simple-ipc send ping
+'
+
+test_done
+

--- a/t/t0052-simple-ipc.sh
+++ b/t/t0052-simple-ipc.sh
@@ -17,20 +17,101 @@ stop_simple_IPC_server () {
 }
 
 test_expect_success 'start simple command server' '
-	{ test-tool simple-ipc daemon & } &&
+	{ test-tool simple-ipc daemon --threads=8 & } &&
 	SIMPLE_IPC_PID=$! &&
 	test_atexit stop_simple_IPC_server
-'
-
-test_expect_success 'servers cannot share the same path' '
-	test_must_fail test-tool simple-ipc daemon &&
-	test-tool simple-ipc is-active
 '
 
 test_expect_success 'simple command server' '
 	test-tool simple-ipc send ping >actual &&
 	echo pong >expect &&
 	test_cmp expect actual
+'
+
+test_expect_success 'servers cannot share the same path' '
+	test_must_fail test-tool simple-ipc daemon &&
+	test-tool simple-ipc is-active
+'
+test_expect_success 'big response' '
+	test-tool simple-ipc send big >actual &&
+	test_line_count -ge 10000 actual &&
+	grep -q "big: [0]*9999\$" actual
+'
+
+test_expect_success 'chunk response' '
+	test-tool simple-ipc send chunk >actual &&
+	test_line_count -ge 10000 actual &&
+	grep -q "big: [0]*9999\$" actual
+'
+
+test_expect_success 'slow response' '
+	test-tool simple-ipc send slow >actual &&
+	test_line_count -ge 100 actual &&
+	grep -q "big: [0]*99\$" actual
+'
+
+# Send an IPC with n=100,000 bytes of ballast.  This should be large enough
+# to force both the kernel and the pkt-line layer to chunk the message to the
+# daemon and for the daemon to receive it in chunks.
+#
+test_expect_success 'sendbytes' '
+	test-tool simple-ipc sendbytes --bytecount=100000 --byte=A >actual &&
+	grep "sent:A00100000 rcvd:A00100000" actual
+'
+
+# Start a series of <threads> client threads that each make <batchsize>
+# IPC requests to the server.  Each (<threads> * <batchsize>) request
+# will open a new connection to the server and randomly bind to a server
+# thread.  Each client thread exits after completing its batch.  So the
+# total number of live client threads will be smaller than the total.
+# Each request will send a message containing at least <bytecount> bytes
+# of ballast.  (Responses are small.)
+#
+# The purpose here is to test threading in the server and responding to
+# many concurrent client requests (regardless of whether they come from
+# 1 client process or many).  And to test that the server side of the
+# named pipe/socket is stable.  (On Windows this means that the server
+# pipe is properly recycled.)
+#
+# On Windows it also lets us adjust the connection timeout in the
+# `ipc_client_send_command()`.
+#
+# Note it is easy to drive the system into failure by requesting an
+# insane number of threads on client or server and/or increasing the
+# per-thread batchsize or the per-request bytecount (ballast).
+# On Windows these failures look like "pipe is busy" errors.
+# So I've chosen fairly conservative values for now.
+#
+# We expect output of the form "sent:<letter><length> ..."
+# With terms (7, 19, 13) we expect:
+#   <letter> in [A-G]
+#   <length> in [19+0 .. 19+(13-1)]
+# and (7 * 13) successful responses.
+#
+test_expect_success 'stress test threads' '
+	test-tool simple-ipc multiple \
+		--threads=7 \
+		--bytecount=19 \
+		--batchsize=13 \
+		>actual &&
+	test_line_count = 91 actual &&
+	grep "sent:A" <actual >actual_a &&
+	cat >expect_a <<-EOF &&
+		sent:A00000019 rcvd:A00000019
+		sent:A00000020 rcvd:A00000020
+		sent:A00000021 rcvd:A00000021
+		sent:A00000022 rcvd:A00000022
+		sent:A00000023 rcvd:A00000023
+		sent:A00000024 rcvd:A00000024
+		sent:A00000025 rcvd:A00000025
+		sent:A00000026 rcvd:A00000026
+		sent:A00000027 rcvd:A00000027
+		sent:A00000028 rcvd:A00000028
+		sent:A00000029 rcvd:A00000029
+		sent:A00000030 rcvd:A00000030
+		sent:A00000031 rcvd:A00000031
+	EOF
+	test_cmp expect_a actual_a
 '
 
 test_expect_success '`quit` works' '


### PR DESCRIPTION
This topic branch introduces support for a super simply command server, backed by Unix sockets (and named pipes on Windows). All it does is to listen for short, textual commands, and respond with a reply, then close the connection.

The intention is to support an upcoming implementation of a built-in, Git-aware FSMonitor.