### PR TITLE
scalar: rework `needs_git_repo`

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -233,19 +233,15 @@ static int stop_fsmonitor_daemon(const char *dir)
 	return res;
 }
 
-static int register_dir(const char *dir)
+static int register_dir(void)
 {
-	int res = add_or_remove_enlistment(dir, 1);
-
-	if (!res) {
-		char *config_path =
-			dir ? xstrfmt("%s/.git/config", dir) : NULL;
-		res = set_recommended_config(config_path);
-		free(config_path);
-	}
+	int res = add_or_remove_enlistment(NULL, 1);
 
 	if (!res)
-		res = toggle_maintenance(dir, 1);
+		res = set_recommended_config(NULL);
+
+	if (!res)
+		res = toggle_maintenance(NULL, 1);
 
 	return res;
 }
@@ -902,7 +898,7 @@ static int cmd_clone(int argc, const char **argv)
 	if (res)
 		goto cleanup;
 
-	res = register_dir(NULL);
+	res = register_dir();
 
 cleanup:
 	free(root);
@@ -1033,7 +1029,7 @@ static int cmd_register(int argc, const char **argv)
 	/* TODO: turn `feature.scalar` into the appropriate settings */
 	/* TODO: enable FSMonitor and other forgotten settings */
 
-	return register_dir(NULL);
+	return register_dir();
 }
 
 static int cmd_run(int argc, const char **argv)
@@ -1084,13 +1080,13 @@ static int cmd_run(int argc, const char **argv)
 	strbuf_release(&buf);
 
 	if (i == 0)
-		return register_dir(NULL);
+		return register_dir();
 
 	if (i > 0)
 		return run_git(NULL, "maintenance", "run",
 			       "--task", tasks[i].task, NULL);
 
-	if (register_dir(NULL))
+	if (register_dir())
 		return -1;
 	for (i = 1; tasks[i].arg; i++)
 		if (run_git(NULL, "maintenance", "run",

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -915,6 +915,13 @@ cleanup:
 
 static int cmd_diagnose(int argc, const char **argv)
 {
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar diagnose [<enlistment>]"),
+		NULL
+	};
 	struct strbuf tmp_dir = STRBUF_INIT;
 	time_t now = time(NULL);
 	struct tm tm;
@@ -922,8 +929,10 @@ static int cmd_diagnose(int argc, const char **argv)
 	char *cache_server_url = NULL, *shared_cache = NULL;
 	int res = 0;
 
-	if (argc != 1)
-		die("'scalar diagnose' does not accept any arguments");
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
 
 	strbuf_addstr(&buf, "../.scalarDiagnostics/scalar_");
 	strbuf_addftime(&buf, "%Y%m%d_%H%M%S",
@@ -1198,7 +1207,7 @@ struct {
 	{ "register", cmd_register, 0 },
 	{ "unregister", cmd_unregister, 0 },
 	{ "run", cmd_run, 0 },
-	{ "diagnose", cmd_diagnose, 1 },
+	{ "diagnose", cmd_diagnose, 0 },
 	{ "cache-server", cmd_cache_server, 0 },
 	{ "test", cmd_test, 0 },
 	{ NULL, NULL},

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -184,9 +184,9 @@ static int set_recommended_config(const char *file)
 	return 0;
 }
 
-static int toggle_maintenance(const char *dir, int enable)
+static int toggle_maintenance(int enable)
 {
-	return run_git(dir, "maintenance", enable ? "start" : "unregister",
+	return run_git(NULL, "maintenance", enable ? "start" : "unregister",
 		       NULL);
 }
 
@@ -237,7 +237,7 @@ static int register_dir(void)
 		res = set_recommended_config(NULL);
 
 	if (!res)
-		res = toggle_maintenance(NULL, 1);
+		res = toggle_maintenance(1);
 
 	return res;
 }
@@ -250,7 +250,7 @@ static int unregister_dir(void)
 		res = add_or_remove_enlistment(0);
 
 	if (!res)
-		res = toggle_maintenance(NULL, 0);
+		res = toggle_maintenance(0);
 
 	return res;
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1074,10 +1074,20 @@ static int cmd_run(int argc, const char **argv)
 
 static int cmd_unregister(int argc, const char **argv)
 {
-	if (argc != 1 && argc != 2)
-		usage(_("scalar unregister [<worktree>]"));
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar unregister [<enlistment>]"),
+		NULL
+	};
 
-	return unregister_dir(argc < 2 ? NULL : argv[1]);
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return unregister_dir(NULL);
 }
 
 static int cmd_cache_server(int argc, const char **argv)
@@ -1177,7 +1187,7 @@ struct {
 	{ "clone", cmd_clone, 0 },
 	{ "list", cmd_list, 0 },
 	{ "register", cmd_register, 0 },
-	{ "unregister", cmd_unregister, 1 },
+	{ "unregister", cmd_unregister, 0 },
 	{ "run", cmd_run, 1 },
 	{ "diagnose", cmd_diagnose, 1 },
 	{ "cache-server", cmd_cache_server, 0 },

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -246,15 +246,15 @@ static int register_dir(void)
 	return res;
 }
 
-static int unregister_dir(const char *dir)
+static int unregister_dir(void)
 {
-	int res = stop_fsmonitor_daemon(dir);
+	int res = stop_fsmonitor_daemon(NULL);
 
 	if (!res)
-		res = add_or_remove_enlistment(dir, 0);
+		res = add_or_remove_enlistment(NULL, 0);
 
 	if (!res)
-		res = toggle_maintenance(dir, 0);
+		res = toggle_maintenance(NULL, 0);
 
 	return res;
 }
@@ -1110,7 +1110,7 @@ static int cmd_unregister(int argc, const char **argv)
 
 	setup_enlistment_directory(argc, argv, usage, options);
 
-	return unregister_dir(NULL);
+	return unregister_dir();
 }
 
 static int cmd_cache_server(int argc, const char **argv)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1122,7 +1122,7 @@ static int cmd_cache_server(int argc, const char **argv)
 	};
 	const char * const usage[] = {
 		N_("scalar cache_server "
-		   "[--get | --set <url> | --list [<remote>]] [<worktree>]"),
+		   "[--get | --set <url> | --list [<remote>]] [<enlistment>]"),
 		NULL
 	};
 	int res = 0;
