### PR TITLE
scalar: enable built-in FSMonitor on `register`

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -118,9 +118,7 @@ static int set_recommended_config(void)
 		{ "core.safeCRLF", "false" },
 #ifdef HAVE_FSMONITOR_DAEMON_BACKEND
 		/*
-		 * The value proposition of Scalar is really only realized by
-		 * using FSMonitor. We choose to only support the built-in
-		 * FSMonitor, and only enable this on supported platforms.
+		 * Enable the built-in FSMonitor on supported platforms.
 		 */
 		{ "core.useBuiltinFSMonitor", "true" },
 #endif

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -20,8 +20,19 @@ export Scalar_UNATTENDED
 GIT_ASKPASS=true
 export GIT_ASKPASS
 
+test_lazy_prereq BUILTIN_FSMONITOR '
+	git version --build-options | grep -q "feature:.*fsmonitor--daemon"
+'
+
 test_expect_success 'scalar shows a usage' '
 	test_expect_code 129 scalar -h
+'
+
+test_expect_success BUILTIN_FSMONITOR 'scalar register starts fsmon daemon' '
+	git init test/src &&
+	test_must_fail git -C test/src fsmonitor--daemon --is-running &&
+	scalar register test/src &&
+	git -C test/src fsmonitor--daemon --is-running
 '
 
 test_expect_success 'scalar unregister' '


### PR DESCRIPTION
The value proposition of Scalar is best realized by using FSMonitor.

Teach the `scalar register` command to enable the built-in FSMonitor and
kick-start the fsmonitor--daemon process (for convenience).

We only support the built-in FSMonitor for simplicity.

Signed-off-by: Matthew John Cheetham <mjcheetham@outlook.com>

**TODO:**

- ~Test the new behaviour of `register`~ ✅ 