### PR TITLE
Scalar: drop incorrect free() calls

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -697,7 +697,7 @@ static char *remote_default_branch(const char *url)
 
 static int cmd_clone(int argc, const char **argv)
 {
-	char *branch = NULL;
+	const char *branch = NULL;
 	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
 	char *cache_server_url = NULL, *local_cache_root = NULL;
 	struct option clone_options[] = {
@@ -895,7 +895,6 @@ cleanup:
 	free(root);
 	free(dir);
 	strbuf_release(&buf);
-	free(branch);
 	free(cache_server_url);
 	free(local_cache_root);
 	free(cache_key);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -700,7 +700,7 @@ static int cmd_clone(int argc, const char **argv)
 	const char *branch = NULL;
 	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
 	const char *cache_server_url = NULL, *local_cache_root = NULL;
-	char *default_cache_server_url = NULL;
+	char *default_cache_server_url = NULL, *local_cache_root_abs = NULL;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -761,7 +761,8 @@ static int cmd_clone(int argc, const char **argv)
 	if (!local_cache_root)
 		local_cache_root = default_cache_root(root);
 	else
-		ensure_absolute_path(&local_cache_root);
+		local_cache_root = local_cache_root_abs =
+			real_pathdup(local_cache_root, 1);
 
 	if (!local_cache_root)
 		die(_("could not determine local cache root"));
@@ -899,7 +900,7 @@ cleanup:
 	free(dir);
 	strbuf_release(&buf);
 	free(default_cache_server_url);
-	free(local_cache_root);
+	free(local_cache_root_abs);
 	free(cache_key);
 	free(shared_cache_path);
 	return res;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -699,7 +699,8 @@ static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
 	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
-	char *cache_server_url = NULL, *local_cache_root = NULL;
+	const char *cache_server_url = NULL, *local_cache_root = NULL;
+	char *default_cache_server_url = NULL;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -831,7 +832,9 @@ static int cmd_clone(int argc, const char **argv)
 	}
 
 	if (cache_server_url ||
-	    supports_gvfs_protocol(url, &cache_server_url)) {
+	    supports_gvfs_protocol(url, &default_cache_server_url)) {
+		if (!cache_server_url)
+			cache_server_url = default_cache_server_url;
 		if (set_config("core.useGVFSHelper=true") ||
 		    set_config("core.gvfs=150")) {
 			res = error(_("could not turn on GVFS helper"));
@@ -895,7 +898,7 @@ cleanup:
 	free(root);
 	free(dir);
 	strbuf_release(&buf);
-	free(cache_server_url);
+	free(default_cache_server_url);
 	free(local_cache_root);
 	free(cache_key);
 	free(shared_cache_path);


### PR DESCRIPTION
The parsed option strings are never `malloc()`ed, therefore they must not be `free()`d. This is the cause of many a `139` exit code (which is 128+11, i.e. signal 11, i.e. a segmentation fault) in the functional test suite.

D'oh!