### PR TITLE
homebrew: add GitHub workflow to release Cask

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,30 @@
+name: Update Homebrew Tap
+on:
+  release:
+    types: [released]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - id: version
+      name: Compute version number
+      run: |
+        echo "::set-output name=result::$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")"
+    - id: hash
+      name: Compute release asset hash
+      uses: mjcheetham/asset-hash@v1
+      with:
+        asset: /git-(.*)\.pkg/
+        hash: sha256
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update scalar Cask
+      uses: mjcheetham/update-homebrew@v1.1
+      with:
+        token: ${{ secrets.HOMEBREW_TOKEN }}
+        tap: microsoft/git
+        name: microsoft-git
+        type: cask
+        version: ${{ steps.version.outputs.result }}
+        sha256: ${{ steps.hash.outputs.result }}
+        alwaysUsePullRequest: true


### PR DESCRIPTION
Add a GitHub workflow that is triggered on the `release` event to automatically update the `microsoft-git` Homebrew Cask on the `microsoft/git` Tap.

A secret `HOMEBREW_TOKEN` with have push permissions to the `microsoft/homebrew-git` repository must exist. A pull request will be created at the moment to allow for last minute manual verification.