### PR TITLE
Allow `git upgrade-git-for-windows`

### DIFF
--- a/builtin.h
+++ b/builtin.h
@@ -228,7 +228,6 @@ int cmd_tag(int argc, const char **argv, const char *prefix);
 int cmd_tar_tree(int argc, const char **argv, const char *prefix);
 int cmd_unpack_file(int argc, const char **argv, const char *prefix);
 int cmd_unpack_objects(int argc, const char **argv, const char *prefix);
-int cmd_update(int argc, const char **argv, const char *prefix);
 int cmd_update_index(int argc, const char **argv, const char *prefix);
 int cmd_update_ref(int argc, const char **argv, const char *prefix);
 int cmd_update_server_info(int argc, const char **argv, const char *prefix);

--- a/git.c
+++ b/git.c
@@ -669,8 +669,6 @@ static struct cmd_struct commands[] = {
 	{ "tag", cmd_tag, RUN_SETUP | DELAY_PAGER_CONFIG },
 	{ "unpack-file", cmd_unpack_file, RUN_SETUP | NO_PARSEOPT },
 	{ "unpack-objects", cmd_unpack_objects, RUN_SETUP | NO_PARSEOPT },
-	{ "update", cmd_update },
-	{ "update-git-for-windows", cmd_update },
 	{ "update-index", cmd_update_index, RUN_SETUP },
 	{ "update-ref", cmd_update_ref, RUN_SETUP },
 	{ "update-server-info", cmd_update_server_info, RUN_SETUP },

--- a/help.c
+++ b/help.c
@@ -745,19 +745,3 @@ NORETURN void help_unknown_ref(const char *ref, const char *cmd,
 	string_list_clear(&suggested_refs, 0);
 	exit(1);
 }
-
-int cmd_update(int argc, const char **argv, const char *prefix)
-{
-	const char * const usage[] = {
-		N_("git update-git-for-windows [<options>]\n"
-		   "\t(not supported in this build of Git for Windows)"),
-		NULL
-	};
-	struct option options[] = {
-		OPT_END()
-	};
-
-	argc = parse_options(argc, argv, prefix, options, usage, 0);
-
-	die(_("git %s is not supported in VFSforGit"), argv[0]);
-}

--- a/t/t0402-block-command-on-gvfs.sh
+++ b/t/t0402-block-command-on-gvfs.sh
@@ -36,11 +36,4 @@ test_expect_success 'test gc --auto succeeds when disabled via config' '
 	git gc --auto
 '
 
-test_expect_success 'update-git-for-windows disabled' '
-	test_must_fail git update 2>out &&
-	test_i18ngrep VFS out &&
-	test_must_fail git update-git-for-windows 2>out &&
-	test_i18ngrep VFS out
-'
-
 test_done


### PR DESCRIPTION
Back in the days, we realized that allowing `git upgrade-git-for-windows` in the Microsoft fork would break user setups pretty quickly because VFS for Git required a specific Git version, and upgrading that without upgrading VFS for Git would break that link.

Therefore, we disabled this command (by implementing a built-in that overrides the script).

However, we recently decoupled that link and _want_ VFS for Git users to upgrade their Git independently. The only catch is that it still needs to be a version from microsoft/git because of the patches supporting VFS for Git (and those patches are pretty much certain never to make it into Git for Windows proper). Meaning: we need `git update-git-for-windows` to look for updates not in git-for-windows/git but in microsoft/git.

To that end, I modified the Azure Pipeline we're using to build microsoft/git's Git installers, by adding the "Retarget auto-update to microsoft/git" task just before building the installer. It is a PowerShell task, executing this scriptlet:

```powershell
c:\git-sdk-64-ci\git-cmd.exe --command=usr\bin\sh.exe -lc @"
    sed -i -e 's|git-for-windows/git|microsoft/git|g' \
        -e 's|\\(latest_tag_url=\\).*|\1https://api.github.com/repos/microsoft/git/releases/latest|' \
        -e 's|\\(latest=\\).*|\1`${latest_tag#*\\\\\"tag_name\\\\\": \\\\\"}; \1`${latest%%\\\\\"*}|' \
        /mingw64/libexec/git-core/git-update-git-for-windows &&
    cp /mingw64/libexec/git-core/git-update-git-for-windows /mingw64/libexec/git-core/git-update-git-for-windows.bup &&
    sed -i -e 's|pacman -S --noconfirm git-extra|& \\&\\& cp /mingw64/libexec/git-core/git-update-git-for-windows.bup /mingw64/libexec/git-core/git-update-git-for-windows|' /usr/src/build-extra/please.sh &&
    git -C /usr/src/build-extra commit -m 'Retarget update-git-for-windows to microsoft/git' please.sh
"@
```

(Yes, I agree, this looks awful, mainly due to the need to quote, escape and re-escape, with backticks for dollar signs and backslashes for double quote characters. That's what you get when you call PowerShell to call Bash which in turn needs to call `sed`. But hey, at least it works.)

Essentially, it edits the [`git-update-git-for-windows` script](https://github.com/git-for-windows/build-extra/blob/HEAD/git-extra/git-update-git-for-windows) such that it looks at microsoft/git's releases instead of git-for-windows/git's.

Side note: it is _slightly_ more involved than that because we're trying to be nice in Git for Windows by _not_ hammering the GitHub API endpoint. Instead, we're looking for the static file https://gitforwindows.org/latest-tag.txt, which is auto-generated as part of each Git for Windows release. However, there are many _less_ users of Microsoft's Git fork, so we're "hammering the GitHub API endpoint" for the microsoft/git releases instead. Also, as `git-update-git-for-windows` is part of the `git-extra` package, which for technical reasons is always force-reinstalled just before packaging the installer, we need to add a hack where the modified script is copied back just after that package was reinstalled.

With this hack in place, it is time to drop the patch that disables `git update-git-for-windows`.

This also obviates the need to fix the bug where `git update-git-for-windows` would say `git (NULL) is not supported` (because I forgot to pass `PARSE_OPT_KEEP_ARGV0` to the `parse_options()` function).

A successful installer with this change can be found here: https://dev.azure.com/gvfs/ci/_build/results?buildId=19647 and I verified that it correctly identifies what version to download, and manages to install it as intended.