### PR TITLE
Fix a couple of issues pointed out by the spell checker `cSpell`

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1257,7 +1257,7 @@ static int option_parse_shared_cache_directory(const struct option *opt,
 	else if (!gvfs_shared_cache_pathname.len) {
 		/*
 		 * A shared-cache was requested and we did not inherit one.
-		 * Try it, but let alt_odb_usabe() secretly disable it if
+		 * Try it, but let alt_odb_usable() secretly disable it if
 		 * it cannot create the directory on disk.
 		 */
 		strbuf_addbuf(&gvfs_shared_cache_pathname, &buf_arg);
@@ -1284,7 +1284,7 @@ static int option_parse_shared_cache_directory(const struct option *opt,
 		add_to_alternates_memory(buf_arg.buf);
 
 		/*
-		 * alt_odb_usabe() releases gvfs_shared_cache_pathname
+		 * alt_odb_usable() releases gvfs_shared_cache_pathname
 		 * if it cannot create the directory on disk, so fallback
 		 * to the previous choice when it fails.
 		 */

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2451,7 +2451,7 @@ static void install_result(struct gh__request_params *params,
 	if (params->objects_mode == GH__OBJECTS_MODE__PREFETCH) {
 		/*
 		 * The "gvfs/prefetch" API is the only thing that sends
-		 * these multi-part packfiles.  According to the procotol
+		 * these multi-part packfiles.  According to the protocol
 		 * documentation, they will have this x- content type.
 		 *
 		 * However, it appears that there is a BUG in the origin
@@ -3309,7 +3309,7 @@ static void cb_find_last(const char *full_path, size_t full_path_len,
  * TODO
  * TODO Since each cache-server maintains its own set of prefetch
  * TODO packs (such that 2 requests may hit 2 different
- * TODO load-balanced servers and get different anwsers (with or
+ * TODO load-balanced servers and get different answers (with or
  * TODO without clock-skew issues)), is it possible for us to miss
  * TODO the absolute fringe of new commits and trees?
  * TODO

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1334,7 +1334,7 @@ static void do__http_get__gvfs_config(struct gh__response_status *status,
 /*
  * Find the URL of the cache-server, if we have one.
  *
- * This routined is called by the initialization code and is allowed
+ * This routine is called by the initialization code and is allowed
  * to call die() rather than returning an 'ec'.
  */
 static void select_cache_server(void)

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -130,7 +130,7 @@
 //            Interactive verb: objects.get
 //
 //                 Fetch 1 or more objects, one at a time, using a
-//                 "/gvfs/ojbects" GET requests.
+//                 "/gvfs/objects" GET requests.
 //
 //                 Each object will be created as a loose object in the ODB.
 //

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2830,7 +2830,7 @@ static void set_cache_server_creds_on_slot(struct active_request_slot *slot,
 	 * [b] If we want to talk to a cache-server, we have get the
 	 *     Basic Auth creds for the main server.  And this may be
 	 *     problematic if the libcurl and/or the credential manager
-	 *     insists on using NTML and prevents us from getting them.
+	 *     insists on using NTLM and prevents us from getting them.
 	 *
 	 * So we never try AUTH-ANY and force Basic Auth (if possible).
 	 */

--- a/t/helper/test-gvfs-protocol.c
+++ b/t/helper/test-gvfs-protocol.c
@@ -1357,7 +1357,7 @@ static enum worker_result req__read(struct req *req, int fd)
 	http_version = req->start_line_fields.items[2].string;
 
 	if (strcmp(http_version, "HTTP/1.1")) {
-		logerror("unsuported version '%s' (expecting HTTP/1.1)",
+		logerror("unsupported version '%s' (expecting HTTP/1.1)",
 			 http_version);
 		return WR_IO_ERROR;
 	}

--- a/t/t5799-gvfs-helper.sh
+++ b/t/t5799-gvfs-helper.sh
@@ -188,7 +188,7 @@ test_expect_success 'setup repos' '
 	git -C "$REPO_T1" branch -M main &&
 	git -C "$REPO_T1" remote add origin $ORIGIN_URL &&
 	git -C "$REPO_T1" config --local gvfs.cache-server $CACHE_URL &&
-	git -C "$REPO_T1" config --local gvfs.sharedcache "$SHARED_CACHE_T1" &&
+	git -C "$REPO_T1" config --local gvfs.sharedCache "$SHARED_CACHE_T1" &&
 	echo "$SHARED_CACHE_T1" >> "$REPO_T1"/.git/objects/info/alternates &&
 	#
 	#
@@ -366,7 +366,7 @@ verify_objects_in_shared_cache () {
 	#
 	# TODO move the shared-cache directory (and/or the
 	# TODO .git/objects/info/alternates and temporarily unset
-	# TODO gvfs.sharedcache) and repeat the first "batch-check"
+	# TODO gvfs.sharedCache) and repeat the first "batch-check"
 	# TODO and make sure that they are ALL missing.
 	#
 	return 0
@@ -1162,14 +1162,14 @@ test_expect_success 'integration: explicit commit/trees, implicit blobs: diff 2 
 	# With gvfs-helper turned off, we should fail.
 	#
 	test_must_fail \
-		git -C "$REPO_T1" -c core.usegvfshelper=false \
+		git -C "$REPO_T1" -c core.useGVFSHelper=false \
 			diff $(cat m1.branch)..$(cat m3.branch) \
 			>OUT.output 2>OUT.stderr &&
 
 	# Turn on gvfs-helper and retry.  This should implicitly fetch
 	# any needed blobs.
 	#
-	git -C "$REPO_T1" -c core.usegvfshelper=true \
+	git -C "$REPO_T1" -c core.useGVFSHelper=true \
 		diff $(cat m1.branch)..$(cat m3.branch) \
 		>OUT.output 2>OUT.stderr &&
 
@@ -1177,7 +1177,7 @@ test_expect_success 'integration: explicit commit/trees, implicit blobs: diff 2 
 	# local ODB, such that a second attempt with gvfs-helper
 	# turned off should succeed.
 	#
-	git -C "$REPO_T1" -c core.usegvfshelper=false \
+	git -C "$REPO_T1" -c core.useGVFSHelper=false \
 		diff $(cat m1.branch)..$(cat m3.branch) \
 		>OUT.output 2>OUT.stderr
 '
@@ -1188,7 +1188,7 @@ test_expect_success 'integration: fully implicit: diff 2 commits' '
 
 	# Implicitly demand-load everything without any pre-seeding.
 	#
-	git -C "$REPO_T1" -c core.usegvfshelper=true \
+	git -C "$REPO_T1" -c core.useGVFSHelper=true \
 		diff $(cat m1.branch)..$(cat m3.branch) \
 		>OUT.output 2>OUT.stderr
 '

--- a/t/t5799-gvfs-helper.sh
+++ b/t/t5799-gvfs-helper.sh
@@ -1199,8 +1199,8 @@ test_expect_success 'integration: fully implicit: diff 2 commits' '
 # If we request a fixed set of blobs, we should get a unique packfile
 # of the form "vfs-<sha>.{pack,idx}".  It we request that same set
 # again, the server should create and send the exact same packfile.
-# True webservers might build the custom packfile in random order,
-# but our test webserver should give us consistent results.
+# True web servers might build the custom packfile in random order,
+# but our test web server should give us consistent results.
 #
 # Verify that we can handle the duplicate pack and idx file properly.
 #################################################################


### PR DESCRIPTION
Whenever possible and convenient, I use VS Code with the configuration initialized by `contrib/vscode/init.sh`, including the spell checker called `cSpell`. It found a couple of issues while I was working on `contrib/scalar/`, and I think it would be best to fix up the corresponding commits before v2.32.0-rc1 comes out (I will gladly take care of porting these fixes into #348, once this PR is merged).