### PR TITLE
BRANCHES.md: update with new branch names

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -6,35 +6,41 @@ The document explains the branching structure that we are using in the VFSForGit
 Repo Branches
 -------------
 
-1. master
-
-    This will track the Git for Windows repository master branch
-
-2. vfs
-
-    Would like to use this branch as an ever-green branch that continually rebases the VFSForGit changes onto a windows ever-green branch that is on the core/master, so that we can detect when the patches for VFSForGit have issues or if we have a new version patches sent upstream git we can regenerate this branch.
-
-3. vs/master
-
-    This tracks with the Git for Windows repository vs/master branch and are the generated files for using a Visual Studio solution.
-
-4. vfs-#
+1. `vfs-#`
 
     These branches are used to track the specific version that match Git for Windows with the VFSForGit specific patches on top.  When a new version of Git for Windows is released, the VFSForGit patches will be rebased on that windows version and a new gvfs-# branch created to create pull requests against.
 
     #### Examples
 
     ```
-    vfs-2.20.0
-    vfs-2.20.1
+    vfs-2.27.0
+    vfs-2.30.0
     ```
 
     The versions of git for VFSForGit are based on the Git for Windows versions.  v2.20.0.vfs.1 will correspond with the v2.20.0.windows.1 with the VFSForGit specific patches applied to the windows version.
+
+2. `vfs-#-exp`
+
+   These branches are for releasing experimental features to early adopters. They
+   should contain everything within the corresponding `vfs-#` branch; if the base
+   branch updates, then merge into the `vfs-#-exp` branch as well.
 
 Tags
 ----
 
 We are using annotated tags to build the version number for git.  The build will look back through the commit history to find the first tag matching `v[0-9]*vfs*` and build the git version number using that tag.
+
+Full releases are of the form `v2.XX.Y.vfs.Z.W` where `v2.XX.Y` comes from the
+upstream version and `Z.W` are custom updates within our fork. Specifically,
+the `.Z` value represents the "compatibility level" with VFS for Git. Only
+increase this version when making a breaking change with a released version
+of VFS for Git. The `.W` version is used for minor updates between major
+versions.
+
+Experimental releases are of the form `v2.XX.Y.vfs.Z.W.exp`. The `.exp`
+suffix indicates that experimental features are available. The rest of the
+version string comes from the full release tag. These versions will only
+be made available as pre-releases on the releases page, never a full release.
 
 Forking
 -------


### PR DESCRIPTION
This is a doc-only fix, and by using a `!fixup` it will squash into the commit that introduces the file during the next rebase.