### PR TITLE
scalar unregister: make it gentler

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1019,7 +1019,9 @@ static int cmd_list(int argc, const char **argv)
 	if (argc != 1)
 		die(_("`scalar list` does not take arguments"));
 
-	return run_git("config", "--global", "--get-all", "scalar.repo", NULL);
+	if (run_git("config", "--global", "--get-all", "scalar.repo", NULL) < 0)
+		return -1;
+	return 0;
 }
 
 static int cmd_register(int argc, const char **argv)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -216,11 +216,23 @@ static int add_or_remove_enlistment(int add)
 static int stop_fsmonitor_daemon(void)
 {
 #ifdef HAVE_FSMONITOR_DAEMON_BACKEND
-	if (!run_git("fsmonitor--daemon", "--stop", NULL))
-		return 0;
+	struct strbuf err = STRBUF_INIT;
+	struct child_process cp = CHILD_PROCESS_INIT;
 
-	if (fsmonitor_ipc__get_state() == IPC_STATE__LISTENING)
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "fsmonitor--daemon", "--stop", NULL);
+	if (!pipe_command(&cp, NULL, 0, NULL, 0, &err, 0)) {
+		strbuf_release(&err);
+		return 0;
+	}
+
+	if (fsmonitor_ipc__get_state() == IPC_STATE__LISTENING) {
+		write_in_full(2, err.buf, err.len);
+		strbuf_release(&err);
 		return error(_("could not stop the FSMonitor daemon"));
+	}
+
+	strbuf_release(&err);
 #endif
 
 	return 0;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1260,7 +1260,7 @@ int cmd_main(int argc, const char **argv)
 
 		for (i = 0; builtins[i].name; i++)
 			if (!strcmp(builtins[i].name, argv[0]))
-				return builtins[i].fn(argc, argv);
+				return !!builtins[i].fn(argc, argv);
 	}
 
 	strbuf_addstr(&scalar_usage,

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1121,6 +1121,37 @@ static int cmd_unregister(int argc, const char **argv)
 	argc = parse_options(argc, argv, NULL, options,
 			     usage, 0);
 
+	/*
+	 * Be forgiving when the enlistment or worktree does not even exist any
+	 * longer; This can be the case if a user deleted the worktree by
+	 * mistake and _still_ wants to unregister the thing.
+	 */
+	if (argc == 1) {
+		struct strbuf path = STRBUF_INIT;
+
+		strbuf_addf(&path, "%s/src/.git", argv[0]);
+		if (!is_directory(path.buf)) {
+			int res = 0;
+
+			strbuf_strip_suffix(&path, "/.git");
+			strbuf_realpath_forgiving(&path, path.buf, 1);
+
+			if (run_git("config", "--global",
+				    "--unset", "--fixed-value",
+				    "scalar.repo", path.buf, NULL) < 0)
+				res = -1;
+
+			if (run_git("config", "--global",
+				    "--unset", "--fixed-value",
+				    "maintenance.repo", path.buf, NULL) < 0)
+				res = -1;
+
+			strbuf_release(&path);
+			return res;
+		}
+		strbuf_release(&path);
+	}
+
 	setup_enlistment_directory(argc, argv, usage, options);
 
 	return unregister_dir();

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -215,16 +215,15 @@ static int add_or_remove_enlistment(int add)
 
 static int stop_fsmonitor_daemon(void)
 {
-	int res = 0;
-
 #ifdef HAVE_FSMONITOR_DAEMON_BACKEND
-	res = run_git("fsmonitor--daemon", "--stop", NULL);
+	if (!run_git("fsmonitor--daemon", "--stop", NULL))
+		return 0;
 
-	if (res == 1 && fsmonitor_ipc__get_state() == IPC_STATE__LISTENING)
-		res = error(_("could not stop the FSMonitor daemon"));
+	if (fsmonitor_ipc__get_state() == IPC_STATE__LISTENING)
+		return error(_("could not stop the FSMonitor daemon"));
 #endif
 
-	return res;
+	return 0;
 }
 
 static int register_dir(void)

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -154,4 +154,19 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 	)
 '
 
+test_expect_success 'scalar unregister' '
+	git init poof/src &&
+	scalar register poof/src &&
+	git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/poof/src" &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/poof/src" scalar.repos &&
+	rm -rf poof/src/.git &&
+	scalar unregister poof &&
+	test_must_fail git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/poof/src" &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/poof/src" scalar.repos
+'
+
 test_done


### PR DESCRIPTION
When the FSMonitor is not even running, or when the enlistment was deleted manually by mistake, `scalar unregister` should still work.