### PR TITLE
scalar: reorder `delete`, `help` and `version` to come before `cache-server`

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1207,6 +1207,74 @@ static int cmd_unregister(int argc, const char **argv)
 	return unregister_dir();
 }
 
+static int cmd_delete(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar delete <enlistment>"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 1)
+		usage_with_options(usage, options);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return delete_enlistment();
+}
+
+static int cmd_help(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar help"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	return run_git("help", "scalar", NULL);
+}
+
+static int cmd_version(int argc, const char **argv)
+{
+	int verbose = 0, build_options = 0;
+	struct option options[] = {
+		OPT__VERBOSE(&verbose, N_("include Git version")),
+		OPT_BOOL(0, "build-options", &build_options,
+			 N_("include Git's build options")),
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar verbose [-v | --verbose] [--build-options]"),
+		NULL
+	};
+	struct strbuf buf = STRBUF_INIT;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	get_version_info(&buf, build_options);
+	fprintf(stderr, "%s\n", buf.buf);
+	strbuf_release(&buf);
+
+	return 0;
+}
+
 static int cmd_cache_server(int argc, const char **argv)
 {
 	int get = 0;
@@ -1278,74 +1346,6 @@ static int cmd_cache_server(int argc, const char **argv)
 	return !!res;
 }
 
-static int cmd_delete(int argc, const char **argv)
-{
-	struct option options[] = {
-		OPT_END(),
-	};
-	const char * const usage[] = {
-		N_("scalar delete <enlistment>"),
-		NULL
-	};
-
-	argc = parse_options(argc, argv, NULL, options,
-			     usage, 0);
-
-	if (argc != 1)
-		usage_with_options(usage, options);
-
-	setup_enlistment_directory(argc, argv, usage, options);
-
-	return delete_enlistment();
-}
-
-static int cmd_help(int argc, const char **argv)
-{
-	struct option options[] = {
-		OPT_END(),
-	};
-	const char * const usage[] = {
-		N_("scalar help"),
-		NULL
-	};
-
-	argc = parse_options(argc, argv, NULL, options,
-			     usage, 0);
-
-	if (argc != 0)
-		usage_with_options(usage, options);
-
-	return run_git("help", "scalar", NULL);
-}
-
-static int cmd_version(int argc, const char **argv)
-{
-	int verbose = 0, build_options = 0;
-	struct option options[] = {
-		OPT__VERBOSE(&verbose, N_("include Git version")),
-		OPT_BOOL(0, "build-options", &build_options,
-			 N_("include Git's build options")),
-		OPT_END(),
-	};
-	const char * const usage[] = {
-		N_("scalar verbose [-v | --verbose] [--build-options]"),
-		NULL
-	};
-	struct strbuf buf = STRBUF_INIT;
-
-	argc = parse_options(argc, argv, NULL, options,
-			     usage, 0);
-
-	if (argc != 0)
-		usage_with_options(usage, options);
-
-	get_version_info(&buf, build_options);
-	fprintf(stderr, "%s\n", buf.buf);
-	strbuf_release(&buf);
-
-	return 0;
-}
-
 static int cmd_test(int argc, const char **argv)
 {
 	const char *url = argc > 1 ? argv[1] :
@@ -1368,10 +1368,10 @@ struct {
 	{ "unregister", cmd_unregister },
 	{ "run", cmd_run },
 	{ "diagnose", cmd_diagnose },
-	{ "cache-server", cmd_cache_server },
 	{ "delete", cmd_delete },
 	{ "help", cmd_help },
 	{ "version", cmd_version },
+	{ "cache-server", cmd_cache_server },
 	{ "test", cmd_test },
 	{ NULL, NULL},
 };

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -9,7 +9,8 @@ SYNOPSIS
 --------
 [verse]
 scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
-         [--no-fetch-commits-and-trees] <url> [<enlistment>]
+         [--no-fetch-commits-and-trees] [--local-cache-path <path>]
+         [--cache-server-url <url>] <url> [<enlistment>]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
@@ -87,6 +88,17 @@ cloning. If the HEAD at the remote did not point at any branch when
     The default behavior is to clone all commit and tree objects, with blob
     objects being fetched on demand. With the `--no-fetch-commits-and-trees`
     option, commit and tree objects are also fetched only as needed.
+
+--local-cache-path <path>::
+    Override the path to the local cache root directory; Pre-fetched objects
+    are stored into a repository-dependent subdirectory of that path.
++
+The default is `<drive>:\.scalarCache` on Windows (on the same drive as the
+clone), and `~/.scalarCache` on macOS.
+
+--cache-server-url <url>::
+    Retrieve missing objects from the specified remote, which is expected to
+    understand the GVFS protocol.
 
 List
 ~~~~

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -16,8 +16,8 @@ scalar register [<enlistment>]
 scalar unregister [<enlistment>]
 scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]
 scalar diagnose [<enlistment>]
