### PR TITLE
Add `scalar` to contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ Release/
 /git.VC.db
 *.dSYM
 /contrib/buildsystems/out
+/scalar

--- a/contrib/scalar/.gitignore
+++ b/contrib/scalar/.gitignore
@@ -1,0 +1,5 @@
+/*.xml
+/*.1
+/*.html
+/*.exe
+/scalar

--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -1,0 +1,48 @@
+D:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+ifneq ($(D),$(CURDIR)/contrib/scalar)
+
+# This Makefile expects to be sourced from Git's top-level directory
+
+scalar scalar.exe Documentation/scalar.html Documentation/scalar.1:
+	$(MAKE) -C "$(D)/../.." -f contrib/scalar/Makefile "$@"
+
+all:
+	$(MAKE) -C "$(D)/../.." -f contrib/scalar/Makefile all-scalar
+
+scalar.1 scalar.html:
+	$(MAKE) -C "$(D)/../.." -f contrib/scalar/Makefile Documentation/"$@"
+
+.PHONY: all scalar.1 scalar.html FORCE
+
+else
+
+# Okay, we're running in Git's top-level directory. Good.
+
+include Makefile
+
+all-scalar: scalar$X Documentation/scalar.html Documentation/scalar.1
+
+all:: all-scalar
+
+scalar$X: scalar.o $(GITLIBS)
+	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $< \
+		$(GITLIBS) $(EXTLIBS)
+
+scalar.o: contrib/scalar/scalar.c
+	$(QUIET_CC)$(CC) $(ALL_CFLAGS) -o $@ -c $<
+
+Documentation/scalar.html: contrib/scalar/scalar.txt
+	$(QUIET_SUBDIR0)Documentation $(QUIET_SUBDIR1) \
+		MAN_TXT=../contrib/scalar/scalar.txt \
+		../contrib/scalar/scalar.html
+	mv contrib/scalar/scalar.html $@
+
+Documentation/scalar.1: contrib/scalar/scalar.txt
+	$(QUIET_SUBDIR0)Documentation $(QUIET_SUBDIR1) \
+		MAN_TXT=../contrib/scalar/scalar.txt \
+		../contrib/scalar/scalar.1
+
+.PHONY: all-scalar FORCE
+
+endif

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -7,6 +7,7 @@
 #include "parse-options.h"
 #include "config.h"
 #include "run-command.h"
+#include "strbuf.h"
 
 static const char scalar_usage[] =
 	N_("scalar <command> [<options>]\n\n"
@@ -108,6 +109,27 @@ static int cmd_list(int argc, const char **argv)
 	die(N_("'%s' not yet implemented"), argv[0]);
 }
 
+static int initialize_enlistment_id(void)
+{
+	const char *key = "scalar.enlistment-id";
+	char *value;
+	struct strbuf id = STRBUF_INIT;
+	int res;
+
+	if (!git_config_get_string(key, &value)) {
+		trace2_data_string("scalar", the_repository, "enlistment-id", value);
+		free(value);
+		return 0;
+	}
+
+	strbuf_addstr(&id, "TODO:GENERATE-GUID");
+
+	trace2_data_string("scalar", the_repository, "enlistment-id", id.buf);
+	res = git_config_set_gently(key, id.buf);
+	strbuf_release(&id);
+	return res;
+}
+
 static int toggle_maintenance(int enable)
 {
 	return run_git(NULL, "maintenance", enable ? "start" : "unregister",
@@ -118,6 +140,7 @@ static int cmd_register(int argc, const char **argv)
 {
 	int res = 0;
 
+	res = res || initialize_enlistment_id(); /* TODO: should we do that only on `clone`? */
 	res = res || set_recommended_config();
 	res = res || toggle_maintenance(1);
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -5,11 +5,69 @@
 #include "cache.h"
 #include "gettext.h"
 #include "parse-options.h"
+#include "config.h"
 
 static const char scalar_usage[] =
 	N_("scalar <command> [<options>]\n\n"
 	   "Commands: clone, config, diagnose, list\n"
 	   "\tregister, run, unregister");
