### PR TITLE
Scalar: clean up the authentication story

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -602,7 +602,8 @@ static char *get_cache_key(const char *url)
 	 * The GVFS protocol is only supported via https://; For testing, we
 	 * also allow http://.
 	 */
-	if (can_url_support_gvfs(url)) {
+	if (!git_env_bool("SCALAR_TEST_SKIP_VSTS_INFO", 0) &&
+	    can_url_support_gvfs(url)) {
 		cp.git_cmd = 1;
 		strvec_pushl(&cp.args, "gvfs-helper", "--remote", url,
 			     "endpoint", "vsts/info", NULL);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -242,13 +242,13 @@ static int register_dir(void)
 
 static int unregister_dir(void)
 {
-	int res = stop_fsmonitor_daemon();
+	int res = toggle_maintenance(0);
 
-	if (!res)
-		res = add_or_remove_enlistment(0);
+	if (add_or_remove_enlistment(0) < 0)
+		res = -1;
 
-	if (!res)
-		res = toggle_maintenance(0);
+	if (stop_fsmonitor_daemon() < 0)
+		res = -1;
 
 	return res;
 }


### PR DESCRIPTION
It is a bit tricky to align the C version of Scalar with the .NET version when it comes to authentication: the .NET version took care of it explicitly, and contains some logic to avoid authenticating _just_ for the `vsts/info` endpoint of a remote repository when the `gvfs/config` endpoint did not require authentication.

This matters because Scalar's functional tests depend on that behavior.

As a work-around, I already tried to clamp down any authentication apart from credential helper-based one, when running in unattended mode. But the functional tests do not run in unattended mode.

So this PR is an attempt to rectify this.

The idea is to prevent terminal-based authentication altogether, and if interactive credential usage was denied by the user (via `credential.interactive=never`), we now pretend that the user entered an empty password (via `GIT_ASKPASS=true`).