### PR TITLE
unpack-trees:virtualfilesystem: Improve efficiency of clear_ce_flags

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -765,6 +765,7 @@ int strcmp_offset(const char *s1, const char *s2, size_t *first_change);
 int index_dir_exists(struct index_state *istate, const char *name, int namelen);
 void adjust_dirname_case(struct index_state *istate, char *name);
 struct cache_entry *index_file_exists(struct index_state *istate, const char *name, int namelen, int igncase);
+struct cache_entry *index_file_next_match(struct index_state *istate, struct cache_entry *ce, int igncase);
 
 /*
  * Searches for an entry defined by name and namelen in the given index.

--- a/name-hash.c
+++ b/name-hash.c
@@ -720,6 +720,26 @@ struct cache_entry *index_file_exists(struct index_state *istate, const char *na
 	return NULL;
 }
 
+struct cache_entry *index_file_next_match(struct index_state *istate, struct cache_entry *ce, int igncase)
+{
+	struct cache_entry *next;
+
+	if (!igncase || !ce) {
+		return NULL;
+	}
+
+	next = hashmap_get_next_entry(&istate->name_hash, ce, ent);
+	if (!next)
+		return NULL;
+
+	hashmap_for_each_entry_from(&istate->name_hash, next, ent) {
+		if (same_name(next, ce->name, ce_namelen(ce), igncase)) 
+			return next;
+	}
+
+	return NULL;
+}
+
 void free_name_hash(struct index_state *istate)
 {
 	if (!istate->name_hash_initialized)

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1445,14 +1445,6 @@ static int clear_ce_flags_1(struct index_state *istate,
 			continue;
 		}
 
-		/* if it's not in the virtual file system, exit early */
-		if (core_virtualfilesystem) {
-			if (is_included_in_virtualfilesystem(ce->name, ce->ce_namelen) > 0)
-				ce->ce_flags &= ~clear_mask;
-			cache++;
-			continue;
-		}
-
 		if (prefix->len && strncmp(ce->name, prefix->buf, prefix->len))
 			break;
 
@@ -1529,12 +1521,19 @@ static int clear_ce_flags(struct index_state *istate,
 	xsnprintf(label, sizeof(label), "clear_ce_flags/0x%08lx_0x%08lx",
 		  (unsigned long)select_mask, (unsigned long)clear_mask);
 	trace2_region_enter("unpack_trees", label, the_repository);
-	rval = clear_ce_flags_1(istate,
-				istate->cache,
-				istate->cache_nr,
-				&prefix,
-				select_mask, clear_mask,
-				pl, 0, 0);
+	if (core_virtualfilesystem) {
+		rval = clear_ce_flags_virtualfilesystem(istate,
+							select_mask,
+							clear_mask);
+	} else {
+		rval = clear_ce_flags_1(istate,
+					istate->cache,
+					istate->cache_nr,
+					&prefix,
+					select_mask, clear_mask,
+					pl, 0, 0);
+	}
+
 	trace2_region_leave("unpack_trees", label, the_repository);
 
 	stop_progress(&istate->progress);

--- a/virtualfilesystem.h
+++ b/virtualfilesystem.h
@@ -7,6 +7,13 @@
 void apply_virtualfilesystem(struct index_state *istate);
 
 /*
+ * Clear the specified flags for all entries in the virtual file system
+ * that match the specified select mask. Returns the number of entries
+ * processed.
+ */
+int clear_ce_flags_virtualfilesystem(struct index_state *istate, int select_mask, int clear_mask);
+
+/*
  * Return 1 if the requested item is found in the virtual file system,
  * 0 for not found and -1 for undecided.
  */


### PR DESCRIPTION
When the virtualfilesystem is enabled the previous implementation of
clear_ce_flags would iterate all of the cache entries and query whether
each one is in the virtual filesystem to determine whether to clear one
of the SKIP_WORKTREE bits. For each cache entry, we would do a hash
lookup for each parent directory in the is_included_in_virtualfilesystem
function.

The former approach is slow for a typical Windows OS enlistment with
3 million files where only a small percentage is in the virtual
filesystem. The cost is
O(n_index_entries * n_chars_per_path * n_parent_directories_per_path).

In this change, we use the same approach as apply_virtualfilesystem,
which iterates the set of entries in the virtualfilesystem and searches
in the cache for the corresponding entries in order to clear their
flags. This approach has a cost of
O(n_virtual_filesystem_entries * n_chars_per_path * log(n_index_entries)).

The apply_virtualfilesystem code was refactored a bit and modified to
clear flags for all names that 'alias' a given virtual filesystem name
when ignore_case is set.

n_virtual_filesystem_entries is typically much less than
n_index_entries, in which case the new approach is much faster. We wind
up building the name hash for the index, but this occurs quickly thanks
to the multi-threading.

Signed-off-by: Neeraj Singh <neerajsi@ntdev.microsoft.com>