### PR TITLE
scalar: fix the gentle config locking

### DIFF
--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -726,7 +726,7 @@ core.abbrev::
 	are shown in their full length.
 	The minimum length is 4.
 
-core.writeConfigLockTimeoutMS::
+core.configWriteLockTimeoutMS::
 	When processes try to write to the config concurrently, it is likely
 	that one process "wins" and the other process(es) fail to lock the
 	config file. By configuring a timeout larger than zero, Git can be

--- a/cache.h
+++ b/cache.h
@@ -971,8 +971,6 @@ extern struct strbuf gvfs_shared_cache_pathname;
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
 
-extern long config_write_lock_timeout_ms;
-
 /*
  * Include broken refs in all ref iterations, which will
  * generally choke dangerous operations rather than letting

--- a/config.c
+++ b/config.c
@@ -3044,7 +3044,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 		config_filename = filename_buf = git_pathdup("config");
 
 	if ((long)timeout_ms < 0 &&
-	    git_config_get_ulong("core.writeConfigLockTimeoutMS", &timeout_ms))
+	    git_config_get_ulong("core.configWriteLockTimeoutMS", &timeout_ms))
 		timeout_ms = 0;
 
 	/*

--- a/config.c
+++ b/config.c
@@ -1593,11 +1593,6 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
-	if (!strcmp(var, "core.writeconfiglocktimeoutms")) {
-		config_write_lock_timeout_ms = git_config_ulong(var, value);
-		return 0;
-	}
-
 	/* Add other config variables here and to Documentation/config.txt. */
 	return platform_core_config(var, value, cb);
 }
@@ -3027,6 +3022,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 					   const char *value_pattern,
 					   unsigned flags)
 {
+	static unsigned long timeout_ms = ULONG_MAX;
 	int fd = -1, in_fd = -1;
 	int ret;
 	struct lock_file lock = LOCK_INIT;
@@ -3047,12 +3043,16 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 	if (!config_filename)
 		config_filename = filename_buf = git_pathdup("config");
 
+	if ((long)timeout_ms < 0 &&
+	    git_config_get_ulong("core.writeConfigLockTimeoutMS", &timeout_ms))
+		timeout_ms = 0;
+
 	/*
 	 * The lock serves a purpose in addition to locking: the new
 	 * contents of .git/config will be written into it.
 	 */
 	fd = hold_lock_file_for_update_timeout(&lock, config_filename, 0,
-					       config_write_lock_timeout_ms);
+					       timeout_ms);
 	if (fd < 0) {
 		error_errno(_("could not lock config file %s"), config_filename);
 		ret = CONFIG_NO_LOCK;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -133,7 +133,7 @@ static int set_recommended_config(void)
 		{ "receive.autoGC", "false" },
 		{ "reset.quiet", "true" },
 		{ "status.aheadBehind", "false" },
-		{ "core.writeConfigLockTimeoutMS", "150" },
+		{ "core.configWriteLockTimeoutMS", "150" },
 #ifndef WIN32
 		{ "core.untrackedCache", "true" },
 #else
@@ -177,8 +177,8 @@ static int toggle_maintenance(int enable)
 {
 	unsigned long ul;
 
-	if (git_config_get_ulong("core.writeConfigLockTimeoutMS", &ul))
-		git_config_push_parameter("core.writeConfigLockTimeoutMS=150");
+	if (git_config_get_ulong("core.configWriteLockTimeoutMS", &ul))
+		git_config_push_parameter("core.configWriteLockTimeoutMS=150");
 
 	return run_git("maintenance", enable ? "start" : "unregister", NULL);
 }
@@ -191,8 +191,8 @@ static int add_or_remove_enlistment(int add)
 	if (!the_repository->worktree)
 		die(_("Scalar enlistments require a worktree"));
 
-	if (git_config_get_ulong("core.writeConfigLockTimeoutMS", &ul))
-		git_config_push_parameter("core.writeConfigLockTimeoutMS=150");
+	if (git_config_get_ulong("core.configWriteLockTimeoutMS", &ul))
+		git_config_push_parameter("core.configWriteLockTimeoutMS=150");
 
 	res = run_git("config", "--global", "--get", "--fixed-value",
 		      "scalar.repo", the_repository->worktree, NULL);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -133,7 +133,7 @@ static int set_recommended_config(void)
 		{ "receive.autoGC", "false" },
 		{ "reset.quiet", "true" },
 		{ "status.aheadBehind", "false" },
-		{ "config.writeConfigLockTimeoutMS", "150" },
+		{ "core.writeConfigLockTimeoutMS", "150" },
 #ifndef WIN32
 		{ "core.untrackedCache", "true" },
 #else
@@ -177,8 +177,8 @@ static int toggle_maintenance(int enable)
 {
 	unsigned long ul;
 
-	if (git_config_get_ulong("config.writeConfigLockTimeoutMS", &ul))
-		git_config_push_parameter("config.writeConfigLockTimeoutMS=150");
+	if (git_config_get_ulong("core.writeConfigLockTimeoutMS", &ul))
+		git_config_push_parameter("core.writeConfigLockTimeoutMS=150");
 
 	return run_git("maintenance", enable ? "start" : "unregister", NULL);
 }
@@ -191,8 +191,8 @@ static int add_or_remove_enlistment(int add)
 	if (!the_repository->worktree)
 		die(_("Scalar enlistments require a worktree"));
 
-	if (git_config_get_ulong("config.writeConfigLockTimeoutMS", &ul))
-		git_config_push_parameter("config.writeConfigLockTimeoutMS=150");
+	if (git_config_get_ulong("core.writeConfigLockTimeoutMS", &ul))
+		git_config_push_parameter("core.writeConfigLockTimeoutMS=150");
 
 	res = run_git("config", "--global", "--get", "--fixed-value",
 		      "scalar.repo", the_repository->worktree, NULL);

--- a/environment.c
+++ b/environment.c
@@ -102,8 +102,6 @@ int auto_comment_line_char;
 /* Parallel index stat data preload? */
 int core_preload_index = 1;
 
-long config_write_lock_timeout_ms;
-
 /*
  * This is a hack for test programs like test-dump-untracked-cache to
  * ensure that they do not modify the untracked cache when reading it.


### PR DESCRIPTION
When I implemented that timeout, I failed to test, and sure enough, the config setting is not even read. This PR fixes that.