### PR TITLE
scalar: fix `dir_inside_of()` issues

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -784,9 +784,6 @@ static int cmd_clone(int argc, const char **argv)
 	if (!local_cache_root)
 		die(_("could not determine local cache root"));
 
-	if (dir_inside_of(local_cache_root, dir) >= 0)
-		die(_("'--local-cache-path' cannot be inside the src folder"));
-
 	if (is_non_empty_dir(dir))
 		die(_("'%s' exists and is not empty"), dir);
 
@@ -808,6 +805,15 @@ static int cmd_clone(int argc, const char **argv)
 	}
 
 	setup_git_directory();
+
+	git_config(git_default_config, NULL);
+
+	/*
+	 * This `dir_inside_of()` call relies on git_config() having parsed the
+	 * newly-initialized repository config's `core.ignoreCase` value.
+	 */
+	if (dir_inside_of(local_cache_root, dir) >= 0)
+		die(_("'--local-cache-path' cannot be inside the src folder"));
 
 	/* common-main already logs `argv` */
 	trace2_data_string("scalar", the_repository, "dir", dir);

--- a/dir.c
+++ b/dir.c
@@ -2894,6 +2894,8 @@ static int cmp_icase(char a, char b)
 {
 	if (a == b)
 		return 0;
+	if (is_dir_sep(a))
+		return is_dir_sep(b) ? 0 : -1;
 	if (ignore_case)
 		return toupper(a) - toupper(b);
 	return a - b;


### PR DESCRIPTION
This pair of commits should address at least the `CloneTests` failures of Scalar's functional test suite on macOS and Windows.