@@ -1134,13 +1134,7 @@ static int cmd_cache_server(int argc, const char **argv)
 		usage_msg_opt(_("--get/--set/--list are mutually exclusive"),
 			      usage, options);
 
-	if (argc == 1) {
-		if (chdir(argv[0]) < 0)
-			die(_("could not switch to '%s'"), argv[0]);
-	} else if (argc > 0)
-		usage_with_options(usage, options);
-
-	setup_git_directory();
+	setup_enlistment_directory(argc, argv, usage, options);
 
 	if (list) {
 		const char *name = list, *url = list;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -637,7 +637,8 @@ static char *get_cache_key(const char *dir, const char *url)
 
 		strbuf_release(&downcased);
 
-		cache_key = xstrfmt("url_%s", hash_to_hex(hash));
+		cache_key = xstrfmt("url_%s",
+				    hash_to_hex_algop(hash, hash_algo));
 	}
 
 	strbuf_release(&out);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -219,12 +219,12 @@ static int add_or_remove_enlistment(const char *dir, int add)
 		       "scalar.repo", worktree, NULL);
 }
 
-static int stop_fsmonitor_daemon(const char *dir)
+static int stop_fsmonitor_daemon(void)
 {
 	int res = 0;
 
 #ifdef HAVE_FSMONITOR_DAEMON_BACKEND
-	res = run_git(dir, "fsmonitor--daemon", "--stop", NULL);
+	res = run_git(NULL, "fsmonitor--daemon", "--stop", NULL);
 
 	if (res == 1 && fsmonitor_ipc__get_state() == IPC_STATE__LISTENING)
 		res = error(_("could not stop the FSMonitor daemon"));
@@ -248,7 +248,7 @@ static int register_dir(void)
 
 static int unregister_dir(void)
 {
-	int res = stop_fsmonitor_daemon(NULL);
+	int res = stop_fsmonitor_daemon();
 
 	if (!res)
 		res = add_or_remove_enlistment(NULL, 0);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1200,16 +1200,15 @@ static int cmd_test(int argc, const char **argv)
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
-	int needs_git_repo;
 } builtins[] = {
-	{ "clone", cmd_clone, 0 },
-	{ "list", cmd_list, 0 },
-	{ "register", cmd_register, 0 },
-	{ "unregister", cmd_unregister, 0 },
-	{ "run", cmd_run, 0 },
-	{ "diagnose", cmd_diagnose, 0 },
-	{ "cache-server", cmd_cache_server, 0 },
-	{ "test", cmd_test, 0 },
+	{ "clone", cmd_clone },
+	{ "list", cmd_list },
+	{ "register", cmd_register },
+	{ "unregister", cmd_unregister },
+	{ "run", cmd_run },
+	{ "diagnose", cmd_diagnose },
+	{ "cache-server", cmd_cache_server },
+	{ "test", cmd_test },
 	{ NULL, NULL},
 };
 
@@ -1248,11 +1247,8 @@ int cmd_main(int argc, const char **argv)
 		argc--;
 
 		for (i = 0; builtins[i].name; i++)
-			if (!strcmp(builtins[i].name, argv[0])) {
-				if (builtins[i].needs_git_repo)
-					setup_git_directory();
+			if (!strcmp(builtins[i].name, argv[0]))
 				return builtins[i].fn(argc, argv);
-			}
 	}
 
 	strbuf_addstr(&scalar_usage,

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -27,9 +27,14 @@ experience will speed up. Scalar sets advanced Git config settings,
 maintains your repositories in the background, and helps reduce data sent
 across the network.
 
+An important Scalar concept is the enlistment: this is the top-level directory
+of the project. It contains the subdirectory `src/` which is a Git worktree.
+This encourages the separation between tracked files (inside `src/`) and
+untracked files (outside `src/`).
+
 The command implements various subcommands, and different options depending
 on the subcommand. With the exception of `clone` and `list`, all subcommands
-expect to be run in a Git worktree.
+expect to be run in an enlistment.
 
 The following options can be specified _before_ the subcommand:
 

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
          [--no-fetch-commits-and-trees] [--local-cache-path <path>]
-         [--cache-server-url <url>] <url> [<directory>]
+         [--cache-server-url <url>] <url> [<enlistment>]
 scalar list
 scalar register
 scalar unregister
@@ -52,10 +52,10 @@ COMMANDS
 Clone
 ~~~~~
 
-clone [<options>] <url> [<directory>]::
+clone [<options>] <url> [<enlistment>]::
     Clones the specified repository, similar to linkgit:git-clone[1]. By
     default, only commit and tree objects are cloned. Once finished, the
-    worktree is located at `<directory>/src`.
+    worktree is located at `<enlistment>/src`.
 +
 The sparse-checkout feature is enabled (except when run with `--full-clone`)
 and the only files present are those in the top-level directory. Use
@@ -73,11 +73,11 @@ subdirectories outside your sparse-checkout by using `git ls-tree HEAD`.
 	Clone only the history leading to the tip of a single branch,
 	either specified by the `--branch` option or the primary
 	branch remote's `HEAD` points at.
-	Further fetches into the resulting repository will only update the
-	remote-tracking branch for the branch this option was used for the
-	initial cloning.  If the HEAD at the remote did not point at any
-	branch when `--single-branch` clone was made, no remote-tracking
-	branch is created.
++
+Further fetches into the resulting repository will only update the
+remote-tracking branch for the branch this option was used for the initial
+cloning. If the HEAD at the remote did not point at any branch when
+`--single-branch` clone was made, no remote-tracking branch is created.
 
 --[no-]full-clone::
     A sparse-checkout is initialized by default. This behavior can be turned

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -16,7 +16,7 @@ scalar register [<enlistment>]
 scalar unregister [<enlistment>]
 scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]
 scalar diagnose [<enlistment>]
