### PR TITLE
Bumping version of update-winget action

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.2.1
+      uses: mjcheetham/update-winget@v1.2.2
       with:
         id: Microsoft.Git
         token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Applying fix to prevent PRs into `winget-pkgs` from default branch of forks. See https://github.com/mjcheetham/update-winget/pull/107 for more details.