### PR TITLE
scalar: implement the `delete` command

### DIFF
--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -17,6 +17,7 @@ scalar unregister [<enlistment>]
 scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]
 scalar diagnose [<enlistment>]
 scalar cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]
+scalar delete <enlistment>
 
 DESCRIPTION
 -----------
@@ -172,6 +173,14 @@ repository), this command mode triggers a request via the network that
 potentially requires authentication. If authentication is required, the
 configured credential helper is employed (see linkgit:git-credential[1]
 for details).
+
+Delete
+~~~~~~
+
+delete <enlistment>::
+    This command lets you delete an existing Scalar enlistment from your
+    local file system, unregistering the repository and stopping any file
+    watcher daemons (FSMonitor).
 
 SEE ALSO
 --------

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -169,4 +169,13 @@ test_expect_success 'scalar unregister' '
 	! grep -F "$(pwd)/poof/src" scalar.repos
 '
 
+test_expect_success 'scalar delete without enlistment shows a usage' '
+	test_expect_code 129 scalar delete
+'
+
+test_expect_success 'scalar delete with enlistment' '
+	scalar delete cloned &&
+	test_path_is_missing cloned
+'
+
 test_done


### PR DESCRIPTION
Delete an enlistment by first unregistering the repository and then deleting the enlisment directory (the directory containing the worktree `src` directory).

On Windows, if the current directory is inside the enlismtnet directory then change to the parent of the enlistment directory, to allow us to delete the enlistment.

Notes:
- Feels like there should be a better/existing way to do what the `strbuf_parent(..)` routine I added does, without having to just inline the `for(..)`

- Should we do any extra checks before we proceed regarding `rm -rf`-ing the enlistment directory? I.e, check that it's not `/` for good measure?

- My test fails, but manual testing of `delete` works. I'm not sure I understand the context in which these tests run.

- Apologies in advance for any implementation that's contra to established Git/C practices; let me know what to fix or change.