-scalar cache-server ( --get | --set <url> | --list [<remote>] )
+scalar cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]
 
 DESCRIPTION
 -----------
@@ -155,7 +155,7 @@ a directory adjacent to the worktree in the `src` directory.
 Cache-server
 ~~~~~~~~~~~~
 
-cache-server ( --get | --set <url> | --list [<remote>] )::
+cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]::
     This command lets you query or set the GVFS-enabled cache server used
     to fetch missing objects.
 

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -12,8 +12,8 @@ scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
          [--no-fetch-commits-and-trees] [--local-cache-path <path>]
          [--cache-server-url <url>] <url> [<enlistment>]
 scalar list
-scalar register
-scalar unregister
+scalar register [<enlistment>]
+scalar unregister [<enlistment>]
 scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files )
 scalar diagnose
 scalar cache-server ( --get | --set <url> | --list [<remote>] )
@@ -110,17 +110,18 @@ list::
 Register
 ~~~~~~~~
 
-register [<path>]::
-    Adds a repository to the list of registered repositories. If `<path>`
-    is not provided, then the repository associated with the current
-    directory is registered.
+register [<enlistment>]::
+    Adds a repository to the list of registered repositories. If
+    `<enlistment>` is not provided, then the enlistment associated with the
+    current working directory is registered.
 
 Unregister
 ~~~~~~~~~~
 