+
+static int set_recommended_config(void)
+{
+	struct {
+		const char *key;
+		const char *value;
+	} config[] = {
+		{ "am.keepCR", "true" },
+		{ "commitGraph.generationVersion", "1" },
+		{ "core.autoCRLF", "false" },
+		{ "core.FSCache", "true" },
+		{ "core.logAllRefUpdates", "true" },
+		{ "core.multiPackIndex", "true" },
+		{ "core.preloadIndex", "true" },
+		{ "core.safeCRLF", "false" },
+		{ "credential.validate", "false" },
+		{ "feature.manyFiles", "false" },
+		{ "feature.experimental", "false" },
+		{ "fetch.unpackLimit", "1" },
+		{ "fetch.writeCommitGraph", "false" },
+		{ "gc.auto", "0" },
+		{ "gui.GCWarning", "false" },
+		{ "index.threads", "true" },
+		{ "index.version", "4" },
+		{ "maintenance.auto", "false" },
+		{ "merge.stat", "false" },
+		{ "merge.renames", "false" },
+		{ "pack.useBitmaps", "false" },
+		{ "pack.useSparse", "true" },
+		{ "receive.autoGC", "false" },
+		{ "reset.quiet", "true" },
+		{ "status.aheadBehind", "false" },
+#ifdef WIN32
+		/*
+		 * Windows-specific settings.
+		 */
+		{ "core.untrackedCache", "true" },
+		{ "core.filemode", "true" },
+#endif
+		{ NULL, NULL },
+	};
+	int i;
+
+	for (i = 0; config[i].key; i++) {
+		char *value;
+
+		if (git_config_get_string(config[i].key, &value)) {
+			trace2_data_string("scalar", the_repository, config[i].key, "created");
+			git_config_set_gently(config[i].key, config[i].value);
+		} else {
+			trace2_data_string("scalar", the_repository, config[i].key, "exists");
+			free(value);
+		}
+	}
+
+	return 0;
+}
 
 static int cmd_clone(int argc, const char **argv)
 {
@@ -33,7 +91,9 @@ static int cmd_list(int argc, const char **argv)
 
 static int cmd_register(int argc, const char **argv)
 {
-	die(N_("'%s' not yet implemented"), argv[0]);
+	set_recommended_config();
+
+	return 0;
 }
 
 static int cmd_run(int argc, const char **argv)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -7,13 +7,57 @@
 #include "parse-options.h"
 
 static const char scalar_usage[] =
-	N_("scalar <command> [<options>]");
+	N_("scalar <command> [<options>]\n\n"
+	   "Commands: clone, config, diagnose, list\n"
+	   "\tregister, run, unregister");
+
+static int cmd_clone(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_config(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_diagnose(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_list(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_register(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_run(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
+
+static int cmd_unregister(int argc, const char **argv)
+{
+	die(N_("'%s' not yet implemented"), argv[0]);
+}
 
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
 	int needs_git_repo;
 } builtins[] = {
+	{ "clone", cmd_clone, 0 },
+	{ "config", cmd_config, 1 },
+	{ "diagnose", cmd_diagnose, 1 },
+	{ "list", cmd_list, 0 },
+	{ "register", cmd_register, 1 },
+	{ "run", cmd_run, 1 },
+	{ "unregister", cmd_unregister, 1 },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -126,6 +126,7 @@ static int initialize_enlistment_id(void)
 
 	trace2_data_string("scalar", the_repository, "enlistment-id", id.buf);
 	res = git_config_set_gently(key, id.buf);
+	/* TODO: CONFIG_FLAGS_MULTI_REPLACE */
 	strbuf_release(&id);
 	return res;
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1,0 +1,37 @@
+/*
+ * This is a port of Scalar to C.
+ */
+
+#include "cache.h"
+#include "gettext.h"
+#include "parse-options.h"
+
+static const char scalar_usage[] =
+	N_("scalar <command> [<options>]");
+
+struct {
+	const char *name;
+	int (*fn)(int, const char **);
+	int needs_git_repo;
+} builtins[] = {
+	{ NULL, NULL},
+};
+
+int cmd_main(int argc, const char **argv)
+{
+	int i;
+
+	if (argc < 2)
+		usage(scalar_usage);
+	argv++;
+	argc--;
+
+	for (i = 0; builtins[i].name; i++)
+		if (!strcmp(builtins[i].name, argv[0])) {
+			if (builtins[i].needs_git_repo)
+				setup_git_directory();
+			return builtins[i].fn(argc, argv);
+		}
+
+	usage(scalar_usage);
+}

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -1,0 +1,16 @@
+scalar(1)
+=========
+
+NAME
+----
+scalar - TBD
+
+SYNOPSIS
+--------
+[verse]
+scalar [<options>]
+
+DESCRIPTION
+-----------
+
+TBD


### PR DESCRIPTION
What with all those features of Scalar having been upstreamed (partial clone, sparse checkout, `git maintenance`), let's try to move the rest to `contrib/scalar/`.

The idea is that you can build the full Scalar including documentation and Git via `make -f contrib/scalar/Makefile`.