### PR TITLE
Move gvfs.h and virtualfilesystem.h headers

### DIFF
--- a/builtin/update-index.c
+++ b/builtin/update-index.c
@@ -5,6 +5,7 @@
  */
 #define USE_THE_INDEX_COMPATIBILITY_MACROS
 #include "cache.h"
+#include "gvfs.h"
 #include "config.h"
 #include "lockfile.h"
 #include "quote.h"
@@ -18,7 +19,6 @@
 #include "dir.h"
 #include "split-index.h"
 #include "fsmonitor.h"
-#include "gvfs.h"
 
 /*
  * Default to not allowing changes to the list of files. The

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include "gvfs.h"
 #include "lockfile.h"
 #include "tree.h"
 #include "tree-walk.h"
@@ -6,7 +7,6 @@
 #include "object-store.h"
 #include "replace-object.h"
 #include "promisor-remote.h"
-#include "gvfs.h"
 
 #ifndef DEBUG_CACHE_TREE
 #define DEBUG_CACHE_TREE 0

--- a/config.c
+++ b/config.c
@@ -6,6 +6,7 @@
  *
  */
 #include "cache.h"
+#include "gvfs.h"
 #include "branch.h"
 #include "config.h"
 #include "repository.h"
@@ -20,7 +21,6 @@
 #include "dir.h"
 #include "color.h"
 #include "refs.h"
-#include "gvfs.h"
 #include "transport.h"
 
 struct config_source {

--- a/connected.c
+++ b/connected.c
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include "gvfs.h"
 #include "object-store.h"
 #include "run-command.h"
 #include "sigchain.h"
@@ -6,7 +7,6 @@
 #include "transport.h"
 #include "packfile.h"
 #include "promisor-remote.h"
-#include "gvfs.h"
 
 /*
  * If we feed all the commits we want to verify to this command

--- a/convert.c
+++ b/convert.c
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include "gvfs.h"
 #include "config.h"
 #include "object-store.h"
 #include "attr.h"
@@ -9,7 +10,6 @@
 #include "sub-process.h"
 #include "utf8.h"
 #include "ll-merge.h"
-#include "gvfs.h"
 
 /*
  * convert.c - convert a file when checking it out and checking it in.

--- a/dir.c
+++ b/dir.c
@@ -6,6 +6,7 @@
  *		 Junio Hamano, 2005-2006
  */
 #include "cache.h"
+#include "virtualfilesystem.h"
 #include "config.h"
 #include "dir.h"
 #include "object-store.h"
@@ -18,7 +19,6 @@
 #include "ewah/ewok.h"
 #include "fsmonitor.h"
 #include "submodule-config.h"
-#include "virtualfilesystem.h"
 
 /*
  * Tells read_directory_recursive how a file or directory should be treated.

--- a/git.c
+++ b/git.c
@@ -1,4 +1,5 @@
 #include "builtin.h"
+#include "gvfs.h"
 #include "config.h"
 #include "exec-cmd.h"
 #include "help.h"
@@ -6,7 +7,6 @@
 #include "alias.h"
 #include "shallow.h"
 #include "dir.h"
-#include "gvfs.h"
 
 #define RUN_SETUP		(1<<0)
 #define RUN_SETUP_GENTLY	(1<<1)

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -5,6 +5,7 @@
  */
 #include "cache.h"
 #include "merge-recursive.h"
+#include "virtualfilesystem.h"
 
 #include "advice.h"
 #include "alloc.h"
@@ -29,7 +30,6 @@
 #include "tree-walk.h"
 #include "unpack-trees.h"
 #include "xdiff-interface.h"
-#include "virtualfilesystem.h"
 
 struct merge_options_internal {
 	int call_depth;

--- a/read-cache.c
+++ b/read-cache.c
@@ -4,6 +4,7 @@
  * Copyright (C) Linus Torvalds, 2005
  */
 #include "cache.h"
+#include "gvfs.h"
 #include "config.h"
 #include "diff.h"
 #include "diffcore.h"

--- a/read-cache.c
+++ b/read-cache.c
@@ -5,6 +5,7 @@
  */
 #include "cache.h"
 #include "gvfs.h"
+#include "virtualfilesystem.h"
 #include "config.h"
 #include "diff.h"
 #include "diffcore.h"
@@ -26,8 +27,6 @@
 #include "fsmonitor.h"
 #include "thread-utils.h"
 #include "progress.h"
-#include "virtualfilesystem.h"
-#include "gvfs.h"
 
 /* Mask for the name length in ce_flags in the on-disk index */
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1,5 +1,6 @@
 #include "cache.h"
 #include "gvfs.h"
+#include "virtualfilesystem.h"
 #include "strvec.h"
 #include "repository.h"
 #include "config.h"
@@ -17,8 +18,6 @@
 #include "fsmonitor.h"
 #include "object-store.h"
 #include "promisor-remote.h"
-#include "gvfs.h"
-#include "virtualfilesystem.h"
 #include "packfile.h"
 
 /*

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include "gvfs.h"
 #include "strvec.h"
 #include "repository.h"
 #include "config.h"


### PR DESCRIPTION
Most of our conflicts with upstream are due to placing the `gvfs.h` and `virtualfilesystem.h` headers at the end of the `#include` list. This is also the same place where upstream adds new headers, which is likely to create a conflict.

Place these headers earlier in the list to avoid these textual conflicts.

These are all `fixup!` commits that will be squashed in the next major-version rebase. By squashing these commits using an `--autosquash`, we should avoid future conflicts.

There are a couple places where the two headers were adjacent, so the `fixup!` is insufficient to properly _move_ the `gvfs.h` header in the earlier commits. Those commits will need to be edited to fully remove the second `gvfs.h` header that will cause conflict during the rebase.