### PR TITLE
Adding winget workflow

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -1,0 +1,38 @@
+name: "release-winget"
+on:
+  release:
+    types: [released]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - id: update-winget
+      name: Update winget repository
+      uses: mjcheetham/update-winget@v1.2
+      with:
+        id: Microsoft.Git
+        token: ${{ secrets.WINGET_TOKEN }}
+        releaseAsset: Git-\[0-9.vfs]*\-64-bit.exe
+        manifestText: |
+          PackageIdentifier: {{id}}
+          PackageVersion: {{version}}
+          PackageName: Microsoft Git
+          Publisher: Microsoft Corporation
+          Moniker: microsoft-git
+          PackageUrl: https://aka.ms/ms-git
+          Tags: [ microsoft/git ]
+          License: Copyright (C) Microsoft Corporation
+          ShortDescription: |
+            Git distribution to support monorepo scenarios.
+            Note: This is not Git for Windows. Unless you are working in a monorepo and require
+            specific Git modifications, please run `winget install git` to start using Git for Windows.
+          Installers:
+          - Architecture: x64
+            InstallerUrl: {{url}}
+            InstallerType: inno
+            InstallerSha256: {{sha256}}
+          PackageLocale: en-US
+          ManifestType: singleton
+          ManifestVersion: 1.0.0
+        alwaysUsePullRequest: true


### PR DESCRIPTION
Adding a shiny new workflow to publish releases to winget! 🥳

I validated this workflow locally by successfully opening a [PR](https://github.com/ldennington/winget-playground/pull/4) against my winget-playground repo and running `winget validate` to ensure the generated manifest adheres to winget's required schema. Any feedback on the fields I've included (\*cough\* `ShortDescription:` \*cough\*) or suggestions for additional fields/values are welcome!
