### PR TITLE
Fixing release asset regex

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -13,7 +13,7 @@ jobs:
       with:
         id: Microsoft.Git
         token: ${{ secrets.WINGET_TOKEN }}
-        releaseAsset: Git-\[0-9.vfs]*\-64-bit.exe
+        releaseAsset: Git-([0-9.vfs]*)\-64-bit.exe
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -21,7 +21,7 @@ jobs:
           Publisher: Microsoft Corporation
           Moniker: microsoft-git
           PackageUrl: https://aka.ms/ms-git
-          Tags: [ microsoft/git ]
+          Tags: [ microsoft-git ]
           License: Copyright (C) Microsoft Corporation
           ShortDescription: |
             Git distribution to support monorepo scenarios.


### PR DESCRIPTION
As @derrickstolee and I were testing our new release to verify the winget workflow, we discovered that I'd goofed on the release asset regex, which caused the `mjcheetham/update-winget` action to be unable to find the Git exe. I'm correcting that here. I'm also removing the `/` from the tag name to align naming with our Homebrew releases.

I validated by running a [demo version](https://github.com/ldennington/validate-winget-action/actions/runs/811048630) in my ldennington/validate-winget-action repo, which opened a [PR](https://github.com/ldennington/winget-playground/pull/8) against my ldennington/winget-playground repo.
