### PR TITLE
Add `git update-microsoft-git`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@
 /git-unpack-file
 /git-unpack-objects
 /git-update-index
+/git-update-microsoft-git
 /git-update-ref
 /git-update-server-info
 /git-upload-archive

--- a/Documentation/git-update-microsoft-git.txt
+++ b/Documentation/git-update-microsoft-git.txt
@@ -1,0 +1,24 @@
+git-update-microsoft-git(1)
+===========================
+
+NAME
+----
+git-update-microsoft-git - Update the installed version of Git
+
+
+SYNOPSIS
+--------
+[verse]
+'git update-microsoft-git'
+
+DESCRIPTION
+-----------
+This version of Git is based on the Microsoft fork of Git, which
+has custom capabilities focused on supporting monorepos. This
+command checks for the latest release of that fork and installs
+it on your machine.
+
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Makefile
+++ b/Makefile
@@ -1162,6 +1162,7 @@ BUILTIN_OBJS += builtin/tag.o
 BUILTIN_OBJS += builtin/unpack-file.o
 BUILTIN_OBJS += builtin/unpack-objects.o
 BUILTIN_OBJS += builtin/update-index.o
+BUILTIN_OBJS += builtin/update-microsoft-git.o
 BUILTIN_OBJS += builtin/update-ref.o
 BUILTIN_OBJS += builtin/update-server-info.o
 BUILTIN_OBJS += builtin/upload-archive.o

--- a/builtin.h
+++ b/builtin.h
@@ -229,6 +229,7 @@ int cmd_tar_tree(int argc, const char **argv, const char *prefix);
 int cmd_unpack_file(int argc, const char **argv, const char *prefix);
 int cmd_unpack_objects(int argc, const char **argv, const char *prefix);
 int cmd_update_index(int argc, const char **argv, const char *prefix);
+int cmd_update_microsoft_git(int argc, const char **argv, const char *prefix);
 int cmd_update_ref(int argc, const char **argv, const char *prefix);
 int cmd_update_server_info(int argc, const char **argv, const char *prefix);
 int cmd_upload_archive(int argc, const char **argv, const char *prefix);

--- a/builtin/update-microsoft-git.c
+++ b/builtin/update-microsoft-git.c
@@ -1,0 +1,20 @@
+#include "builtin.h"
+#include "repository.h"
+#include "parse-options.h"
+#include "run-command.h"
+
+static int platform_specific_upgrade(void)
+{
+	return 1;
+}
+
+static const char builtin_update_microsoft_git_usage[] =
+	N_("git update-microsoft-git");
+
+int cmd_update_microsoft_git(int argc, const char **argv, const char *prefix)
+{
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage(builtin_update_microsoft_git_usage);
+
+	return platform_specific_upgrade();
+}

--- a/builtin/update-microsoft-git.c
+++ b/builtin/update-microsoft-git.c
@@ -2,11 +2,31 @@
 #include "repository.h"
 #include "parse-options.h"
 #include "run-command.h"
+#include "strvec.h"
 
+#if defined(GIT_WINDOWS_NATIVE)
+/*
+ * On Windows, run 'git update-git-for-windows' which
+ * is installed by the installer, based on the script
+ * in git-for-windows/build-extra.
+ */
 static int platform_specific_upgrade(void)
 {
+	int res;
+	struct strvec args = STRVEC_INIT;
+
+	strvec_push(&args, "git-update-git-for-windows");
+	res = run_command_v_opt(args.v, 0);
+	strvec_clear(&args);
+	return res;
+}
+#else
+static int platform_specific_upgrade(void)
+{
+	error(_("update-microsoft-git is not supported on this platform"));
 	return 1;
 }
+#endif
 
 static const char builtin_update_microsoft_git_usage[] =
 	N_("git update-microsoft-git");

--- a/builtin/update-microsoft-git.c
+++ b/builtin/update-microsoft-git.c
@@ -20,6 +20,39 @@ static int platform_specific_upgrade(void)
 	strvec_clear(&args);
 	return res;
 }
+#elif defined(__APPLE__)
+/*
+ * On macOS, we expect the user to have the microsoft-git
+ * cask installed via Homebrew. We check using these
+ * commands:
+ *
+ * 1. 'brew update' to get latest versions.
+ * 2. 'brew upgrade --cask microsoft-git' to get the
+ *    latest version.
+ */
+static int platform_specific_upgrade(void)
+{
+	int res;
+	struct strvec args = STRVEC_INIT;
+
+	printf("Updating Homebrew with 'brew update'\n");
+
+	strvec_pushl(&args, "brew", "update", NULL);
+	res = run_command_v_opt(args.v, 0);
+	strvec_clear(&args);
+
+	if (res) {
+		error(_("'brew update' failed; is brew installed?"));
+		return 1;
+	}
+
+	printf("Upgrading microsoft-git with 'brew upgrade --cask microsoft-git'\n");
+	strvec_pushl(&args, "brew", "upgrade", "--cask", "microsoft-git", NULL);
+	res = run_command_v_opt(args.v, 0);
+	strvec_clear(&args);
+
+	return res;
+}
 #else
 static int platform_specific_upgrade(void)
 {

--- a/git.c
+++ b/git.c
@@ -670,6 +670,7 @@ static struct cmd_struct commands[] = {
 	{ "unpack-file", cmd_unpack_file, RUN_SETUP | NO_PARSEOPT },
 	{ "unpack-objects", cmd_unpack_objects, RUN_SETUP | NO_PARSEOPT },
 	{ "update-index", cmd_update_index, RUN_SETUP },
+	{ "update-microsoft-git", cmd_update_microsoft_git },
 	{ "update-ref", cmd_update_ref, RUN_SETUP },
 	{ "update-server-info", cmd_update_server_info, RUN_SETUP },
 	{ "upload-archive", cmd_upload_archive, NO_PARSEOPT },


### PR DESCRIPTION
This adds a new builtin, `git update-microsoft-git`, that executes the platform-specific upgrade steps to get the latest version of `microsoft-git`.

On Windows, this means running `git update-git-for-windows` which was updated to use the `microsoft/git` releases page, when appropriate. See #321 for details.

On macOS, this means running a sequence of `brew` commands. These are adapted from the `UpgradeVerb` in `microsoft/scalar`, with an important simplification: we don't need to differentiate between the `scalar` and `scalar-azrepos` cask.