### PR TITLE
scalar: let more functional tests pass

### DIFF
--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -725,3 +725,12 @@ core.abbrev::
 	If set to "no", no abbreviation is made and the object names
 	are shown in their full length.
 	The minimum length is 4.
+
+core.writeConfigLockTimeoutMS::
+	When processes try to write to the config concurrently, it is likely
+	that one process "wins" and the other process(es) fail to lock the
+	config file. By configuring a timeout larger than zero, Git can be
+	told to try to lock the config again a couple times within the
+	specified timeout. If the timeout is configure to zero (which is the
+	default), Git will fail immediately when the config is already
+	locked.

--- a/cache.h
+++ b/cache.h
@@ -971,6 +971,8 @@ extern struct strbuf gvfs_shared_cache_pathname;
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
 
+extern long config_write_lock_timeout_ms;
+
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/config.c
+++ b/config.c
@@ -1593,6 +1593,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "core.writeconfiglocktimeoutms")) {
+		config_write_lock_timeout_ms = git_config_ulong(var, value);
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }
@@ -3046,7 +3051,8 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 	 * The lock serves a purpose in addition to locking: the new
 	 * contents of .git/config will be written into it.
 	 */
-	fd = hold_lock_file_for_update(&lock, config_filename, 0);
+	fd = hold_lock_file_for_update_timeout(&lock, config_filename, 0,
+					       config_write_lock_timeout_ms);
 	if (fd < 0) {
 		error_errno(_("could not lock config file %s"), config_filename);
 		ret = CONFIG_NO_LOCK;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -133,6 +133,7 @@ static int set_recommended_config(void)
 		{ "receive.autoGC", "false" },
 		{ "reset.quiet", "true" },
 		{ "status.aheadBehind", "false" },
+		{ "config.writeConfigLockTimeoutMS", "150" },
 #ifndef WIN32
 		{ "core.untrackedCache", "true" },
 #else
@@ -174,15 +175,24 @@ static int set_recommended_config(void)
 
 static int toggle_maintenance(int enable)
 {
+	unsigned long ul;
+
+	if (git_config_get_ulong("config.writeConfigLockTimeoutMS", &ul))
+		git_config_push_parameter("config.writeConfigLockTimeoutMS=150");
+
 	return run_git("maintenance", enable ? "start" : "unregister", NULL);
 }
 
 static int add_or_remove_enlistment(int add)
 {
 	int res;
+	unsigned long ul;
 
 	if (!the_repository->worktree)
 		die(_("Scalar enlistments require a worktree"));
+
+	if (git_config_get_ulong("config.writeConfigLockTimeoutMS", &ul))
+		git_config_push_parameter("config.writeConfigLockTimeoutMS=150");
 
 	res = run_git("config", "--global", "--get", "--fixed-value",
 		      "scalar.repo", the_repository->worktree, NULL);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -826,8 +826,17 @@ static int cmd_clone(int argc, const char **argv)
 	 * This `dir_inside_of()` call relies on git_config() having parsed the
 	 * newly-initialized repository config's `core.ignoreCase` value.
 	 */
-	if (dir_inside_of(local_cache_root, dir) >= 0)
+	if (dir_inside_of(local_cache_root, dir) >= 0) {
+		struct strbuf path = STRBUF_INIT;
+
+		strbuf_addstr(&path, enlistment);
+		if (chdir("../..") < 0 ||
+		    remove_dir_recursively(&path, 0) < 0)
+			die(_("'--local-cache-path' cannot be inside the src "
+			      "folder;\nCould not remove '%s'"), enlistment);
+
 		die(_("'--local-cache-path' cannot be inside the src folder"));
+	}
 
 	/* common-main already logs `argv` */
 	trace2_data_string("scalar", the_repository, "dir", dir);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -780,7 +780,7 @@ static int cmd_clone(int argc, const char **argv)
 		NULL
 	};
 	const char *url;
-	char *root = NULL, *dir = NULL;
+	char *enlistment = NULL, *dir = NULL;
 	char *cache_key = NULL, *shared_cache_path = NULL;
 	struct strbuf buf = STRBUF_INIT;
 	int res;
@@ -789,7 +789,7 @@ static int cmd_clone(int argc, const char **argv)
 
 	if (argc == 2) {
 		url = argv[0];
-		root = xstrdup(argv[1]);
+		enlistment = xstrdup(argv[1]);
 	} else if (argc == 1) {
 		url = argv[0];
 
@@ -800,18 +800,18 @@ static int cmd_clone(int argc, const char **argv)
 		/* Strip suffix `.git`, if any */
 		strbuf_strip_suffix(&buf, ".git");
 
-		root = find_last_dir_sep(buf.buf);
-		if (!root) {
+		enlistment = find_last_dir_sep(buf.buf);
+		if (!enlistment) {
 			die(_("cannot deduce worktree name from '%s'"), url);
 		}
-		root = xstrdup(root + 1);
+		enlistment = xstrdup(enlistment + 1);
 	} else {
 		usage_msg_opt(N_("need a URL"), clone_usage, clone_options);
 	}
 
 	ensure_absolute_path(root, &root);
 
-	dir = xstrfmt("%s/src", root);
+	dir = xstrfmt("%s/src", enlistment);
 
 	if (!local_cache_root)
 		local_cache_root = local_cache_root_abs =
@@ -961,7 +961,7 @@ static int cmd_clone(int argc, const char **argv)
 	res = register_dir();
 
 cleanup:
-	free(root);
+	free(enlistment);
 	free(dir);
 	strbuf_release(&buf);
 	free(default_cache_server_url);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -133,12 +133,22 @@ static int set_recommended_config(void)
 		{ "receive.autoGC", "false" },
 		{ "reset.quiet", "true" },
 		{ "status.aheadBehind", "false" },
-#ifdef WIN32
-		/*
-		 * Windows-specific settings.
-		 */
+#ifndef WIN32
 		{ "core.untrackedCache", "true" },
-		{ "core.filemode", "true" },
+#else
+		/*
+		 * Unfortunately, Scalar's Functional Tests demonstrated
+		 * that the untracked cache feature is unreliable on Windows
+		 * (which is a bummer because that platform would benefit the
+		 * most from it). For some reason, freshly created files seem
+		 * not to update the directory's `lastModified` time
+		 * immediately, but the untracked cache would need to rely on
+		 * that.
+		 *
+		 * Therefore, with a sad heart, we disable this very useful
+		 * feature on Windows.
+		 */
+		{ "core.untrackedCache", "false" },
 #endif
 		{ NULL, NULL },
 	};

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -809,13 +809,13 @@ static int cmd_clone(int argc, const char **argv)
 		usage_msg_opt(N_("need a URL"), clone_usage, clone_options);
 	}
 
