### PR TITLE
contrib/scalar: add the `version` subcommand

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1304,6 +1304,25 @@ static int cmd_delete(int argc, const char **argv)
 	return delete_enlistment();
 }
 
+static int cmd_help(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar help"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	return run_git("help", "scalar", NULL);
+}
+
 static int cmd_version(int argc, const char **argv)
 {
 	int verbose = 0, build_options = 0;
@@ -1356,6 +1375,7 @@ struct {
 	{ "diagnose", cmd_diagnose },
 	{ "cache-server", cmd_cache_server },
 	{ "delete", cmd_delete },
+	{ "help", cmd_help },
 	{ "version", cmd_version },
 	{ "test", cmd_test },
 	{ NULL, NULL},

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1304,6 +1304,34 @@ static int cmd_delete(int argc, const char **argv)
 	return delete_enlistment();
 }
 
+static int cmd_version(int argc, const char **argv)
+{
+	int verbose = 0, build_options = 0;
+	struct option options[] = {
+		OPT__VERBOSE(&verbose, N_("include Git version")),
+		OPT_BOOL(0, "build-options", &build_options,
+			 N_("include Git's build options")),
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar verbose [-v | --verbose] [--build-options]"),
+		NULL
+	};
+	struct strbuf buf = STRBUF_INIT;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	get_version_info(&buf, build_options);
+	fprintf(stderr, "%s\n", buf.buf);
+	strbuf_release(&buf);
+
+	return 0;
+}
+
 static int cmd_test(int argc, const char **argv)
 {
 	const char *url = argc > 1 ? argv[1] :
@@ -1328,6 +1356,7 @@ struct {
 	{ "diagnose", cmd_diagnose },
 	{ "cache-server", cmd_cache_server },
 	{ "delete", cmd_delete },
+	{ "version", cmd_version },
 	{ "test", cmd_test },
 	{ NULL, NULL},
 };

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -8,7 +8,7 @@
 #include "config.h"
 #include "run-command.h"
 #include "refs.h"
-#include "version.h"
+#include "help.h"
 #include "dir.h"
 #include "fsmonitor-ipc.h"
 #include "json-parser.h"
@@ -975,6 +975,15 @@ cleanup:
 	return res;
 }
 
+/*
+ * Dummy implementation; Using `get_version_info()` would cause a link error
+ * without this.
+ */
+void load_builtin_commands(const char *prefix, struct cmdnames *cmds)
+{
+	die("not implemented");
+}
+
 static int cmd_diagnose(int argc, const char **argv)
 {
 	struct option options[] = {
@@ -1009,10 +1018,7 @@ static int cmd_diagnose(int argc, const char **argv)
 	strbuf_addf(&buf, "Collecting diagnostic info into temp folder %s\n\n",
 		    tmp_dir.buf);
 
-	strbuf_addf(&buf, "git version %s\n", git_version_string);
-	strbuf_addf(&buf, "built from commit: %s\n\n",
-		    git_built_from_commit_string[0] ?
-		    git_built_from_commit_string : "(n/a)");
+	get_version_info(&buf, 1);
 
 	strbuf_addf(&buf, "Enlistment root: %s\n", the_repository->worktree);
 


### PR DESCRIPTION
This command is handled somewhat magically in the .NET version, and it is a bit unclear to this developer how the version is updated... Maybe we can start with a hard-coded version, though, and make it more dynamic (e.g. generated from the recent dates of the commit history of `contrib/scalar/`) later?