-unregister [<path>]::
+unregister [<enlistment>]::
     Remove the specified repository from the list of repositories
-    registered with Scalar.
+    registered with Scalar. This stops the scheduled maintenance and the
+    built-in FSMonitor.
 
 Run
 ~~~

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -14,8 +14,8 @@ scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
-scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files )
-scalar diagnose
+scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]
+scalar diagnose [<enlistment>]
 scalar cache-server ( --get | --set <url> | --list [<remote>] )
 
 DESCRIPTION
@@ -126,7 +126,7 @@ unregister [<enlistment>]::
 Run
 ~~~
 
-scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files )::
+scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]::
     Run the given maintenance task (or all tasks, if `all` was specified).
     Except for `all` and `config`, this subcommand simply hands off to
     linkgit:git-maintenance[1] (mapping `fetch` to `prefetch` and
@@ -144,10 +144,10 @@ automatically, explicit invocations of this task are rarely needed.
 Diagnose
 ~~~~~~~~
 
-diagnose::
+diagnose [<enlistment>]::
     When reporting issues with Scalar, it is often helpful to provide the
     information gathered by this command, including logs and certain
-    statistics describing the data shape of the current repository.
+    statistics describing the data shape of the current enlistment.
 +
 The output of this command is a `.zip` file that is written into
 a directory adjacent to the worktree in the `src` directory.

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -59,19 +59,15 @@ test_expect_success 'scalar clone' '
 
 SQ="'"
 test_expect_success UNZIP 'scalar diagnose' '
-	(
-		cd cloned/src &&
-		scalar diagnose >out &&
-		cat out &&
-		sed -n "s/.*$SQ\\(.*\\.zip\\)$SQ.*/\\1/p" <out >zip_path &&
-		zip_path=$(cat zip_path) &&
-		test -n "$zip_path" &&
-		unzip -v "$zip_path" &&
-		folder=${zip_path%.zip} &&
-		test_path_is_missing "$folder" &&
-		unzip -p "$zip_path" diagnostics.log >out &&
-		test_file_not_empty out
-	)
+	scalar diagnose cloned >out &&
+	sed -n "s/.*$SQ\\(.*\\.zip\\)$SQ.*/\\1/p" <out >zip_path &&
+	zip_path=$(cat zip_path) &&
+	test -n "$zip_path" &&
+	unzip -v "$zip_path" &&
+	folder=${zip_path%.zip} &&
+	test_path_is_missing "$folder" &&
+	unzip -p "$zip_path" diagnostics.log >out &&
+	test_file_not_empty out
 '
 
 GIT_TEST_ALLOW_GVFS_VIA_HTTP=1


### PR DESCRIPTION
We cannot actually set up the gitdir before parsing the options because we want to support the optional enlistment path parameter. Meaning: the `cmd_*()` function must be allowed to parse the options _before_ we know whether that optional enlistment path parameter was provided or not.

While at it, we change the paradigm by always `chdir()`-ing into the worktree. That allows us to simplify the code rather dramatically, as we no longer have to pass around the `dir` parameter, and we also need not care to specify the exact path to the local repository config anymore.