### PR TITLE
Adding /AUTOUPDATE switch to winget manifest template

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -32,6 +32,8 @@ jobs:
             InstallerUrl: {{url}}
             InstallerType: inno
             InstallerSha256: {{sha256}}
+            InstallerSwitches:
+              Custom: "/AUTOUPDATE"
           PackageLocale: en-US
           ManifestType: singleton
           ManifestVersion: 1.0.0


### PR DESCRIPTION
Adding the `/AUTOUPDATE` flag to our winget manifest template. This will ensure microsoft/git users get a toast notification when new versions of the tool are available.

Although this passed the `winget validate` test, it's tough to do more to validate this change until we have an official release of microsoft/git with this flag in the wild, so planning to let this PR sit open until I can verify this does what we expect it to do.