-	ensure_absolute_path(root, &root);
+	ensure_absolute_path(enlistment, &enlistment);
 
 	dir = xstrfmt("%s/src", enlistment);
 
 	if (!local_cache_root)
 		local_cache_root = local_cache_root_abs =
-			default_cache_root(root);
+			default_cache_root(enlistment);
 	else
 		local_cache_root = ensure_absolute_path(local_cache_root,
 							&local_cache_root_abs);

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -25,18 +25,18 @@ test_expect_success 'scalar shows a usage' '
 '
 
 test_expect_success 'scalar unregister' '
-	git init poof/src &&
-	scalar register poof/src &&
+	git init vanish/src &&
+	scalar register vanish/src &&
 	git config --get --global --fixed-value \
-		maintenance.repo "$(pwd)/poof/src" &&
+		maintenance.repo "$(pwd)/vanish/src" &&
 	scalar list >scalar.repos &&
-	grep -F "$(pwd)/poof/src" scalar.repos &&
-	rm -rf poof/src/.git &&
-	scalar unregister poof &&
+	grep -F "$(pwd)/vanish/src" scalar.repos &&
+	rm -rf vanish/src/.git &&
+	scalar unregister vanish &&
 	test_must_fail git config --get --global --fixed-value \
-		maintenance.repo "$(pwd)/poof/src" &&
+		maintenance.repo "$(pwd)/vanish/src" &&
 	scalar list >scalar.repos &&
-	! grep -F "$(pwd)/poof/src" scalar.repos
+	! grep -F "$(pwd)/vanish/src" scalar.repos
 '
 
 test_expect_success 'set up repository to clone' '

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -24,6 +24,21 @@ test_expect_success 'scalar shows a usage' '
 	test_expect_code 129 scalar -h
 '
 
+test_expect_success 'scalar unregister' '
+	git init poof/src &&
+	scalar register poof/src &&
+	git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/poof/src" &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/poof/src" scalar.repos &&
+	rm -rf poof/src/.git &&
+	scalar unregister poof &&
+	test_must_fail git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/poof/src" &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/poof/src" scalar.repos
+'
+
 test_expect_success 'set up repository to clone' '
 	test_commit first &&
 	test_commit second &&
@@ -153,22 +168,6 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 		test_cmp expect actual
 	)
 '
-
-test_expect_success 'scalar unregister' '
-	git init poof/src &&
-	scalar register poof/src &&
-	git config --get --global --fixed-value \
-		maintenance.repo "$(pwd)/poof/src" &&
-	scalar list >scalar.repos &&
-	grep -F "$(pwd)/poof/src" scalar.repos &&
-	rm -rf poof/src/.git &&
-	scalar unregister poof &&
-	test_must_fail git config --get --global --fixed-value \
-		maintenance.repo "$(pwd)/poof/src" &&
-	scalar list >scalar.repos &&
-	! grep -F "$(pwd)/poof/src" scalar.repos
-'
-
 test_expect_success 'scalar delete without enlistment shows a usage' '
 	test_expect_code 129 scalar delete
 '

--- a/environment.c
+++ b/environment.c
@@ -102,6 +102,8 @@ int auto_comment_line_char;
 /* Parallel index stat data preload? */
 int core_preload_index = 1;
 
+long config_write_lock_timeout_ms;
+
 /*
  * This is a hack for test programs like test-dump-untracked-cache to
  * ensure that they do not modify the untracked cache when reading it.


### PR DESCRIPTION
A couple assorted fixes, most notably disabling the untracked cache on Windows to work around test failures.