-scalar cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]
 scalar delete <enlistment>
+scalar cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]
 
 DESCRIPTION
 -----------
@@ -153,6 +153,14 @@ diagnose [<enlistment>]::
 The output of this command is a `.zip` file that is written into
 a directory adjacent to the worktree in the `src` directory.
 
+Delete
+~~~~~~
+
+delete <enlistment>::
+    This command lets you delete an existing Scalar enlistment from your
+    local file system, unregistering the repository and stopping any file
+    watcher daemons (FSMonitor).
+
 Cache-server
 ~~~~~~~~~~~~
 
@@ -173,14 +181,6 @@ repository), this command mode triggers a request via the network that
 potentially requires authentication. If authentication is required, the
 configured credential helper is employed (see linkgit:git-credential[1]
 for details).
-
-Delete
-~~~~~~
-
-delete <enlistment>::
-    This command lets you delete an existing Scalar enlistment from your
-    local file system, unregistering the repository and stopping any file
-    watcher daemons (FSMonitor).
 
 SEE ALSO
 --------

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -9,8 +9,7 @@ SYNOPSIS
 --------
 [verse]
 scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
-         [--no-fetch-commits-and-trees] [--local-cache-path <path>]
-         [--cache-server-url <url>] <url> [<enlistment>]
+         [--no-fetch-commits-and-trees] <url> [<enlistment>]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
@@ -88,17 +87,6 @@ cloning. If the HEAD at the remote did not point at any branch when
     The default behavior is to clone all commit and tree objects, with blob
     objects being fetched on demand. With the `--no-fetch-commits-and-trees`
     option, commit and tree objects are also fetched only as needed.
-
---local-cache-path <path>::
-    Override the path to the local cache root directory; Pre-fetched objects
-    are stored into a repository-dependent subdirectory of that path.
-+
-The default is `<drive>:\.scalarCache` on Windows (on the same drive as the
-clone), and `~/.scalarCache` on macOS.
-
---cache-server-url <url>::
-    Retrieve missing objects from the specified remote, which is expected to
-    understand the GVFS protocol.
 
 List
 ~~~~

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -85,6 +85,15 @@ test_expect_success UNZIP 'scalar diagnose' '
 	test_file_not_empty out
 '
 
+test_expect_success 'scalar delete without enlistment shows a usage' '
+	test_expect_code 129 scalar delete
+'
+
+test_expect_success 'scalar delete with enlistment' '
+	scalar delete cloned &&
+	test_path_is_missing cloned
+'
+
 GIT_TEST_ALLOW_GVFS_VIA_HTTP=1
 export GIT_TEST_ALLOW_GVFS_VIA_HTTP
 
@@ -167,14 +176,6 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 		echo "second" >expect &&
 		test_cmp expect actual
 	)
-'
-test_expect_success 'scalar delete without enlistment shows a usage' '
-	test_expect_code 129 scalar delete
-'
-
-test_expect_success 'scalar delete with enlistment' '
-	scalar delete cloned &&
-	test_path_is_missing cloned
 '
 
 test_done


### PR DESCRIPTION
We do not plan on upstreaming the `cache-server` command. Therefore, it makes most sense to move its implementation, documentation and test to the bottom of the respective files (this makes it easier to maintain the `cleaned-up/scalar` branch thicket, where I try to reflect a "clean" commit topology that contains well-separated topics, ordered according to the "upstreamable first" motto).