### PR TITLE
scalar: drop cmd_clone TODO for filtering output

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -932,11 +932,6 @@ static int cmd_clone(int argc, const char **argv)
 	if (set_recommended_config())
 		return error(_("could not configure '%s'"), dir);
 
-	/*
-	 * TODO: should we pipe the output and grep for "filtering not
-	 * recognized by server", and suppress the error output in
-	 * that case?
-	 */
 	if ((res = run_git("fetch", "--quiet", "origin", NULL))) {
 		warning(_("Partial clone failed; Trying full clone"));
 


### PR DESCRIPTION
Drop a TODO comment in the `scalar clone` command about filtering output
from a partial clone, to avoid writing "not recognized by the server"
messages. This logic was originally added to the C# version of Scalar
when GitHub did not fully support partial clone, and would write back to
messages like this that we wanted to hide from the user.

Signed-off-by: Matthew John Cheetham <mjcheetham@outlook.com>