### PR TITLE
scalar: break infinite loop looking for the enlistment

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -57,7 +57,7 @@ static void setup_enlistment_directory(int argc, const char **argv,
 				break;
 			}
 
-			for (; len > 0 && !is_dir_sep(path.buf[len]); len--)
+			while (len > 0 && !is_dir_sep(path.buf[--len]))
 				; /* keep looking for parent directory */
 
 			if (!len)


### PR DESCRIPTION
Apparently I never really tested the loop looking for the enlistment, and it would work only if we are already in the enlistment's top-level directory.

This bug is the reason why the functional tests in https://github.com/microsoft/scalar/pull/505 kept timing out.