### PR TITLE
Integrate Scalar (ported to C) into vfs-2.32.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   DEVELOPER: 1
+  INCLUDE_SCALAR: YesPlease
 
 jobs:
   ci-config:

--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -726,3 +726,12 @@ core.abbrev::
 	If set to "no", no abbreviation is made and the object names
 	are shown in their full length.
 	The minimum length is 4.
+
+core.configWriteLockTimeoutMS::
+	When processes try to write to the config concurrently, it is likely
+	that one process "wins" and the other process(es) fail to lock the
+	config file. By configuring a timeout larger than zero, Git can be
+	told to try to lock the config again a couple times within the
+	specified timeout. If the timeout is configure to zero (which is the
+	default), Git will fail immediately when the config is already
+	locked.

--- a/Makefile
+++ b/Makefile
@@ -2471,6 +2471,10 @@ endif
 .PHONY: objects
 objects: $(OBJECTS)
 
+SCALAR_SOURCES := contrib/scalar/scalar.c
+SCALAR_OBJECTS := $(SCALAR_SOURCES:c=o)
+OBJECTS += $(SCALAR_OBJECTS)
+
 dep_files := $(foreach f,$(OBJECTS),$(dir $f).depend/$(notdir $f).d)
 dep_dirs := $(addsuffix .depend,$(sort $(dir $(OBJECTS))))
 
@@ -2616,6 +2620,10 @@ $(REMOTE_CURL_ALIASES): $(REMOTE_CURL_PRIMARY)
 $(REMOTE_CURL_PRIMARY): remote-curl.o http.o http-walker.o GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
+
+contrib/scalar/scalar$X: $(SCALAR_OBJECTS) GIT-LDFLAGS $(GITLIBS)
+	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
+		$(filter %.o,$^) $(LIBS)
 
 git-gvfs-helper$X: gvfs-helper.o http.o GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \

--- a/Makefile
+++ b/Makefile
@@ -2475,7 +2475,7 @@ endif
 .PHONY: objects
 objects: $(OBJECTS)
 
-SCALAR_SOURCES := contrib/scalar/scalar.c
+SCALAR_SOURCES := contrib/scalar/scalar.c contrib/scalar/json-parser.c
 SCALAR_OBJECTS := $(SCALAR_SOURCES:c=o)
 OBJECTS += $(SCALAR_OBJECTS)
 

--- a/Makefile
+++ b/Makefile
@@ -1966,6 +1966,10 @@ ifndef PAGER_ENV
 PAGER_ENV = LESS=FRX LV=-c
 endif
 
+ifneq (,$(INCLUDE_SCALAR))
+EXTRA_PROGRAMS += contrib/scalar/scalar$X
+endif
+
 QUIET_SUBDIR0  = +$(MAKE) -C # space to separate -C and subdir
 QUIET_SUBDIR1  =
 
@@ -2625,6 +2629,9 @@ contrib/scalar/scalar$X: $(SCALAR_OBJECTS) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
 		$(filter %.o,$^) $(LIBS)
 
+bin-wrappers/scalar: contrib/scalar/Makefile
+	$(QUIET_SUBDIR0)contrib/scalar $(QUIET_SUBDIR1) ../../bin-wrappers/scalar
+
 git-gvfs-helper$X: gvfs-helper.o http.o GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
@@ -2648,14 +2655,23 @@ Documentation/GIT-EXCLUDED-PROGRAMS: FORCE
 .PHONY: doc man man-perl html info pdf
 doc: man-perl
 	$(MAKE) -C Documentation all
+ifneq (,$(INCLUDE_SCALAR))
+	$(QUIET_SUBDIR0)contrib/scalar $(QUIET_SUBDIR1) scalar.html scalar.1
+endif
 
 man: man-perl
 	$(MAKE) -C Documentation man
+ifneq (,$(INCLUDE_SCALAR))
+	$(QUIET_SUBDIR0)contrib/scalar $(QUIET_SUBDIR1) scalar.1
+endif
 
 man-perl: perl/build/man/man3/Git.3pm
 
 html:
 	$(MAKE) -C Documentation html
+ifneq (,$(INCLUDE_SCALAR))
+	$(QUIET_SUBDIR0)contrib/scalar $(QUIET_SUBDIR1) scalar.html
+endif
 
 info:
 	$(MAKE) -C Documentation info
@@ -2894,6 +2910,10 @@ endif
 
 test_bindir_programs := $(patsubst %,bin-wrappers/%,$(BINDIR_PROGRAMS_NEED_X) $(BINDIR_PROGRAMS_NO_X) $(TEST_PROGRAMS_NEED_X))
 
+ifneq (,$(INCLUDE_SCALAR))
+test_bindir_programs += bin-wrappers/scalar
+endif
+
 all:: $(TEST_PROGRAMS) $(test_bindir_programs)
 
 bin-wrappers/%: wrap-for-bin.sh
@@ -2914,6 +2934,9 @@ export TEST_NO_MALLOC_CHECK
 
 test: all
 	$(MAKE) -C t/ all
+ifneq (,$(INCLUDE_SCALAR))
+	$(MAKE) -C contrib/scalar/t
+endif
 
 perf: all
 	$(MAKE) -C t/perf/ all
@@ -3039,6 +3062,9 @@ install: all
 	$(INSTALL) $(ALL_PROGRAMS) '$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
 	$(INSTALL) -m 644 $(SCRIPT_LIB) '$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
 	$(INSTALL) $(install_bindir_programs) '$(DESTDIR_SQ)$(bindir_SQ)'
+ifneq (,$(INCLUDE_SCALAR))
+	$(INSTALL) contrib/scalar/scalar$X '$(DESTDIR_SQ)$(bindir_SQ)'
+endif
 ifdef MSVC
 	# We DO NOT install the individual foo.o.pdb files because they
 	# have already been rolled up into the exe's pdb file.
@@ -3132,6 +3158,10 @@ install-doc: install-man-perl
 
 install-man: install-man-perl
 	$(MAKE) -C Documentation install-man
+ifneq (,$(INCLUDE_SCALAR))
+	$(MAKE) -C contrib/scalar scalar.1
+	$(INSTALL) contrib/scalar/scalar.1 '$(DESTDIR_SQ)$(mandir_SQ)/man1'
+endif
 
 install-man-perl: man-perl
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(mandir_SQ)/man3'
@@ -3140,6 +3170,10 @@ install-man-perl: man-perl
 
 install-html:
 	$(MAKE) -C Documentation install-html
+ifneq (,$(INCLUDE_SCALAR))
+	$(MAKE) -C contrib/scalar scalar.html
+	$(INSTALL) contrib/scalar/scalar.html '$(DESTDIR_SQ)$(htmldir)'
+endif
 
 install-info:
 	$(MAKE) -C Documentation install-info
@@ -3277,6 +3311,9 @@ endif
 ifndef NO_TCLTK
 	$(MAKE) -C gitk-git clean
 	$(MAKE) -C git-gui clean
+endif
+ifneq (,$(INCLUDE_SCALAR))
+	$(MAKE) -C contrib/scalar clean
 endif
 	$(RM) GIT-VERSION-FILE GIT-CFLAGS GIT-LDFLAGS GIT-BUILD-OPTIONS
 	$(RM) GIT-USER-AGENT GIT-PREFIX

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -1617,16 +1617,14 @@ static int launchctl_remove_plists(const char *cmd)
 
 static int launchctl_schedule_plist(const char *exec_path, enum schedule_priority schedule, const char *cmd)
 {
-	FILE *plist;
-	int i;
+	int i, fd;
 	const char *preamble, *repeat;
 	const char *frequency = get_frequency(schedule);
 	char *name = launchctl_service_name(frequency);
 	char *filename = launchctl_service_filename(name);
-
-	if (safe_create_leading_directories(filename))
-		die(_("failed to create directories for '%s'"), filename);
-	plist = xfopen(filename, "w");
+	struct lock_file lk = LOCK_INIT;
+	static unsigned long lock_file_timeout_ms = ULONG_MAX;
+	struct strbuf plist = STRBUF_INIT;
 
 	preamble = "<?xml version=\"1.0\"?>\n"
 		   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
@@ -1645,7 +1643,7 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 		   "</array>\n"
 		   "<key>StartCalendarInterval</key>\n"
 		   "<array>\n";
-	fprintf(plist, preamble, name, exec_path, exec_path, frequency);
+	strbuf_addf(&plist, preamble, name, exec_path, exec_path, frequency);
 
 	switch (schedule) {
 	case SCHEDULE_HOURLY:
@@ -1654,7 +1652,7 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 			 "<key>Minute</key><integer>0</integer>\n"
 			 "</dict>\n";
 		for (i = 1; i <= 23; i++)
-			fprintf(plist, repeat, i);
+			strbuf_addf(&plist, repeat, i);
 		break;
 
 	case SCHEDULE_DAILY:
@@ -1664,24 +1662,38 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 			 "<key>Minute</key><integer>0</integer>\n"
 			 "</dict>\n";
 		for (i = 1; i <= 6; i++)
-			fprintf(plist, repeat, i);
+			strbuf_addf(&plist, repeat, i);
 		break;
 
 	case SCHEDULE_WEEKLY:
-		fprintf(plist,
-			"<dict>\n"
-			"<key>Day</key><integer>0</integer>\n"
-			"<key>Hour</key><integer>0</integer>\n"
-			"<key>Minute</key><integer>0</integer>\n"
-			"</dict>\n");
+		strbuf_addstr(&plist,
+			      "<dict>\n"
+			      "<key>Day</key><integer>0</integer>\n"
+			      "<key>Hour</key><integer>0</integer>\n"
+			      "<key>Minute</key><integer>0</integer>\n"
+			      "</dict>\n");
 		break;
 
 	default:
 		/* unreachable */
 		break;
 	}
-	fprintf(plist, "</array>\n</dict>\n</plist>\n");
-	fclose(plist);
+	strbuf_addstr(&plist, "</array>\n</dict>\n</plist>\n");
+
+	if (safe_create_leading_directories(filename))
+		die(_("failed to create directories for '%s'"), filename);
+
+	if ((long)lock_file_timeout_ms < 0 &&
+	    git_config_get_ulong("gc.launchctlplistlocktimeoutms",
+				 &lock_file_timeout_ms))
+		lock_file_timeout_ms = 150;
+
+	fd = hold_lock_file_for_update_timeout(&lk, filename, LOCK_DIE_ON_ERROR,
+					       lock_file_timeout_ms);
+
+	if (write_in_full(fd, plist.buf, plist.len) < 0 ||
+	    commit_lock_file(&lk))
+		die_errno(_("could not write '%s'"), filename);
 
 	/* bootout might fail if not already running, so ignore */
 	launchctl_boot_plist(0, filename, cmd);
@@ -1690,6 +1702,7 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 
 	free(filename);
 	free(name);
+	strbuf_release(&plist);
 	return 0;
 }
 

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -1615,6 +1615,29 @@ static int launchctl_remove_plists(const char *cmd)
 		launchctl_remove_plist(SCHEDULE_WEEKLY, cmd);
 }
 
+static int launchctl_list_contains_plist(const char *name, const char *cmd)
+{
+	int result;
+	struct child_process child = CHILD_PROCESS_INIT;
+	char *uid = launchctl_get_uid();
+
+	strvec_split(&child.args, cmd);
+	strvec_pushl(&child.args, "list", name, NULL);
+
+	child.no_stderr = 1;
+	child.no_stdout = 1;
+
+	if (start_command(&child))
+		die(_("failed to start launchctl"));
+
+	result = finish_command(&child);
+
+	free(uid);
+
+	/* Returns failure if 'name' doesn't exist. */
+	return !result;
+}
+
 static int launchctl_schedule_plist(const char *exec_path, enum schedule_priority schedule, const char *cmd)
 {
 	int i, fd;
@@ -1624,7 +1647,8 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 	char *filename = launchctl_service_filename(name);
 	struct lock_file lk = LOCK_INIT;
 	static unsigned long lock_file_timeout_ms = ULONG_MAX;
-	struct strbuf plist = STRBUF_INIT;
+	struct strbuf plist = STRBUF_INIT, plist2 = STRBUF_INIT;
+	struct stat st;
 
 	preamble = "<?xml version=\"1.0\"?>\n"
 		   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
@@ -1691,18 +1715,30 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 	fd = hold_lock_file_for_update_timeout(&lk, filename, LOCK_DIE_ON_ERROR,
 					       lock_file_timeout_ms);
 
-	if (write_in_full(fd, plist.buf, plist.len) < 0 ||
-	    commit_lock_file(&lk))
-		die_errno(_("could not write '%s'"), filename);
+	/*
+	 * Does this file already exist? With the intended contents? Is it
+	 * registered already? Then it does not need to be re-registered.
+	 */
+	if (!stat(filename, &st) && st.st_size == plist.len &&
+	    strbuf_read_file(&plist2, filename, plist.len) == plist.len &&
+	    !strbuf_cmp(&plist, &plist2) &&
+	    launchctl_list_contains_plist(name, cmd))
+		rollback_lock_file(&lk);
+	else {
+		if (write_in_full(fd, plist.buf, plist.len) < 0 ||
+		    commit_lock_file(&lk))
+			die_errno(_("could not write '%s'"), filename);
 
-	/* bootout might fail if not already running, so ignore */
-	launchctl_boot_plist(0, filename, cmd);
-	if (launchctl_boot_plist(1, filename, cmd))
-		die(_("failed to bootstrap service %s"), filename);
+		/* bootout might fail if not already running, so ignore */
+		launchctl_boot_plist(0, filename, cmd);
+		if (launchctl_boot_plist(1, filename, cmd))
+			die(_("failed to bootstrap service %s"), filename);
+	}
 
 	free(filename);
 	free(name);
 	strbuf_release(&plist);
+	strbuf_release(&plist2);
 	return 0;
 }
 

--- a/builtin/help.c
+++ b/builtin/help.c
@@ -395,6 +395,8 @@ static const char *cmd_to_page(const char *git_cmd)
 		return git_cmd;
 	else if (is_git_command(git_cmd))
 		return xstrfmt("git-%s", git_cmd);
+	else if (!strcmp("scalar", git_cmd))
+		return xstrdup(git_cmd);
 	else
 		return xstrfmt("git%s", git_cmd);
 }

--- a/ci/run-test-slice.sh
+++ b/ci/run-test-slice.sh
@@ -14,4 +14,9 @@ make --quiet -C t T="$(cd t &&
 	./helper/test-tool path-utils slice-tests "$1" "$2" t[0-9]*.sh |
 	tr '\n' ' ')"
 
+if test 0 = "$1" && test -n "$INCLUDE_SCALAR"
+then
+	make -C contrib/scalar/t
+fi
+
 check_unignored_build_artifacts

--- a/config.c
+++ b/config.c
@@ -3024,6 +3024,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 					   const char *value_pattern,
 					   unsigned flags)
 {
+	static unsigned long timeout_ms = ULONG_MAX;
 	int fd = -1, in_fd = -1;
 	int ret;
 	struct lock_file lock = LOCK_INIT;
@@ -3044,11 +3045,16 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
 	if (!config_filename)
 		config_filename = filename_buf = git_pathdup("config");
 
+	if ((long)timeout_ms < 0 &&
+	    git_config_get_ulong("core.configWriteLockTimeoutMS", &timeout_ms))
+		timeout_ms = 0;
+
 	/*
 	 * The lock serves a purpose in addition to locking: the new
 	 * contents of .git/config will be written into it.
 	 */
-	fd = hold_lock_file_for_update(&lock, config_filename, 0);
+	fd = hold_lock_file_for_update_timeout(&lock, config_filename, 0,
+					       timeout_ms);
 	if (fd < 0) {
 		error_errno(_("could not lock config file %s"), config_filename);
 		ret = CONFIG_NO_LOCK;

--- a/contrib/buildsystems/CMakeLists.txt
+++ b/contrib/buildsystems/CMakeLists.txt
@@ -717,6 +717,13 @@ if(CURL_FOUND)
 	target_link_libraries(git-gvfs-helper http_obj common-main ${CURL_LIBRARIES} )
 endif()
 
+if(DEFINED ENV{INCLUDE_SCALAR} AND NOT ENV{INCLUDE_SCALAR} STREQUAL "")
+	add_executable(scalar ${CMAKE_SOURCE_DIR}/contrib/scalar/scalar.c ${CMAKE_SOURCE_DIR}/contrib/scalar/json-parser.c)
+	target_link_libraries(scalar common-main)
+	set_target_properties(scalar PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/contrib/scalar)
+	set_target_properties(scalar PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/contrib/scalar)
+endif()
+
 parse_makefile_for_executables(git_builtin_extra "BUILT_INS")
 
 option(SKIP_DASHED_BUILT_INS "Skip hardlinking the dashed versions of the built-ins")
@@ -935,7 +942,6 @@ if(CURL_FOUND)
 	endif()
 endif()
 
-
 foreach(script ${wrapper_scripts})
 	file(STRINGS ${CMAKE_SOURCE_DIR}/wrap-for-bin.sh content NEWLINE_CONSUME)
 	string(REPLACE "@@BUILD_DIR@@" "${CMAKE_BINARY_DIR}" content "${content}")
@@ -954,6 +960,13 @@ file(STRINGS ${CMAKE_SOURCE_DIR}/wrap-for-bin.sh content NEWLINE_CONSUME)
 string(REPLACE "@@BUILD_DIR@@" "${CMAKE_BINARY_DIR}" content "${content}")
 string(REPLACE "@@PROG@@" "git-cvsserver" content "${content}")
 file(WRITE ${CMAKE_BINARY_DIR}/bin-wrappers/git-cvsserver ${content})
+
+if(DEFINED ENV{INCLUDE_SCALAR} AND NOT ENV{INCLUDE_SCALAR} STREQUAL "")
+	file(STRINGS ${CMAKE_SOURCE_DIR}/wrap-for-bin.sh content NEWLINE_CONSUME)
+	string(REPLACE "@@BUILD_DIR@@" "${CMAKE_BINARY_DIR}" content "${content}")
+	string(REPLACE "@@PROG@@" "contrib/scalar/scalar${EXE_EXTENSION}" content "${content}")
+	file(WRITE ${CMAKE_BINARY_DIR}/bin-wrappers/scalar ${content})
+endif()
 
 #options for configuring test options
 option(PERL_TESTS "Perform tests that use perl" ON)

--- a/contrib/scalar/.gitignore
+++ b/contrib/scalar/.gitignore
@@ -1,0 +1,2 @@
+/*.exe
+/scalar

--- a/contrib/scalar/.gitignore
+++ b/contrib/scalar/.gitignore
@@ -1,2 +1,5 @@
+/*.xml
+/*.1
+/*.html
 /*.exe
 /scalar

--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -1,0 +1,48 @@
+CC = cc
+RM = rm -f
+MV = mv
+
+CFLAGS = -g -O2 -Wall
+LDFLAGS =
+EXTLIBS = -lz
+
+DESTDIR_SQ = $(subst ','\'',$(DESTDIR))
+
+QUIET_SUBDIR0  = +$(MAKE) -C # space to separate -C and subdir
+QUIET_SUBDIR1  =
+
+ifneq ($(findstring s,$(MAKEFLAGS)),s)
+ifndef V
+	QUIET_CC       = @echo '   ' CC $@;
+	QUIET_LINK     = @echo '   ' LINK $@;
+	QUIET_GEN      = @echo '   ' GEN $@;
+	QUIET_SUBDIR0  = +@subdir=
+	QUIET_SUBDIR1  = ;$(NO_SUBDIR) echo '   ' SUBDIR $$subdir; \
+			 $(MAKE) $(PRINT_DIR) -C $$subdir
+	export V
+	export QUIET_GEN
+	export QUIET_BUILT_IN
+endif
+endif
+
+all:
+
+include ../../config.mak.uname
+-include ../../config.mak.autogen
+-include ../../config.mak
+
+TARGETS = scalar$(X) scalar.o
+GITLIBS = ../../common-main.o ../../libgit.a ../../xdiff/lib.a
+
+all: scalar$X
+
+$(GITLIBS):
+	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(subst ../../,,$@)
+
+$(TARGETS): $(GITLIBS) scalar.c
+	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(patsubst %,contrib/scalar/%,$@)
+
+clean:
+	$(RM) $(TARGETS)
+
+.PHONY: all clean FORCE

--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -19,6 +19,8 @@ ifndef V
 	QUIET_SUBDIR0  = +@subdir=
 	QUIET_SUBDIR1  = ;$(NO_SUBDIR) echo '   ' SUBDIR $$subdir; \
 			 $(MAKE) $(PRINT_DIR) -C $$subdir
+	QUIET          = @
+
 	export V
 	export QUIET_GEN
 	export QUIET_BUILT_IN
@@ -44,6 +46,7 @@ $(TARGETS): $(GITLIBS) scalar.c
 
 clean:
 	$(RM) $(TARGETS) ../../bin-wrappers/scalar
+	$(RM) scalar.1 scalar.html scalar.xml
 
 ../../bin-wrappers/scalar: ../../wrap-for-bin.sh Makefile
 	@mkdir -p ../../bin-wrappers
@@ -55,4 +58,14 @@ clean:
 test: all
 	$(MAKE) -C t
 
-.PHONY: all clean test FORCE
+docs: scalar.html scalar.1
+
+scalar.html: | scalar.1 # prevent them from trying to build `doc.dep` in parallel
+
+scalar.html scalar.1: scalar.txt
+	$(QUIET_SUBDIR0)../../Documentation$(QUIET_SUBDIR1) \
+		MAN_TXT=../contrib/scalar/scalar.txt \
+		../contrib/scalar/$@
+	$(QUIET)test scalar.1 != "$@" || mv ../../Documentation/$@ .
+
+.PHONY: all clean test docs FORCE

--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -34,7 +34,7 @@ include ../../config.mak.uname
 TARGETS = scalar$(X) scalar.o
 GITLIBS = ../../common-main.o ../../libgit.a ../../xdiff/lib.a
 
-all: scalar$X
+all: scalar$X ../../bin-wrappers/scalar
 
 $(GITLIBS):
 	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(subst ../../,,$@)
@@ -43,6 +43,16 @@ $(TARGETS): $(GITLIBS) scalar.c
 	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(patsubst %,contrib/scalar/%,$@)
 
 clean:
-	$(RM) $(TARGETS)
+	$(RM) $(TARGETS) ../../bin-wrappers/scalar
 
-.PHONY: all clean FORCE
+../../bin-wrappers/scalar: ../../wrap-for-bin.sh Makefile
+	@mkdir -p ../../bin-wrappers
+	$(QUIET_GEN)sed -e '1s|#!.*/sh|#!$(SHELL_PATH_SQ)|' \
+	     -e 's|@@BUILD_DIR@@|$(shell cd ../.. && pwd)|' \
+	     -e 's|@@PROG@@|contrib/scalar/scalar$(X)|' < $< > $@ && \
+	chmod +x $@
+
+test: all
+	$(MAKE) -C t
+
+.PHONY: all clean test FORCE

--- a/contrib/scalar/Makefile
+++ b/contrib/scalar/Makefile
@@ -33,7 +33,7 @@ include ../../config.mak.uname
 -include ../../config.mak.autogen
 -include ../../config.mak
 
-TARGETS = scalar$(X) scalar.o
+TARGETS = scalar$(X) scalar.o json-parser.o
 GITLIBS = ../../common-main.o ../../libgit.a ../../xdiff/lib.a
 
 all: scalar$X ../../bin-wrappers/scalar
@@ -41,7 +41,7 @@ all: scalar$X ../../bin-wrappers/scalar
 $(GITLIBS):
 	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(subst ../../,,$@)
 
-$(TARGETS): $(GITLIBS) scalar.c
+$(TARGETS): $(GITLIBS) scalar.c json-parser.c json-parser.h
 	$(QUIET_SUBDIR0)../.. $(QUIET_SUBDIR1) $(patsubst %,contrib/scalar/%,$@)
 
 clean:

--- a/contrib/scalar/json-parser.c
+++ b/contrib/scalar/json-parser.c
@@ -1,0 +1,182 @@
+#include "cache.h"
+#include "json-parser.h"
+
+static int reset_iterator(struct json_iterator *it)
+{
+	it->p = it->begin = it->json;
+	strbuf_release(&it->key);
+	strbuf_release(&it->string_value);
+	it->type = JSON_NULL;
+	return -1;
+}
+
+static int parse_json_string(struct json_iterator *it, struct strbuf *out)
+{
+	const char *begin = it->p;
+
+	if (*(it->p)++ != '"')
+		return error("expected double quote: '%.*s'", 5, begin),
+			reset_iterator(it);
+
+	strbuf_reset(&it->string_value);
+#define APPEND(c) strbuf_addch(out, c)
+	while (*it->p != '"') {
+		switch (*it->p) {
+		case '\0':
+			return error("incomplete string: '%s'", begin),
+				reset_iterator(it);
+		case '\\':
+			it->p++;
+			if (*it->p == '\\' || *it->p == '"')
+				APPEND(*it->p);
+			else if (*it->p == 'b')
+				APPEND(8);
+			else if (*it->p == 't')
+				APPEND(9);
+			else if (*it->p == 'n')
+				APPEND(10);
+			else if (*it->p == 'f')
+				APPEND(12);
+			else if (*it->p == 'r')
+				APPEND(13);
+			else if (*it->p == 'u') {
+				unsigned char binary[2];
+				int i;
+
+				if (hex_to_bytes(binary, it->p + 1, 2) < 0)
+					return error("invalid: '%.*s'",
+						     6, it->p - 1),
+						reset_iterator(it);
+				it->p += 4;
+
+				i = (binary[0] << 8) | binary[1];
+				if (i < 0x80)
+					APPEND(i);
+				else if (i < 0x0800) {
+					APPEND(0xc0 | ((i >> 6) & 0x1f));
+					APPEND(0x80 | (i & 0x3f));
+				} else if (i < 0x10000) {
+					APPEND(0xe0 | ((i >> 12) & 0x0f));
+					APPEND(0x80 | ((i >> 6) & 0x3f));
+					APPEND(0x80 | (i & 0x3f));
+				} else {
+					APPEND(0xf0 | ((i >> 18) & 0x07));
+					APPEND(0x80 | ((i >> 12) & 0x3f));
+					APPEND(0x80 | ((i >> 6) & 0x3f));
+					APPEND(0x80 | (i & 0x3f));
+				}
+			}
+			break;
+		default:
+			APPEND(*it->p);
+		}
+		it->p++;
+	}
+
+	it->end = it->p++;
+	return 0;
+}
+
+static void skip_whitespace(struct json_iterator *it)
+{
+	while (isspace(*it->p))
+		it->p++;
+}
+
+int iterate_json(struct json_iterator *it)
+{
+	skip_whitespace(it);
+	it->begin = it->p;
+
+	switch (*it->p) {
+	case '\0':
+		return reset_iterator(it), 0;
+	case 'n':
+		if (!starts_with(it->p, "null"))
+			return error("unexpected value: %.*s", 4, it->p),
+				reset_iterator(it);
+		it->type = JSON_NULL;
+		it->end = it->p = it->begin + 4;
+		break;
+	case 't':
+		if (!starts_with(it->p, "true"))
+			return error("unexpected value: %.*s", 4, it->p),
+				reset_iterator(it);
+		it->type = JSON_TRUE;
+		it->end = it->p = it->begin + 4;
+		break;
+	case 'f':
+		if (!starts_with(it->p, "false"))
+			return error("unexpected value: %.*s", 5, it->p),
+				reset_iterator(it);
+		it->type = JSON_FALSE;
+		it->end = it->p = it->begin + 5;
+		break;
+	case '-': case '.':
+	case '0': case '1': case '2': case '3': case '4':
+	case '5': case '6': case '7': case '8': case '9':
+		it->type = JSON_NUMBER;
+		it->end = it->p = it->begin + strspn(it->p, "-.0123456789");
+		break;
+	case '"':
+		it->type = JSON_STRING;
+		if (parse_json_string(it, &it->string_value) < 0)
+			return -1;
+		break;
+	case '[': {
+		const char *save = it->begin;
+		size_t key_offset = it->key.len;
+		int i = 0, res;
+
+		for (it->p++, skip_whitespace(it); *it->p != ']'; i++) {
+			strbuf_addf(&it->key, "[%d]", i);
+
+			if ((res = iterate_json(it)))
+				return reset_iterator(it), res;
+			strbuf_setlen(&it->key, key_offset);
+
+			skip_whitespace(it);
+			if (*it->p == ',')
+				it->p++;
+		}
+
+		it->type = JSON_ARRAY;
+		it->begin = save;
+		it->end = it->p;
+		it->p++;
+		break;
+	}
+	case '{': {
+		const char *save = it->begin;
+		size_t key_offset = it->key.len;
+		int res;
+
+		strbuf_addch(&it->key, '.');
+		for (it->p++, skip_whitespace(it); *it->p != '}'; ) {
+			strbuf_setlen(&it->key, key_offset + 1);
+			if (parse_json_string(it, &it->key) < 0)
+				return -1;
+			skip_whitespace(it);
+			if (*(it->p)++ != ':')
+				return error("expected colon: %.*s", 5, it->p),
+					reset_iterator(it);
+
+			if ((res = iterate_json(it)))
+				return res;
+
+			skip_whitespace(it);
+			if (*it->p == ',')
+				it->p++;
+		}
+		strbuf_setlen(&it->key, key_offset);
+
+		it->type = JSON_OBJECT;
+		it->begin = save;
+		it->end = it->p;
+		it->p++;
+		break;
+	}
+	}
+
+	return it->fn(it);
+}

--- a/contrib/scalar/json-parser.h
+++ b/contrib/scalar/json-parser.h
@@ -1,0 +1,29 @@
+#ifndef JSON_PARSER_H
+#define JSON_PARSER_H
+
+#include "strbuf.h"
+
+struct json_iterator {
+	const char *json, *p, *begin, *end;
+	struct strbuf key, string_value;
+	enum {
+		JSON_NULL = 0,
+		JSON_FALSE,
+		JSON_TRUE,
+		JSON_NUMBER,
+		JSON_STRING,
+		JSON_ARRAY,
+		JSON_OBJECT
+	} type;
+	int (*fn)(struct json_iterator *it);
+	void *fn_data;
+};
+#define JSON_ITERATOR_INIT(json_, fn_, fn_data_) { \
+	.json = json_, .p = json_, \
+	.key = STRBUF_INIT, .string_value = STRBUF_INIT, \
+	.fn = fn_, .fn_data = fn_data_ \
+}
+
+int iterate_json(struct json_iterator *it);
+
+#endif

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1068,6 +1068,34 @@ static int cmd_delete(int argc, const char **argv)
 	return delete_enlistment();
 }
 
+static int cmd_version(int argc, const char **argv)
+{
+	int verbose = 0, build_options = 0;
+	struct option options[] = {
+		OPT__VERBOSE(&verbose, N_("include Git version")),
+		OPT_BOOL(0, "build-options", &build_options,
+			 N_("include Git's build options")),
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar verbose [-v | --verbose] [--build-options]"),
+		NULL
+	};
+	struct strbuf buf = STRBUF_INIT;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	get_version_info(&buf, build_options);
+	fprintf(stderr, "%s\n", buf.buf);
+	strbuf_release(&buf);
+
+	return 0;
+}
+
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
@@ -1080,6 +1108,7 @@ struct {
 	{ "reconfigure", cmd_reconfigure },
 	{ "diagnose", cmd_diagnose },
 	{ "delete", cmd_delete },
+	{ "version", cmd_version },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -684,6 +684,9 @@ int cmd_main(int argc, const char **argv)
 		argv++;
 		argc--;
 
+		if (!strcmp(argv[0], "config"))
+			argv[0] = "reconfigure";
+
 		for (i = 0; builtins[i].name; i++)
 			if (!strcmp(builtins[i].name, argv[0]))
 				return !!builtins[i].fn(argc, argv);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -473,6 +473,69 @@ static int cmd_register(int argc, const char **argv)
 	return register_dir();
 }
 
+static int cmd_run(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	struct {
+		const char *arg, *task;
+	} tasks[] = {
+		{ "config", NULL },
+		{ "commit-graph", "commit-graph" },
+		{ "fetch", "prefetch" },
+		{ "loose-objects", "loose-objects" },
+		{ "pack-files", "incremental-repack" },
+		{ NULL, NULL }
+	};
+	struct strbuf buf = STRBUF_INIT;
+	const char *usagestr[] = { NULL, NULL };
+	int i;
+
+	strbuf_addstr(&buf, N_("scalar run <task> [<enlistment>]\nTasks:\n"));
+	for (i = 0; tasks[i].arg; i++)
+		strbuf_addf(&buf, "\t%s\n", tasks[i].arg);
+	usagestr[0] = buf.buf;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usagestr, 0);
+
+	if (argc == 0)
+		usage_with_options(usagestr, options);
+
+	if (!strcmp("all", argv[0]))
+		i = -1;
+	else {
+		for (i = 0; tasks[i].arg && strcmp(tasks[i].arg, argv[0]); i++)
+			; /* keep looking for the task */
+
+		if (i > 0 && !tasks[i].arg) {
+			error(_("no such task: '%s'"), argv[0]);
+			usage_with_options(usagestr, options);
+		}
+	}
+
+	argc--;
+	argv++;
+	setup_enlistment_directory(argc, argv, usagestr, options);
+	strbuf_release(&buf);
+
+	if (i == 0)
+		return register_dir();
+
+	if (i > 0)
+		return run_git("maintenance", "run",
+			       "--task", tasks[i].task, NULL);
+
+	if (register_dir())
+		return -1;
+	for (i = 1; tasks[i].arg; i++)
+		if (run_git("maintenance", "run",
+			    "--task", tasks[i].task, NULL))
+			return -1;
+	return 0;
+}
+
 static int cmd_unregister(int argc, const char **argv)
 {
 	struct option options[] = {
@@ -530,6 +593,7 @@ struct {
 	{ "list", cmd_list },
 	{ "register", cmd_register },
 	{ "unregister", cmd_unregister },
+	{ "run", cmd_run },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1,0 +1,36 @@
+/*
+ * This is a port of Scalar to C.
+ */
+
+#include "cache.h"
+#include "gettext.h"
+#include "parse-options.h"
+
+struct {
+	const char *name;
+	int (*fn)(int, const char **);
+} builtins[] = {
+	{ NULL, NULL},
+};
+
+int cmd_main(int argc, const char **argv)
+{
+	struct strbuf scalar_usage = STRBUF_INIT;
+	int i;
+
+	if (argc > 1) {
+		argv++;
+		argc--;
+
+		for (i = 0; builtins[i].name; i++)
+			if (!strcmp(builtins[i].name, argv[0]))
+				return !!builtins[i].fn(argc, argv);
+	}
+
+	strbuf_addstr(&scalar_usage,
+		      N_("scalar <command> [<options>]\n\nCommands:\n"));
+	for (i = 0; builtins[i].name; i++)
+		strbuf_addf(&scalar_usage, "\t%s\n", builtins[i].name);
+
+	usage(scalar_usage.buf);
+}

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1117,6 +1117,25 @@ int cmd_main(int argc, const char **argv)
 	struct strbuf scalar_usage = STRBUF_INIT;
 	int i;
 
+	while (argc > 1 && *argv[1] == '-') {
+		if (!strcmp(argv[1], "-C")) {
+			if (argc < 3)
+				die(_("-C requires a <directory>"));
+			if (chdir(argv[2]) < 0)
+				die_errno(_("could not change to '%s'"),
+					  argv[2]);
+			argc -= 2;
+			argv += 2;
+		} else if (!strcmp(argv[1], "-c")) {
+			if (argc < 3)
+				die(_("-c requires a <key>=<value> argument"));
+			git_config_push_parameter(argv[2]);
+			argc -= 2;
+			argv += 2;
+		} else
+			break;
+	}
+
 	if (argc > 1) {
 		argv++;
 		argc--;
@@ -1130,7 +1149,8 @@ int cmd_main(int argc, const char **argv)
 	}
 
 	strbuf_addstr(&scalar_usage,
-		      N_("scalar <command> [<options>]\n\nCommands:\n"));
+		      N_("scalar [-C <directory>] [-c <key>=<value>] "
+			 "<command> [<options>]\n\nCommands:\n"));
 	for (i = 0; builtins[i].name; i++)
 		strbuf_addf(&scalar_usage, "\t%s\n", builtins[i].name);
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -348,6 +348,58 @@ static int index_to_zip(const char *git_dir)
 	return run_command(&cp);
 }
 
+#ifndef WIN32
+#include <sys/statvfs.h>
+#endif
+
+static int get_disk_info(struct strbuf *out)
+{
+#ifdef WIN32
+	struct strbuf buf = STRBUF_INIT;
+	char volume_name[MAX_PATH], fs_name[MAX_PATH];
+	DWORD serial_number, component_length, flags;
+	ULARGE_INTEGER avail2caller, total, avail;
+
+	strbuf_realpath(&buf, ".", 1);
+	if (!GetDiskFreeSpaceExA(buf.buf, &avail2caller, &total, &avail)) {
+		error(_("could not determine free disk size for '%s'"),
+		      buf.buf);
+		strbuf_release(&buf);
+		return -1;
+	}
+
+	strbuf_setlen(&buf, offset_1st_component(buf.buf));
+	if (!GetVolumeInformationA(buf.buf, volume_name, sizeof(volume_name),
+				   &serial_number, &component_length, &flags,
+				   fs_name, sizeof(fs_name))) {
+		error(_("could not get info for '%s'"), buf.buf);
+		strbuf_release(&buf);
+		return -1;
+	}
+	strbuf_addf(out, "Available space on '%s': ", buf.buf);
+	strbuf_humanise_bytes(out, avail2caller.QuadPart);
+	strbuf_addch(out, '\n');
+	strbuf_release(&buf);
+#else
+	struct strbuf buf = STRBUF_INIT;
+	struct statvfs stat;
+
+	strbuf_realpath(&buf, ".", 1);
+	if (statvfs(buf.buf, &stat) < 0) {
+		error_errno(_("could not determine free disk size for '%s'"),
+			    buf.buf);
+		strbuf_release(&buf);
+		return -1;
+	}
+
+	strbuf_addf(out, "Available space on '%s': ", buf.buf);
+	strbuf_humanise_bytes(out, st_mult(stat.f_bsize, stat.f_bavail));
+	strbuf_addf(out, " (mount flags 0x%lx)\n", stat.f_flag);
+	strbuf_release(&buf);
+#endif
+	return 0;
+}
+
 /* printf-style interface, expects `<key>=<value>` argument */
 static int set_config(const char *fmt, ...)
 {
@@ -598,6 +650,7 @@ static int cmd_diagnose(int argc, const char **argv)
 	get_version_info(&buf, 1);
 
 	strbuf_addf(&buf, "Enlistment root: %s\n", the_repository->worktree);
+	get_disk_info(&buf);
 	fwrite(buf.buf, buf.len, 1, stdout);
 
 	if ((res = stage(tmp_dir.buf, &buf, "diagnostics.log")))

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -7,6 +7,7 @@
 #include "parse-options.h"
 #include "config.h"
 #include "run-command.h"
+#include "refs.h"
 
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
@@ -362,7 +363,16 @@ static int cmd_clone(int argc, const char **argv)
 
 	dir = xstrfmt("%s/src", enlistment);
 
-	if ((res = run_git("init", "--", dir, NULL)))
+	strbuf_reset(&buf);
+	if (branch)
+		strbuf_addf(&buf, "init.defaultBranch=%s", branch);
+	else {
+		char *b = repo_default_branch_name(the_repository, 1);
+		strbuf_addf(&buf, "init.defaultBranch=%s", b);
+		free(b);
+	}
+
+	if ((res = run_git("-c", buf.buf, "init", "--", dir, NULL)))
 		goto cleanup;
 
 	if (chdir(dir) < 0) {

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -80,18 +80,20 @@ static int run_git(const char *arg, ...)
 	return res;
 }
 
-static int set_recommended_config(void)
+static int set_recommended_config(int reconfigure)
 {
 	struct {
 		const char *key;
 		const char *value;
+		int overwrite_on_reconfigure;
 	} config[] = {
-		{ "am.keepCR", "true" },
-		{ "core.FSCache", "true" },
-		{ "core.multiPackIndex", "true" },
-		{ "core.preloadIndex", "true" },
+		/* Required */
+		{ "am.keepCR", "true", 1 },
+		{ "core.FSCache", "true", 1 },
+		{ "core.multiPackIndex", "true", 1 },
+		{ "core.preloadIndex", "true", 1 },
 #ifndef WIN32
-		{ "core.untrackedCache", "true" },
+		{ "core.untrackedCache", "true", 1 },
 #else
 		/*
 		 * Unfortunately, Scalar's Functional Tests demonstrated
@@ -105,29 +107,30 @@ static int set_recommended_config(void)
 		 * Therefore, with a sad heart, we disable this very useful
 		 * feature on Windows.
 		 */
-		{ "core.untrackedCache", "false" },
+		{ "core.untrackedCache", "false", 1 },
 #endif
-		{ "core.bare", "false" },
-		{ "core.logAllRefUpdates", "true" },
-		{ "credential.https://dev.azure.com.useHttpPath", "true" },
-		{ "credential.validate", "false" }, /* GCM4W-only */
-		{ "gc.auto", "0" },
-		{ "gui.GCWarning", "false" },
-		{ "index.threads", "true" },
-		{ "index.version", "4" },
-		{ "merge.stat", "false" },
-		{ "merge.renames", "false" },
-		{ "pack.useBitmaps", "false" },
-		{ "pack.useSparse", "true" },
-		{ "receive.autoGC", "false" },
-		{ "reset.quiet", "true" },
-		{ "feature.manyFiles", "false" },
-		{ "feature.experimental", "false" },
-		{ "fetch.unpackLimit", "1" },
-		{ "fetch.writeCommitGraph", "false" },
+		{ "core.bare", "false", 1 },
+		{ "core.logAllRefUpdates", "true", 1 },
+		{ "credential.https://dev.azure.com.useHttpPath", "true", 1 },
+		{ "credential.validate", "false", 1 }, /* GCM4W-only */
+		{ "gc.auto", "0", 1 },
+		{ "gui.GCWarning", "false", 1 },
+		{ "index.threads", "true", 1 },
+		{ "index.version", "4", 1 },
+		{ "merge.stat", "false", 1 },
+		{ "merge.renames", "false", 1 },
+		{ "pack.useBitmaps", "false", 1 },
+		{ "pack.useSparse", "true", 1 },
+		{ "receive.autoGC", "false", 1 },
+		{ "reset.quiet", "true", 1 },
+		{ "feature.manyFiles", "false", 1 },
+		{ "feature.experimental", "false", 1 },
+		{ "fetch.unpackLimit", "1", 1 },
+		{ "fetch.writeCommitGraph", "false", 1 },
 #ifdef WIN32
-		{ "http.sslBackend", "schannel" },
+		{ "http.sslBackend", "schannel", 1 },
 #endif
+		/* Optional */
 		{ "status.aheadBehind", "false" },
 		{ "commitGraph.generationVersion", "1" },
 		{ "core.autoCRLF", "false" },
@@ -151,7 +154,8 @@ static int set_recommended_config(void)
 	char *value;
 
 	for (i = 0; config[i].key; i++) {
-		if (git_config_get_string(config[i].key, &value)) {
+		if ((reconfigure && config[i].overwrite_on_reconfigure) ||
+		    git_config_get_string(config[i].key, &value)) {
 			trace2_data_string("scalar", the_repository, config[i].key, "created");
 			if (git_config_set_gently(config[i].key,
 						  config[i].value) < 0)
@@ -219,7 +223,7 @@ static int register_dir(void)
 	int res = add_or_remove_enlistment(1);
 
 	if (!res)
-		res = set_recommended_config();
+		res = set_recommended_config(0);
 
 	if (!res)
 		res = toggle_maintenance(1);
@@ -408,7 +412,7 @@ static int cmd_clone(int argc, const char **argv)
 	    (res = run_git("sparse-checkout", "init", "--cone", NULL)))
 		goto cleanup;
 
-	if (set_recommended_config())
+	if (set_recommended_config(0))
 		return error(_("could not configure '%s'"), dir);
 
 	if ((res = run_git("fetch", "--quiet", "origin", NULL))) {
@@ -471,6 +475,24 @@ static int cmd_register(int argc, const char **argv)
 	setup_enlistment_directory(argc, argv, usage, options);
 
 	return register_dir();
+}
+
+static int cmd_reconfigure(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar reconfigure [<enlistment>]"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return set_recommended_config(1);
 }
 
 static int cmd_run(int argc, const char **argv)
@@ -594,6 +616,7 @@ struct {
 	{ "register", cmd_register },
 	{ "unregister", cmd_unregister },
 	{ "run", cmd_run },
+	{ "reconfigure", cmd_reconfigure },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -477,22 +477,77 @@ static int cmd_register(int argc, const char **argv)
 	return register_dir();
 }
 
+static int get_scalar_repos(const char *key, const char *value, void *data)
+{
+	struct string_list *list = data;
+
+	if (!strcmp(key, "scalar.repo"))
+		string_list_append(list, value);
+
+	return 0;
+}
+
 static int cmd_reconfigure(int argc, const char **argv)
 {
+	int all = 0;
 	struct option options[] = {
+		OPT_BOOL('a', "all", &all,
+			 N_("reconfigure all registered enlistments")),
 		OPT_END(),
 	};
 	const char * const usage[] = {
-		N_("scalar reconfigure [<enlistment>]"),
+		N_("scalar reconfigure [--all | <enlistment>]"),
 		NULL
 	};
+	struct string_list scalar_repos = STRING_LIST_INIT_DUP;
+	int i, res = 0;
+	struct repository r = { NULL };
+	struct strbuf commondir = STRBUF_INIT, gitdir = STRBUF_INIT;
 
 	argc = parse_options(argc, argv, NULL, options,
 			     usage, 0);
 
-	setup_enlistment_directory(argc, argv, usage, options);
+	if (!all) {
+		setup_enlistment_directory(argc, argv, usage, options);
 
-	return set_recommended_config(1);
+		return set_recommended_config(1);
+	}
+
+	if (argc > 0)
+		usage_msg_opt(_("--all or <enlistment>, but not both"),
+			      usage, options);
+
+	git_config(get_scalar_repos, &scalar_repos);
+
+	for (i = 0; i < scalar_repos.nr; i++) {
+		const char *dir = scalar_repos.items[i].string;
+
+		strbuf_reset(&commondir);
+		strbuf_reset(&gitdir);
+
+		if (chdir(dir) < 0) {
+			warning_errno(_("could not switch to '%s'"), dir);
+			res = -1;
+		} else if (discover_git_directory(&commondir, &gitdir) < 0) {
+			warning_errno(_("Git repository gone in '%s'"), dir);
+			res = -1;
+		} else {
+			git_config_clear();
+
+			the_repository = &r;
+			r.commondir = commondir.buf;
+			r.gitdir = gitdir.buf;
+
+			if (set_recommended_config(1) < 0)
+				res = -1;
+		}
+	}
+
+	string_list_clear(&scalar_repos, 1);
+	strbuf_release(&commondir);
+	strbuf_release(&gitdir);
+
+	return res;
 }
 
 static int cmd_run(int argc, const char **argv)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -614,6 +614,39 @@ void load_builtin_commands(const char *prefix, struct cmdnames *cmds)
 	die("not implemented");
 }
 
+static void dir_file_stats(struct strbuf *buf, const char *path)
+{
+	DIR *dir = opendir(path);
+	struct dirent *e;
+	struct stat e_stat;
+	struct strbuf file_path = STRBUF_INIT;
+	int base_path_len;
+
+	if (!dir)
+		return;
+
+	strbuf_addstr(buf, "Contents of ");
+	strbuf_add_absolute_path(buf, path);
+	strbuf_addstr(buf, ":\n");
+
+	strbuf_add_absolute_path(&file_path, path);
+	strbuf_addch(&file_path, '/');
+	base_path_len = file_path.len;
+
+	while ((e = readdir(dir)) != NULL)
+		if (!is_dot_or_dotdot(e->d_name) && e->d_type == DT_REG) {
+			strbuf_setlen(&file_path, base_path_len);
+			strbuf_addstr(&file_path, e->d_name);
+			if (!stat(file_path.buf, &e_stat))
+				strbuf_addf(buf, "%-70s %16"PRIuMAX"\n",
+					    e->d_name,
+					    (uintmax_t)e_stat.st_size);
+		}
+
+	strbuf_release(&file_path);
+	closedir(dir);
+}
+
 static int cmd_diagnose(int argc, const char **argv)
 {
 	struct option options[] = {
@@ -654,6 +687,12 @@ static int cmd_diagnose(int argc, const char **argv)
 	fwrite(buf.buf, buf.len, 1, stdout);
 
 	if ((res = stage(tmp_dir.buf, &buf, "diagnostics.log")))
+		goto diagnose_cleanup;
+
+	strbuf_reset(&buf);
+	dir_file_stats(&buf, ".git/objects/pack");
+
+	if ((res = stage(tmp_dir.buf, &buf, "packs-local.txt")))
 		goto diagnose_cleanup;
 
 	if ((res = stage_directory(tmp_dir.buf, ".git", 0)) ||

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -5,11 +5,197 @@
 #include "cache.h"
 #include "gettext.h"
 #include "parse-options.h"
+#include "config.h"
+
+static void setup_enlistment_directory(int argc, const char **argv,
+				       const char * const *usagestr,
+				       const struct option *options)
+{
+	if (startup_info->have_repository)
+		BUG("gitdir already set up?!?");
+
+	if (argc > 1)
+		usage_with_options(usagestr, options);
+
+	if (argc == 1) {
+		char *src = xstrfmt("%s/src", argv[0]);
+		const char *dir = is_directory(src) ? src : argv[0];
+
+		if (chdir(dir) < 0)
+			die_errno(_("could not switch to '%s'"), dir);
+
+		free(src);
+	} else {
+		/* find the worktree, and ensure that it is named `src` */
+		struct strbuf path = STRBUF_INIT;
+
+		if (strbuf_getcwd(&path) < 0)
+			die(_("need a working directory"));
+
+		for (;;) {
+			size_t len = path.len;
+
+			strbuf_addstr(&path, "/src/.git");
+			if (is_git_directory(path.buf)) {
+				strbuf_setlen(&path, len);
+				strbuf_addstr(&path, "/src");
+				if (chdir(path.buf) < 0)
+					die_errno(_("could not switch to '%s'"),
+						  path.buf);
+				strbuf_release(&path);
+				break;
+			}
+
+			while (len > 0 && !is_dir_sep(path.buf[--len]))
+				; /* keep looking for parent directory */
+
+			if (!len)
+				die(_("could not find enlistment root"));
+
+			strbuf_setlen(&path, len);
+		}
+	}
+
+	setup_git_directory();
+}
+
+static int set_recommended_config(void)
+{
+	struct {
+		const char *key;
+		const char *value;
+	} config[] = {
+		{ "am.keepCR", "true" },
+		{ "core.FSCache", "true" },
+		{ "core.multiPackIndex", "true" },
+		{ "core.preloadIndex", "true" },
+#ifndef WIN32
+		{ "core.untrackedCache", "true" },
+#else
+		/*
+		 * Unfortunately, Scalar's Functional Tests demonstrated
+		 * that the untracked cache feature is unreliable on Windows
+		 * (which is a bummer because that platform would benefit the
+		 * most from it). For some reason, freshly created files seem
+		 * not to update the directory's `lastModified` time
+		 * immediately, but the untracked cache would need to rely on
+		 * that.
+		 *
+		 * Therefore, with a sad heart, we disable this very useful
+		 * feature on Windows.
+		 */
+		{ "core.untrackedCache", "false" },
+#endif
+		{ "core.bare", "false" },
+		{ "core.logAllRefUpdates", "true" },
+		{ "credential.https://dev.azure.com.useHttpPath", "true" },
+		{ "credential.validate", "false" }, /* GCM4W-only */
+		{ "gc.auto", "0" },
+		{ "gui.GCWarning", "false" },
+		{ "index.threads", "true" },
+		{ "index.version", "4" },
+		{ "merge.stat", "false" },
+		{ "merge.renames", "false" },
+		{ "pack.useBitmaps", "false" },
+		{ "pack.useSparse", "true" },
+		{ "receive.autoGC", "false" },
+		{ "reset.quiet", "true" },
+		{ "feature.manyFiles", "false" },
+		{ "feature.experimental", "false" },
+		{ "fetch.unpackLimit", "1" },
+		{ "fetch.writeCommitGraph", "false" },
+#ifdef WIN32
+		{ "http.sslBackend", "schannel" },
+#endif
+		{ "status.aheadBehind", "false" },
+		{ "commitGraph.generationVersion", "1" },
+		{ "core.autoCRLF", "false" },
+		{ "core.safeCRLF", "false" },
+		{ "maintenance.gc.enabled", "false" },
+		{ "maintenance.prefetch.enabled", "true" },
+		{ "maintenance.prefetch.auto", "0" },
+		{ "maintenance.prefetch.schedule", "hourly" },
+		{ "maintenance.commit-graph.enabled", "true" },
+		{ "maintenance.commit-graph.auto", "0" },
+		{ "maintenance.commit-graph.schedule", "hourly" },
+		{ "maintenance.loose-objects.enabled", "true" },
+		{ "maintenance.loose-objects.auto", "0" },
+		{ "maintenance.loose-objects.schedule", "daily" },
+		{ "maintenance.incremental-repack.enabled", "true" },
+		{ "maintenance.incremental-repack.auto", "0" },
+		{ "maintenance.incremental-repack.schedule", "daily" },
+		{ NULL, NULL },
+	};
+	int i;
+	char *value;
+
+	for (i = 0; config[i].key; i++) {
+		if (git_config_get_string(config[i].key, &value)) {
+			trace2_data_string("scalar", the_repository, config[i].key, "created");
+			if (git_config_set_gently(config[i].key,
+						  config[i].value) < 0)
+				return error(_("could not configure %s=%s"),
+					     config[i].key, config[i].value);
+		} else {
+			trace2_data_string("scalar", the_repository, config[i].key, "exists");
+			free(value);
+		}
+	}
+
+	/*
+	 * The `log.excludeDecoration` setting is special because we want to
+	 * set multiple values.
+	 */
+	if (git_config_get_string("log.excludeDecoration", &value)) {
+		trace2_data_string("scalar", the_repository,
+				   "log.excludeDecoration", "created");
+		if (git_config_set_multivar_gently("log.excludeDecoration",
+						   "refs/scalar/*",
+						   CONFIG_REGEX_NONE, 0) ||
+		    git_config_set_multivar_gently("log.excludeDecoration",
+						   "refs/prefetch/*",
+						   CONFIG_REGEX_NONE, 0))
+			return error(_("could not configure "
+				       "log.excludeDecoration"));
+	} else {
+		trace2_data_string("scalar", the_repository,
+				   "log.excludeDecoration", "exists");
+		free(value);
+	}
+
+	return 0;
+}
+
+static int register_dir(void)
+{
+	int res = set_recommended_config();
+
+	return res;
+}
+
+static int cmd_register(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar register [<enlistment>]"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return register_dir();
+}
 
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
 } builtins[] = {
+	{ "register", cmd_register },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -314,7 +314,7 @@ static char *remote_default_branch(const char *url)
 static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
-	int no_fetch_commits_and_trees = 0, full_clone = 0;
+	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -323,6 +323,9 @@ static int cmd_clone(int argc, const char **argv)
 			 N_("skip fetching commits and trees after clone")),
 		OPT_BOOL(0, "full-clone", &full_clone,
 			 N_("when cloning, create full working directory")),
+		OPT_BOOL(0, "single-branch", &single_branch,
+			 N_("only download metadata for the branch that will "
+			    "be checked out")),
 		OPT_END(),
 	};
 	const char * const clone_usage[] = {
@@ -392,7 +395,9 @@ static int cmd_clone(int argc, const char **argv)
 
 	if (set_config("remote.origin.url=%s", url) ||
 	    set_config("remote.origin.fetch="
-		       "+refs/heads/*:refs/remotes/origin/*") ||
+		    "+refs/heads/%s:refs/remotes/origin/%s",
+		    single_branch ? branch : "*",
+		    single_branch ? branch : "*") ||
 	    set_config("remote.origin.promisor=true") ||
 	    set_config("remote.origin.partialCloneFilter=blob:none")) {
 		res = error(_("could not configure remote in '%s'"), dir);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -485,6 +485,45 @@ static char *remote_default_branch(const char *url)
 	return NULL;
 }
 
+static void strbuf_parentdir(struct strbuf *buf)
+{
+	int len = buf->len;
+	while (len > 0 && !is_dir_sep(buf->buf[--len]))
+		; /* keep looking for parent directory */
+	strbuf_setlen(buf, len);
+}
+
+static int delete_enlistment(void)
+{
+	struct strbuf enlistment = STRBUF_INIT;
+#ifdef WIN32
+	struct strbuf parent = STRBUF_INIT;
+#endif
+
+	if (unregister_dir())
+		die(_("failed to unregister repository"));
+
+	/* Compute the enlistment path (parent of the worktree) */
+	strbuf_addstr(&enlistment, the_repository->worktree);
+	strbuf_parentdir(&enlistment);
+
+#ifdef WIN32
+	/* Change current directory to one outside of the enlistment
+	   so that we may delete everything underneath it. */
+	strbuf_addbuf(&parent, &enlistment);
+	strbuf_parentdir(&parent);
+	if (chdir(parent.buf) < 0)
+		die_errno(_("could not switch to '%s'"), parent.buf);
+	strbuf_release(&parent);
+#endif
+
+	if (remove_dir_recursively(&enlistment, 0))
+		die(_("failed to delete enlistment directory"));
+
+	strbuf_release(&enlistment);
+	return 0;
+}
+
 static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
@@ -1008,6 +1047,27 @@ static int cmd_unregister(int argc, const char **argv)
 	return unregister_dir();
 }
 
+static int cmd_delete(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar delete <enlistment>"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 1)
+		usage_with_options(usage, options);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return delete_enlistment();
+}
+
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
@@ -1019,6 +1079,7 @@ struct {
 	{ "run", cmd_run },
 	{ "reconfigure", cmd_reconfigure },
 	{ "diagnose", cmd_diagnose },
+	{ "delete", cmd_delete },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -647,6 +647,60 @@ static void dir_file_stats(struct strbuf *buf, const char *path)
 	closedir(dir);
 }
 
+static int count_files(char *path)
+{
+	DIR *dir = opendir(path);
+	struct dirent *e;
+	int count = 0;
+
+	if (!dir)
+		return 0;
+
+	while ((e = readdir(dir)) != NULL)
+		if (!is_dot_or_dotdot(e->d_name) && e->d_type == DT_REG)
+			count++;
+
+	closedir(dir);
+	return count;
+}
+
+static void loose_objs_stats(struct strbuf *buf, const char *path)
+{
+	DIR *dir = opendir(path);
+	struct dirent *e;
+	int count;
+	int total = 0;
+	unsigned char c;
+	struct strbuf count_path = STRBUF_INIT;
+	int base_path_len;
+
+	if (!dir)
+		return;
+
+	strbuf_addstr(buf, "Object directory stats for ");
+	strbuf_add_absolute_path(buf, path);
+	strbuf_addstr(buf, ":\n");
+
+	strbuf_add_absolute_path(&count_path, path);
+	strbuf_addch(&count_path, '/');
+	base_path_len = count_path.len;
+
+	while ((e = readdir(dir)) != NULL)
+		if (!is_dot_or_dotdot(e->d_name) &&
+		    e->d_type == DT_DIR && strlen(e->d_name) == 2 &&
+		    !hex_to_bytes(&c, e->d_name, 1)) {
+			strbuf_setlen(&count_path, base_path_len);
+			strbuf_addstr(&count_path, e->d_name);
+			total += (count = count_files(count_path.buf));
+			strbuf_addf(buf, "%s : %7d files\n", e->d_name, count);
+		}
+
+	strbuf_addf(buf, "Total: %d loose objects", total);
+
+	strbuf_release(&count_path);
+	closedir(dir);
+}
+
 static int cmd_diagnose(int argc, const char **argv)
 {
 	struct option options[] = {
@@ -693,6 +747,12 @@ static int cmd_diagnose(int argc, const char **argv)
 	dir_file_stats(&buf, ".git/objects/pack");
 
 	if ((res = stage(tmp_dir.buf, &buf, "packs-local.txt")))
+		goto diagnose_cleanup;
+
+	strbuf_reset(&buf);
+	loose_objs_stats(&buf, ".git/objects");
+
+	if ((res = stage(tmp_dir.buf, &buf, "objects-local.txt")))
 		goto diagnose_cleanup;
 
 	if ((res = stage_directory(tmp_dir.buf, ".git", 0)) ||

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -246,11 +246,25 @@ static int unregister_dir(void)
 	return res;
 }
 
+static void spinner(void)
+{
+	static const char whee[] = "|\010/\010-\010\\\010", *next = whee;
+
+	if (!next)
+		return;
+	if (write(2, next, 2) < 0)
+		next = NULL;
+	else
+		next = next[2] ? next + 2 : whee;
+}
+
 static int stage(const char *git_dir, struct strbuf *buf, const char *path)
 {
 	struct strbuf cacheinfo = STRBUF_INIT;
 	struct child_process cp = CHILD_PROCESS_INIT;
 	int res;
+
+	spinner();
 
 	strbuf_addstr(&cacheinfo, "100644,");
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -6,6 +6,7 @@
 #include "gettext.h"
 #include "parse-options.h"
 #include "config.h"
+#include "run-command.h"
 
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
@@ -57,6 +58,25 @@ static void setup_enlistment_directory(int argc, const char **argv,
 	}
 
 	setup_git_directory();
+}
+
+static int run_git(const char *arg, ...)
+{
+	struct strvec argv = STRVEC_INIT;
+	va_list args;
+	const char *p;
+	int res;
+
+	va_start(args, arg);
+	strvec_push(&argv, arg);
+	while ((p = va_arg(args, const char *)))
+		strvec_push(&argv, p);
+	va_end(args);
+
+	res = run_command_v_opt(argv.v, RUN_GIT_CMD);
+
+	strvec_clear(&argv);
+	return res;
 }
 
 static int set_recommended_config(void)
@@ -166,11 +186,24 @@ static int set_recommended_config(void)
 	return 0;
 }
 
+static int toggle_maintenance(int enable)
+{
+	return run_git("maintenance", enable ? "start" : "unregister", NULL);
+}
+
 static int register_dir(void)
 {
 	int res = set_recommended_config();
 
+	if (!res)
+		res = toggle_maintenance(1);
+
 	return res;
+}
+
+static int unregister_dir(void)
+{
+	return toggle_maintenance(0);
 }
 
 static int cmd_register(int argc, const char **argv)
@@ -191,11 +224,30 @@ static int cmd_register(int argc, const char **argv)
 	return register_dir();
 }
 
+static int cmd_unregister(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar unregister [<enlistment>]"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	return unregister_dir();
+}
+
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
 } builtins[] = {
 	{ "register", cmd_register },
+	{ "unregister", cmd_unregister },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -191,9 +191,34 @@ static int toggle_maintenance(int enable)
 	return run_git("maintenance", enable ? "start" : "unregister", NULL);
 }
 
+static int add_or_remove_enlistment(int add)
+{
+	int res;
+
+	if (!the_repository->worktree)
+		die(_("Scalar enlistments require a worktree"));
+
+	res = run_git("config", "--global", "--get", "--fixed-value",
+		      "scalar.repo", the_repository->worktree, NULL);
+
+	/*
+	 * If we want to add and the setting is already there, then do nothing.
+	 * If we want to remove and the setting is not there, then do nothing.
+	 */
+	if ((add && !res) || (!add && res))
+		return 0;
+
+	return run_git("config", "--global", add ? "--add" : "--unset",
+		       add ? "--no-fixed-value" : "--fixed-value",
+		       "scalar.repo", the_repository->worktree, NULL);
+}
+
 static int register_dir(void)
 {
-	int res = set_recommended_config();
+	int res = add_or_remove_enlistment(1);
+
+	if (!res)
+		res = set_recommended_config();
 
 	if (!res)
 		res = toggle_maintenance(1);
@@ -203,7 +228,25 @@ static int register_dir(void)
 
 static int unregister_dir(void)
 {
-	return toggle_maintenance(0);
+	int res = 0;
+
+	if (toggle_maintenance(0) < 0)
+		res = -1;
+
+	if (add_or_remove_enlistment(0) < 0)
+		res = -1;
+
+	return res;
+}
+
+static int cmd_list(int argc, const char **argv)
+{
+	if (argc != 1)
+		die(_("`scalar list` does not take arguments"));
+
+	if (run_git("config", "--global", "--get-all", "scalar.repo", NULL) < 0)
+		return -1;
+	return 0;
 }
 
 static int cmd_register(int argc, const char **argv)
@@ -246,6 +289,7 @@ struct {
 	const char *name;
 	int (*fn)(int, const char **);
 } builtins[] = {
+	{ "list", cmd_list },
 	{ "register", cmd_register },
 	{ "unregister", cmd_unregister },
 	{ NULL, NULL},

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -239,6 +239,197 @@ static int unregister_dir(void)
 	return res;
 }
 
+/* printf-style interface, expects `<key>=<value>` argument */
+static int set_config(const char *fmt, ...)
+{
+	struct strbuf buf = STRBUF_INIT;
+	char *value;
+	int res;
+	va_list args;
+
+	va_start(args, fmt);
+	strbuf_vaddf(&buf, fmt, args);
+	va_end(args);
+
+	value = strchr(buf.buf, '=');
+	if (value)
+		*(value++) = '\0';
+	res = git_config_set_gently(buf.buf, value);
+	strbuf_release(&buf);
+
+	return res;
+}
+
+static char *remote_default_branch(const char *url)
+{
+	struct child_process cp = CHILD_PROCESS_INIT;
+	struct strbuf out = STRBUF_INIT;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "ls-remote", "--symref", url, "HEAD", NULL);
+	strbuf_addstr(&out, "-\n");
+	if (!pipe_command(&cp, NULL, 0, &out, 0, NULL, 0)) {
+		char *ref = out.buf;
+
+		while ((ref = strstr(ref + 1, "\nref: "))) {
+			const char *p;
+			char *head, *branch;
+
+			ref += strlen("\nref: ");
+			head = strstr(ref, "\tHEAD");
+
+			if (!head || memchr(ref, '\n', head - ref))
+				continue;
+
+			if (skip_prefix(ref, "refs/heads/", &p)) {
+				branch = xstrndup(p, head - p);
+				strbuf_release(&out);
+				return branch;
+			}
+
+			error(_("remote HEAD is not a branch: '%.*s'"),
+			      (int)(head - ref), ref);
+			strbuf_release(&out);
+			return NULL;
+		}
+	}
+	warning(_("failed to get default branch name from remote; "
+		  "using local default"));
+	strbuf_reset(&out);
+
+	child_process_init(&cp);
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "symbolic-ref", "--short", "HEAD", NULL);
+	if (!pipe_command(&cp, NULL, 0, &out, 0, NULL, 0)) {
+		strbuf_trim(&out);
+		return strbuf_detach(&out, NULL);
+	}
+
+	strbuf_release(&out);
+	error(_("failed to get default branch name"));
+	return NULL;
+}
+
+static int cmd_clone(int argc, const char **argv)
+{
+	const char *branch = NULL;
+	int no_fetch_commits_and_trees = 0, full_clone = 0;
+	struct option clone_options[] = {
+		OPT_STRING('b', "branch", &branch, N_("<branch>"),
+			   N_("branch to checkout after clone")),
+		OPT_BOOL(0, "no-fetch-commits-and-trees",
+			 &no_fetch_commits_and_trees,
+			 N_("skip fetching commits and trees after clone")),
+		OPT_BOOL(0, "full-clone", &full_clone,
+			 N_("when cloning, create full working directory")),
+		OPT_END(),
+	};
+	const char * const clone_usage[] = {
+		N_("scalar clone [<options>] [--] <repo> [<dir>]"),
+		NULL
+	};
+	const char *url;
+	char *enlistment = NULL, *dir = NULL;
+	struct strbuf buf = STRBUF_INIT;
+	int res;
+
+	argc = parse_options(argc, argv, NULL, clone_options, clone_usage, 0);
+
+	if (argc == 2) {
+		url = argv[0];
+		enlistment = xstrdup(argv[1]);
+	} else if (argc == 1) {
+		url = argv[0];
+
+		strbuf_addstr(&buf, url);
+		/* Strip trailing slashes, if any */
+		while (buf.len > 0 && is_dir_sep(buf.buf[buf.len - 1]))
+			strbuf_setlen(&buf, buf.len - 1);
+		/* Strip suffix `.git`, if any */
+		strbuf_strip_suffix(&buf, ".git");
+
+		enlistment = find_last_dir_sep(buf.buf);
+		if (!enlistment) {
+			die(_("cannot deduce worktree name from '%s'"), url);
+		}
+		enlistment = xstrdup(enlistment + 1);
+	} else {
+		usage_msg_opt(N_("need a URL"), clone_usage, clone_options);
+	}
+
+	if (is_directory(enlistment))
+		die(_("directory '%s' exists already"), enlistment);
+
+	dir = xstrfmt("%s/src", enlistment);
+
+	if ((res = run_git("init", "--", dir, NULL)))
+		goto cleanup;
+
+	if (chdir(dir) < 0) {
+		res = error_errno(_("could not switch to '%s'"), dir);
+		goto cleanup;
+	}
+
+	setup_git_directory();
+
+	/* common-main already logs `argv` */
+	trace2_data_string("scalar", the_repository, "dir", dir);
+
+	if (!branch && !(branch = remote_default_branch(url))) {
+		res = error(_("failed to get default branch for '%s'"), url);
+		goto cleanup;
+	}
+
+	if (set_config("remote.origin.url=%s", url) ||
+	    set_config("remote.origin.fetch="
+		       "+refs/heads/*:refs/remotes/origin/*") ||
+	    set_config("remote.origin.promisor=true") ||
+	    set_config("remote.origin.partialCloneFilter=blob:none")) {
+		res = error(_("could not configure remote in '%s'"), dir);
+		goto cleanup;
+	}
+
+	if (!full_clone &&
+	    (res = run_git("sparse-checkout", "init", "--cone", NULL)))
+		goto cleanup;
+
+	if (set_recommended_config())
+		return error(_("could not configure '%s'"), dir);
+
+	if ((res = run_git("fetch", "--quiet", "origin", NULL))) {
+		warning(_("Partial clone failed; Trying full clone"));
+
+		if (set_config("remote.origin.promisor") ||
+		    set_config("remote.origin.partialCloneFilter")) {
+			res = error(_("could not configure for full clone"));
+			goto cleanup;
+		}
+
+		if ((res = run_git("fetch", "--quiet", "origin", NULL)))
+			goto cleanup;
+	}
+
+	if ((res = set_config("branch.%s.remote=origin", branch)))
+		goto cleanup;
+	if ((res = set_config("branch.%s.merge=refs/heads/%s",
+			      branch, branch)))
+		goto cleanup;
+
+	strbuf_reset(&buf);
+	strbuf_addf(&buf, "origin/%s", branch);
+	res = run_git("checkout", "-f", "-t", buf.buf, NULL);
+	if (res)
+		goto cleanup;
+
+	res = register_dir();
+
+cleanup:
+	free(enlistment);
+	free(dir);
+	strbuf_release(&buf);
+	return res;
+}
+
 static int cmd_list(int argc, const char **argv)
 {
 	if (argc != 1)
@@ -320,6 +511,7 @@ struct {
 	const char *name;
 	int (*fn)(int, const char **);
 } builtins[] = {
+	{ "clone", cmd_clone },
 	{ "list", cmd_list },
 	{ "register", cmd_register },
 	{ "unregister", cmd_unregister },

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -8,6 +8,8 @@
 #include "config.h"
 #include "run-command.h"
 #include "refs.h"
+#include "help.h"
+#include "dir.h"
 
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
@@ -244,6 +246,108 @@ static int unregister_dir(void)
 	return res;
 }
 
+static int stage(const char *git_dir, struct strbuf *buf, const char *path)
+{
+	struct strbuf cacheinfo = STRBUF_INIT;
+	struct child_process cp = CHILD_PROCESS_INIT;
+	int res;
+
+	strbuf_addstr(&cacheinfo, "100644,");
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "--git-dir", git_dir,
+		     "hash-object", "-w", "--stdin", NULL);
+	res = pipe_command(&cp, buf->buf, buf->len, &cacheinfo, 256, NULL, 0);
+	if (!res) {
+		strbuf_rtrim(&cacheinfo);
+		strbuf_addch(&cacheinfo, ',');
+		/* We cannot stage `.git`, use `_git` instead. */
+		if (starts_with(path, ".git/"))
+			strbuf_addf(&cacheinfo, "_%s", path + 1);
+		else
+			strbuf_addstr(&cacheinfo, path);
+
+		child_process_init(&cp);
+		cp.git_cmd = 1;
+		strvec_pushl(&cp.args, "--git-dir", git_dir,
+			     "update-index", "--add", "--cacheinfo",
+			     cacheinfo.buf, NULL);
+		res = run_command(&cp);
+	}
+
+	strbuf_release(&cacheinfo);
+	return res;
+}
+
+static int stage_file(const char *git_dir, const char *path)
+{
+	struct strbuf buf = STRBUF_INIT;
+	int res;
+
+	if (strbuf_read_file(&buf, path, 0) < 0)
+		return error(_("could not read '%s'"), path);
+
+	res = stage(git_dir, &buf, path);
+
+	strbuf_release(&buf);
+	return res;
+}
+
+static int stage_directory(const char *git_dir, const char *path, int recurse)
+{
+	int at_root = !*path;
+	DIR *dir = opendir(at_root ? "." : path);
+	struct dirent *e;
+	struct strbuf buf = STRBUF_INIT;
+	size_t len;
+	int res = 0;
+
+	if (!dir)
+		return error(_("could not open directory '%s'"), path);
+
+	if (!at_root)
+		strbuf_addf(&buf, "%s/", path);
+	len = buf.len;
+
+	while (!res && (e = readdir(dir))) {
+		if (!strcmp(".", e->d_name) || !strcmp("..", e->d_name))
+			continue;
+
+		strbuf_setlen(&buf, len);
+		strbuf_addstr(&buf, e->d_name);
+
+		if ((e->d_type == DT_REG && stage_file(git_dir, buf.buf)) ||
+		    (e->d_type == DT_DIR && recurse &&
+		     stage_directory(git_dir, buf.buf, recurse)))
+			res = -1;
+	}
+
+	closedir(dir);
+	strbuf_release(&buf);
+	return res;
+}
+
+static int index_to_zip(const char *git_dir)
+{
+	struct child_process cp = CHILD_PROCESS_INIT;
+	struct strbuf oid = STRBUF_INIT;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "--git-dir", git_dir, "write-tree", NULL);
+	if (pipe_command(&cp, NULL, 0, &oid, the_hash_algo->hexsz + 1,
+			 NULL, 0))
+		return error(_("could not write temporary tree object"));
+
+	strbuf_rtrim(&oid);
+	child_process_init(&cp);
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "--git-dir", git_dir, "archive", "-o", NULL);
+	strvec_pushf(&cp.args, "%s.zip", git_dir);
+	strvec_pushl(&cp.args, oid.buf, "--", NULL);
+	strbuf_release(&oid);
+	return run_command(&cp);
+}
+
 /* printf-style interface, expects `<key>=<value>` argument */
 static int set_config(const char *fmt, ...)
 {
@@ -446,6 +550,82 @@ cleanup:
 	free(enlistment);
 	free(dir);
 	strbuf_release(&buf);
+	return res;
+}
+
+/*
+ * Dummy implementation; Using `get_version_info()` would cause a link error
+ * without this.
+ */
+void load_builtin_commands(const char *prefix, struct cmdnames *cmds)
+{
+	die("not implemented");
+}
+
+static int cmd_diagnose(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar diagnose [<enlistment>]"),
+		NULL
+	};
+	struct strbuf tmp_dir = STRBUF_INIT;
+	time_t now = time(NULL);
+	struct tm tm;
+	struct strbuf path = STRBUF_INIT, buf = STRBUF_INIT;
+	int res = 0;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	strbuf_addstr(&buf, "../.scalarDiagnostics/scalar_");
+	strbuf_addftime(&buf, "%Y%m%d_%H%M%S", localtime_r(&now, &tm), 0, 0);
+	if (run_git("init", "-q", "-b", "dummy", "--bare", buf.buf, NULL)) {
+		res = error(_("could not initialize temporary repository: %s"),
+			    buf.buf);
+		goto diagnose_cleanup;
+	}
+	strbuf_realpath(&tmp_dir, buf.buf, 1);
+
+	strbuf_reset(&buf);
+	strbuf_addf(&buf, "Collecting diagnostic info into temp folder %s\n\n",
+		    tmp_dir.buf);
+
+	get_version_info(&buf, 1);
+
+	strbuf_addf(&buf, "Enlistment root: %s\n", the_repository->worktree);
+	fwrite(buf.buf, buf.len, 1, stdout);
+
+	if ((res = stage(tmp_dir.buf, &buf, "diagnostics.log")))
+		goto diagnose_cleanup;
+
+	if ((res = stage_directory(tmp_dir.buf, ".git", 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/hooks", 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/info", 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/logs", 1)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/objects/info", 0)))
+		goto diagnose_cleanup;
+
+	res = index_to_zip(tmp_dir.buf);
+
+	if (!res)
+		res = remove_dir_recursively(&tmp_dir, 0);
+
+	if (!res)
+		printf("\n"
+		       "Diagnostics complete.\n"
+		       "All of the gathered info is captured in '%s.zip'\n",
+		       tmp_dir.buf);
+
+diagnose_cleanup:
+	strbuf_release(&tmp_dir);
+	strbuf_release(&path);
+	strbuf_release(&buf);
+
 	return res;
 }
 
@@ -672,6 +852,7 @@ struct {
 	{ "unregister", cmd_unregister },
 	{ "run", cmd_run },
 	{ "reconfigure", cmd_reconfigure },
+	{ "diagnose", cmd_diagnose },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -690,7 +690,8 @@ static char *get_cache_key(const char *url)
 	 * The GVFS protocol is only supported via https://; For testing, we
 	 * also allow http://.
 	 */
-	if (can_url_support_gvfs(url)) {
+	if (!git_env_bool("SCALAR_TEST_SKIP_VSTS_INFO", 0) &&
+	    can_url_support_gvfs(url)) {
 		cp.git_cmd = 1;
 		strvec_pushl(&cp.args, "gvfs-helper", "--remote", url,
 			     "endpoint", "vsts/info", NULL);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -10,6 +10,8 @@
 #include "refs.h"
 #include "help.h"
 #include "dir.h"
+#include "simple-ipc.h"
+#include "fsmonitor-ipc.h"
 
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
@@ -150,6 +152,12 @@ static int set_recommended_config(int reconfigure)
 		{ "maintenance.incremental-repack.enabled", "true" },
 		{ "maintenance.incremental-repack.auto", "0" },
 		{ "maintenance.incremental-repack.schedule", "daily" },
+#ifdef HAVE_FSMONITOR_DAEMON_BACKEND
+		/*
+		 * Enable the built-in FSMonitor on supported platforms.
+		 */
+		{ "core.useBuiltinFSMonitor", "true" },
+#endif
 		{ NULL, NULL },
 	};
 	int i;
@@ -220,6 +228,31 @@ static int add_or_remove_enlistment(int add)
 		       "scalar.repo", the_repository->worktree, NULL);
 }
 
+static int start_fsmonitor_daemon(void)
+{
+#ifdef HAVE_FSMONITOR_DAEMON_BACKEND
+	struct strbuf err = STRBUF_INIT;
+	struct child_process cp = CHILD_PROCESS_INIT;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "fsmonitor--daemon", "start", NULL);
+	if (!pipe_command(&cp, NULL, 0, NULL, 0, &err, 0)) {
+		strbuf_release(&err);
+		return 0;
+	}
+
+	if (fsmonitor_ipc__get_state() != IPC_STATE__LISTENING) {
+		write_in_full(2, err.buf, err.len);
+		strbuf_release(&err);
+		return error(_("could not start the FSMonitor daemon"));
+	}
+
+	strbuf_release(&err);
+#endif
+
+	return 0;
+}
+
 static int register_dir(void)
 {
 	int res = add_or_remove_enlistment(1);
@@ -229,6 +262,9 @@ static int register_dir(void)
 
 	if (!res)
 		res = toggle_maintenance(1);
+
+	if (!res)
+		res = start_fsmonitor_daemon();
 
 	return res;
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -565,6 +565,13 @@ static int get_cache_server_url(struct json_iterator *it)
 	return 0;
 }
 
+static int can_url_support_gvfs(const char *url)
+{
+	return starts_with(url, "https://") ||
+		(git_env_bool("GIT_TEST_ALLOW_GVFS_VIA_HTTP", 0) &&
+		 starts_with(url, "http://"));
+}
+
 /*
  * If `cache_server_url` is `NULL`, print the list to `stdout`.
  *
@@ -575,6 +582,13 @@ static int supports_gvfs_protocol(const char *url, char **cache_server_url)
 {
 	struct child_process cp = CHILD_PROCESS_INIT;
 	struct strbuf out = STRBUF_INIT;
+
+	/*
+	 * The GVFS protocol is only supported via https://; For testing, we
+	 * also allow http://.
+	 */
+	if (!can_url_support_gvfs(url))
+		return 0;
 
 	cp.git_cmd = 1;
 	strvec_pushl(&cp.args, "gvfs-helper", "--remote", url, "config", NULL);
@@ -644,19 +658,26 @@ static char *get_cache_key(const char *url)
 	struct strbuf out = STRBUF_INIT;
 	char *cache_key = NULL;
 
-	cp.git_cmd = 1;
-	strvec_pushl(&cp.args, "gvfs-helper", "--remote", url,
-		     "endpoint", "vsts/info", NULL);
-	if (!pipe_command(&cp, NULL, 0, &out, 512, NULL, 0)) {
-		char *id = NULL;
-		struct json_iterator it =
-			JSON_ITERATOR_INIT(out.buf, get_repository_id, &id);
+	/*
+	 * The GVFS protocol is only supported via https://; For testing, we
+	 * also allow http://.
+	 */
+	if (can_url_support_gvfs(url)) {
+		cp.git_cmd = 1;
+		strvec_pushl(&cp.args, "gvfs-helper", "--remote", url,
+			     "endpoint", "vsts/info", NULL);
+		if (!pipe_command(&cp, NULL, 0, &out, 512, NULL, 0)) {
+			char *id = NULL;
+			struct json_iterator it =
+				JSON_ITERATOR_INIT(out.buf, get_repository_id,
+						   &id);
 
-		if (iterate_json(&it) < 0)
-			warning("JSON parse error (%s)", out.buf);
-		else if (id)
-			cache_key = xstrfmt("id_%s", id);
-		free(id);
+			if (iterate_json(&it) < 0)
+				warning("JSON parse error (%s)", out.buf);
+			else if (id)
+				cache_key = xstrfmt("id_%s", id);
+			free(id);
+		}
 	}
 
 	if (!cache_key) {

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1142,6 +1142,25 @@ static int cmd_delete(int argc, const char **argv)
 	return delete_enlistment();
 }
 
+static int cmd_help(int argc, const char **argv)
+{
+	struct option options[] = {
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar help"),
+		NULL
+	};
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (argc != 0)
+		usage_with_options(usage, options);
+
+	return run_git("help", "scalar", NULL);
+}
+
 static int cmd_version(int argc, const char **argv)
 {
 	int verbose = 0, build_options = 0;
@@ -1182,6 +1201,7 @@ struct {
 	{ "reconfigure", cmd_reconfigure },
 	{ "diagnose", cmd_diagnose },
 	{ "delete", cmd_delete },
+	{ "help", cmd_help },
 	{ "version", cmd_version },
 	{ NULL, NULL},
 };

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -158,6 +158,7 @@ static int set_recommended_config(int reconfigure)
 		 */
 		{ "core.useBuiltinFSMonitor", "true" },
 #endif
+		{ "core.configWriteLockTimeoutMS", "150" },
 		{ NULL, NULL },
 	};
 	int i;
@@ -203,15 +204,24 @@ static int set_recommended_config(int reconfigure)
 
 static int toggle_maintenance(int enable)
 {
+	unsigned long ul;
+
+	if (git_config_get_ulong("core.configWriteLockTimeoutMS", &ul))
+		git_config_push_parameter("core.configWriteLockTimeoutMS=150");
+
 	return run_git("maintenance", enable ? "start" : "unregister", NULL);
 }
 
 static int add_or_remove_enlistment(int add)
 {
 	int res;
+	unsigned long ul;
 
 	if (!the_repository->worktree)
 		die(_("Scalar enlistments require a worktree"));
+
+	if (git_config_get_ulong("core.configWriteLockTimeoutMS", &ul))
+		git_config_push_parameter("core.configWriteLockTimeoutMS=150");
 
 	res = run_git("config", "--global", "--get", "--fixed-value",
 		      "scalar.repo", the_repository->worktree, NULL);

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -253,6 +253,31 @@ static int start_fsmonitor_daemon(void)
 	return 0;
 }
 
+static int stop_fsmonitor_daemon(void)
+{
+#ifdef HAVE_FSMONITOR_DAEMON_BACKEND
+	struct strbuf err = STRBUF_INIT;
+	struct child_process cp = CHILD_PROCESS_INIT;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "fsmonitor--daemon", "stop", NULL);
+	if (!pipe_command(&cp, NULL, 0, NULL, 0, &err, 0)) {
+		strbuf_release(&err);
+		return 0;
+	}
+
+	if (fsmonitor_ipc__get_state() == IPC_STATE__LISTENING) {
+		write_in_full(2, err.buf, err.len);
+		strbuf_release(&err);
+		return error(_("could not stop the FSMonitor daemon"));
+	}
+
+	strbuf_release(&err);
+#endif
+
+	return 0;
+}
+
 static int register_dir(void)
 {
 	int res = add_or_remove_enlistment(1);
@@ -277,6 +302,9 @@ static int unregister_dir(void)
 		res = -1;
 
 	if (add_or_remove_enlistment(0) < 0)
+		res = -1;
+
+	if (stop_fsmonitor_daemon() < 0)
 		res = -1;
 
 	return res;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -13,6 +13,7 @@
 #include "simple-ipc.h"
 #include "fsmonitor-ipc.h"
 #include "json-parser.h"
+#include "remote.h"
 
 static int is_unattended(void) {
 	return git_env_bool("Scalar_UNATTENDED", 0);
@@ -529,6 +530,21 @@ static int set_config(const char *fmt, ...)
 	return res;
 }
 
+static int list_cache_server_urls(struct json_iterator *it)
+{
+	const char *p;
+	char *q;
+	long l;
+
+	if (it->type == JSON_STRING &&
+	    skip_iprefix(it->key.buf, ".CacheServers[", &p) &&
+	    (l = strtol(p, &q, 10)) >= 0 && p != q &&
+	    !strcasecmp(q, "].Url"))
+		printf("#%ld: %s\n", l, it->string_value.buf);
+
+	return 0;
+}
+
 /* Find N for which .CacheServers[N].GlobalDefault == true */
 static int get_cache_server_index(struct json_iterator *it)
 {
@@ -598,6 +614,16 @@ static int supports_gvfs_protocol(const char *url, char **cache_server_url)
 			JSON_ITERATOR_INIT(out.buf, get_cache_server_index, &l);
 		struct cache_server_url_data data = { .url = NULL };
 
+		if (!cache_server_url) {
+			it.fn = list_cache_server_urls;
+			if (iterate_json(&it) < 0) {
+				strbuf_release(&out);
+				return error("JSON parse error");
+			}
+			strbuf_release(&out);
+			return 0;
+		}
+
 		if (iterate_json(&it) < 0) {
 			strbuf_release(&out);
 			return error("JSON parse error");
@@ -614,7 +640,9 @@ static int supports_gvfs_protocol(const char *url, char **cache_server_url)
 		return 1;
 	}
 	strbuf_release(&out);
-	return 0; /* error out quietly */
+	/* error out quietly, unless we wanted to list URLs */
+	return cache_server_url ?
+		0 : error(_("Could not access gvfs/config endpoint"));
 }
 
 static char *default_cache_root(const char *root)
@@ -1512,6 +1540,77 @@ static int cmd_version(int argc, const char **argv)
 	return 0;
 }
 
+static int cmd_cache_server(int argc, const char **argv)
+{
+	int get = 0;
+	char *set = NULL, *list = NULL;
+	const char *default_remote = "(default)";
+	struct option options[] = {
+		OPT_BOOL(0, "get", &get,
+			 N_("get the configured cache-server URL")),
+		OPT_STRING(0, "set", &set, N_("URL"),
+			    N_("configure the cache-server to use")),
+		{ OPTION_STRING, 0, "list", &list, N_("remote"),
+		  N_("list the possible cache-server URLs"),
+		  PARSE_OPT_OPTARG, NULL, (intptr_t) default_remote },
+		OPT_END(),
+	};
+	const char * const usage[] = {
+		N_("scalar cache_server "
+		   "[--get | --set <url> | --list [<remote>]] [<enlistment>]"),
+		NULL
+	};
+	int res = 0;
+
+	argc = parse_options(argc, argv, NULL, options,
+			     usage, 0);
+
+	if (get + !!set + !!list > 1)
+		usage_msg_opt(_("--get/--set/--list are mutually exclusive"),
+			      usage, options);
+
+	setup_enlistment_directory(argc, argv, usage, options);
+
+	if (list) {
+		const char *name = list, *url = list;
+
+		if (list == default_remote)
+			list = NULL;
+
+		if (!list || !strchr(list, '/')) {
+			struct remote *remote;
+
+			/* Look up remote */
+			remote = remote_get(list);
+			if (!remote) {
+				error("no such remote: '%s'", name);
+				free(list);
+				return 1;
+			}
+			if (remote->url == 0) {
+				free(list);
+				return error(_("remote '%s' has no URLs"),
+					     name);
+			}
+			url = remote->url[0];
+		}
+		res = supports_gvfs_protocol(url, NULL);
+		free(list);
+	} else if (set) {
+		res = set_config("gvfs.cache-server=%s", set);
+		free(set);
+	} else {
+		char *url = NULL;
+
+		printf("Using cache server: %s\n",
+		       git_config_get_string("gvfs.cache-server", &url) ?
+		       "(undefined)" : url);
+		free(url);
+	}
+
+	return !!res;
+}
+
 struct {
 	const char *name;
 	int (*fn)(int, const char **);
@@ -1526,6 +1625,7 @@ struct {
 	{ "delete", cmd_delete },
 	{ "help", cmd_help },
 	{ "version", cmd_version },
+	{ "cache-server", cmd_cache_server },
 	{ NULL, NULL},
 };
 

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -14,6 +14,10 @@
 #include "fsmonitor-ipc.h"
 #include "json-parser.h"
 
+static int is_unattended(void) {
+	return git_env_bool("Scalar_UNATTENDED", 0);
+}
+
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
 				       const struct option *options)
@@ -83,6 +87,19 @@ static int run_git(const char *arg, ...)
 
 	strvec_clear(&argv);
 	return res;
+}
+
+static const char *ensure_absolute_path(const char *path, char **absolute)
+{
+	struct strbuf buf = STRBUF_INIT;
+
+	if (is_absolute_path(path))
+		return path;
+
+	strbuf_realpath_forgiving(&buf, path, 1);
+	free(*absolute);
+	*absolute = strbuf_detach(&buf, NULL);
+	return *absolute;
 }
 
 static int set_recommended_config(int reconfigure)
@@ -584,6 +601,87 @@ static int supports_gvfs_protocol(const char *url, char **cache_server_url)
 	return 0; /* error out quietly */
 }
 
+static char *default_cache_root(const char *root)
+{
+	const char *env;
+
+	if (is_unattended())
+		return xstrfmt("%s/.scalarCache", root);
+
+#ifdef WIN32
+	(void)env;
+	return xstrfmt("%.*s.scalarCache", offset_1st_component(root), root);
+#elif defined(__APPLE__)
+	if ((env = getenv("HOME")) && *env)
+		return xstrfmt("%s/.scalarCache", env);
+	return NULL;
+#else
+	if ((env = getenv("XDG_CACHE_HOME")) && *env)
+		return xstrfmt("%s/scalar", env);
+	if ((env = getenv("HOME")) && *env)
+		return xstrfmt("%s/.cache/scalar", env);
+	return NULL;
+#endif
+}
+
+static int get_repository_id(struct json_iterator *it)
+{
+	if (it->type == JSON_STRING &&
+	    !strcasecmp(".repository.id", it->key.buf)) {
+		*(char **)it->fn_data = strbuf_detach(&it->string_value, NULL);
+		return 1;
+	}
+
+	return 0;
+}
+
+/* Needs to run this in a worktree; gvfs-helper requires a Git repository */
+static char *get_cache_key(const char *url)
+{
+	struct child_process cp = CHILD_PROCESS_INIT;
+	struct strbuf out = STRBUF_INIT;
+	char *cache_key = NULL;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "gvfs-helper", "--remote", url,
+		     "endpoint", "vsts/info", NULL);
+	if (!pipe_command(&cp, NULL, 0, &out, 512, NULL, 0)) {
+		char *id = NULL;
+		struct json_iterator it =
+			JSON_ITERATOR_INIT(out.buf, get_repository_id, &id);
+
+		if (iterate_json(&it) < 0)
+			warning("JSON parse error (%s)", out.buf);
+		else if (id)
+			cache_key = xstrfmt("id_%s", id);
+		free(id);
+	}
+
+	if (!cache_key) {
+		struct strbuf downcased = STRBUF_INIT;
+		int hash_algo_index = hash_algo_by_name("sha1");
+		const struct git_hash_algo *hash_algo = hash_algo_index < 0 ?
+			the_hash_algo : &hash_algos[hash_algo_index];
+		git_hash_ctx ctx;
+		unsigned char hash[GIT_MAX_RAWSZ];
+
+		strbuf_addstr(&downcased, url);
+		strbuf_tolower(&downcased);
+
+		hash_algo->init_fn(&ctx);
+		hash_algo->update_fn(&ctx, downcased.buf, downcased.len);
+		hash_algo->final_fn(hash, &ctx);
+
+		strbuf_release(&downcased);
+
+		cache_key = xstrfmt("url_%s",
+				    hash_to_hex_algop(hash, hash_algo));
+	}
+
+	strbuf_release(&out);
+	return cache_key;
+}
+
 static char *remote_default_branch(const char *url)
 {
 	struct child_process cp = CHILD_PROCESS_INIT;
@@ -677,8 +775,8 @@ static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
 	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
-	const char *cache_server_url = NULL;
-	char *default_cache_server_url = NULL;
+	const char *cache_server_url = NULL, *local_cache_root = NULL;
+	char *default_cache_server_url = NULL, *local_cache_root_abs = NULL;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -693,6 +791,9 @@ static int cmd_clone(int argc, const char **argv)
 		OPT_STRING(0, "cache-server-url", &cache_server_url,
 			   N_("<url>"),
 			   N_("the url or friendly name of the cache server")),
+		OPT_STRING(0, "local-cache-path", &local_cache_root,
+			   N_("<path>"),
+			   N_("override the path for the local Scalar cache")),
 		OPT_END(),
 	};
 	const char * const clone_usage[] = {
@@ -701,6 +802,7 @@ static int cmd_clone(int argc, const char **argv)
 	};
 	const char *url;
 	char *enlistment = NULL, *dir = NULL;
+	char *cache_key = NULL, *shared_cache_path = NULL;
 	struct strbuf buf = STRBUF_INIT;
 	int res;
 
@@ -731,7 +833,19 @@ static int cmd_clone(int argc, const char **argv)
 	if (is_directory(enlistment))
 		die(_("directory '%s' exists already"), enlistment);
 
+	ensure_absolute_path(enlistment, &enlistment);
+
 	dir = xstrfmt("%s/src", enlistment);
+
+	if (!local_cache_root)
+		local_cache_root = local_cache_root_abs =
+			default_cache_root(enlistment);
+	else
+		local_cache_root = ensure_absolute_path(local_cache_root,
+							&local_cache_root_abs);
+
+	if (!local_cache_root)
+		die(_("could not determine local cache root"));
 
 	strbuf_reset(&buf);
 	if (branch)
@@ -752,13 +866,57 @@ static int cmd_clone(int argc, const char **argv)
 
 	setup_git_directory();
 
+	git_config(git_default_config, NULL);
+
+	/*
+	 * This `dir_inside_of()` call relies on git_config() having parsed the
+	 * newly-initialized repository config's `core.ignoreCase` value.
+	 */
+	if (dir_inside_of(local_cache_root, dir) >= 0) {
+		struct strbuf path = STRBUF_INIT;
+
+		strbuf_addstr(&path, enlistment);
+		if (chdir("../..") < 0 ||
+		    remove_dir_recursively(&path, 0) < 0)
+			die(_("'--local-cache-path' cannot be inside the src "
+			      "folder;\nCould not remove '%s'"), enlistment);
+
+		die(_("'--local-cache-path' cannot be inside the src folder"));
+	}
+
 	/* common-main already logs `argv` */
 	trace2_data_string("scalar", the_repository, "dir", dir);
+	trace2_data_intmax("scalar", the_repository, "unattended",
+			   is_unattended());
 
 	if (!branch && !(branch = remote_default_branch(url))) {
 		res = error(_("failed to get default branch for '%s'"), url);
 		goto cleanup;
 	}
+
+	if (!(cache_key = get_cache_key(url))) {
+		res = error(_("could not determine cache key for '%s'"), url);
+		goto cleanup;
+	}
+
+	shared_cache_path = xstrfmt("%s/%s", local_cache_root, cache_key);
+	if (set_config("gvfs.sharedCache=%s", shared_cache_path)) {
+		res = error(_("could not configure shared cache"));
+		goto cleanup;
+	}
+
+	strbuf_reset(&buf);
+	strbuf_addf(&buf, "%s/pack", shared_cache_path);
+	switch (safe_create_leading_directories(buf.buf)) {
+	case SCLD_OK: case SCLD_EXISTS:
+		break; /* okay */
+	default:
+		res = error_errno(_("could not initialize '%s'"), buf.buf);
+		goto cleanup;
+	}
+
+	write_file_buf(git_path("objects/info/alternates"),
+		       shared_cache_path, strlen(shared_cache_path));
 
 	if (set_config("remote.origin.url=%s", url) ||
 	    set_config("remote.origin.fetch="
@@ -838,6 +996,9 @@ cleanup:
 	free(dir);
 	strbuf_release(&buf);
 	free(default_cache_server_url);
+	free(local_cache_root_abs);
+	free(cache_key);
+	free(shared_cache_path);
 	return res;
 }
 
@@ -950,7 +1111,7 @@ static int cmd_diagnose(int argc, const char **argv)
 	time_t now = time(NULL);
 	struct tm tm;
 	struct strbuf path = STRBUF_INIT, buf = STRBUF_INIT;
-	char *cache_server_url = NULL;
+	char *cache_server_url = NULL, *shared_cache = NULL;
 	int res = 0;
 
 	argc = parse_options(argc, argv, NULL, options,
@@ -976,8 +1137,10 @@ static int cmd_diagnose(int argc, const char **argv)
 	strbuf_addf(&buf, "Enlistment root: %s\n", the_repository->worktree);
 
 	git_config_get_string("gvfs.cache-server", &cache_server_url);
-	strbuf_addf(&buf, "Cache Server: %s\n\n",
-		    cache_server_url ? cache_server_url : "None");
+	git_config_get_string("gvfs.sharedCache", &shared_cache);
+	strbuf_addf(&buf, "Cache Server: %s\nLocal Cache: %s\n\n",
+		    cache_server_url ? cache_server_url : "None",
+		    shared_cache ? shared_cache : "None");
 	get_disk_info(&buf);
 	fwrite(buf.buf, buf.len, 1, stdout);
 
@@ -1019,6 +1182,7 @@ diagnose_cleanup:
 	strbuf_release(&path);
 	strbuf_release(&buf);
 	free(cache_server_url);
+	free(shared_cache);
 
 	return res;
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -12,6 +12,7 @@
 #include "dir.h"
 #include "simple-ipc.h"
 #include "fsmonitor-ipc.h"
+#include "json-parser.h"
 
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
@@ -509,6 +510,80 @@ static int set_config(const char *fmt, ...)
 	return res;
 }
 
+/* Find N for which .CacheServers[N].GlobalDefault == true */
+static int get_cache_server_index(struct json_iterator *it)
+{
+	const char *p;
+	char *q;
+	long l;
+
+	if (it->type == JSON_TRUE &&
+	    skip_iprefix(it->key.buf, ".CacheServers[", &p) &&
+	    (l = strtol(p, &q, 10)) >= 0 && p != q &&
+	    !strcasecmp(q, "].GlobalDefault")) {
+		*(long *)it->fn_data = l;
+		return 1;
+	}
+
+	return 0;
+}
+
+struct cache_server_url_data {
+	char *key, *url;
+};
+
+/* Get .CacheServers[N].Url */
+static int get_cache_server_url(struct json_iterator *it)
+{
+	struct cache_server_url_data *data = it->fn_data;
+
+	if (it->type == JSON_STRING &&
+	    !strcasecmp(data->key, it->key.buf)) {
+		data->url = strbuf_detach(&it->string_value, NULL);
+		return 1;
+	}
+
+	return 0;
+}
+
+/*
+ * If `cache_server_url` is `NULL`, print the list to `stdout`.
+ *
+ * Since `gvfs-helper` requires a Git directory, this _must_ be run in
+ * a worktree.
+ */
+static int supports_gvfs_protocol(const char *url, char **cache_server_url)
+{
+	struct child_process cp = CHILD_PROCESS_INIT;
+	struct strbuf out = STRBUF_INIT;
+
+	cp.git_cmd = 1;
+	strvec_pushl(&cp.args, "gvfs-helper", "--remote", url, "config", NULL);
+	if (!pipe_command(&cp, NULL, 0, &out, 512, NULL, 0)) {
+		long l = 0;
+		struct json_iterator it =
+			JSON_ITERATOR_INIT(out.buf, get_cache_server_index, &l);
+		struct cache_server_url_data data = { .url = NULL };
+
+		if (iterate_json(&it) < 0) {
+			strbuf_release(&out);
+			return error("JSON parse error");
+		}
+		data.key = xstrfmt(".CacheServers[%ld].Url", l);
+		it.fn = get_cache_server_url;
+		it.fn_data = &data;
+		if (iterate_json(&it) < 0) {
+			strbuf_release(&out);
+			return error("JSON parse error");
+		}
+		*cache_server_url = data.url;
+		free(data.key);
+		return 1;
+	}
+	strbuf_release(&out);
+	return 0; /* error out quietly */
+}
+
 static char *remote_default_branch(const char *url)
 {
 	struct child_process cp = CHILD_PROCESS_INIT;
@@ -602,6 +677,8 @@ static int cmd_clone(int argc, const char **argv)
 {
 	const char *branch = NULL;
 	int no_fetch_commits_and_trees = 0, full_clone = 0, single_branch = 0;
+	const char *cache_server_url = NULL;
+	char *default_cache_server_url = NULL;
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
 			   N_("branch to checkout after clone")),
@@ -613,6 +690,9 @@ static int cmd_clone(int argc, const char **argv)
 		OPT_BOOL(0, "single-branch", &single_branch,
 			 N_("only download metadata for the branch that will "
 			    "be checked out")),
+		OPT_STRING(0, "cache-server-url", &cache_server_url,
+			   N_("<url>"),
+			   N_("the url or friendly name of the cache server")),
 		OPT_END(),
 	};
 	const char * const clone_usage[] = {
@@ -684,11 +764,39 @@ static int cmd_clone(int argc, const char **argv)
 	    set_config("remote.origin.fetch="
 		    "+refs/heads/%s:refs/remotes/origin/%s",
 		    single_branch ? branch : "*",
-		    single_branch ? branch : "*") ||
-	    set_config("remote.origin.promisor=true") ||
-	    set_config("remote.origin.partialCloneFilter=blob:none")) {
+		    single_branch ? branch : "*")) {
 		res = error(_("could not configure remote in '%s'"), dir);
 		goto cleanup;
+	}
+
+	if (set_config("credential.https://dev.azure.com.useHttpPath=true")) {
+		res = error(_("could not configure credential.useHttpPath"));
+		goto cleanup;
+	}
+
+	if (cache_server_url ||
+	    supports_gvfs_protocol(url, &default_cache_server_url)) {
+		if (!cache_server_url)
+			cache_server_url = default_cache_server_url;
+		if (set_config("core.useGVFSHelper=true") ||
+		    set_config("core.gvfs=150") ||
+		    set_config("http.version=HTTP/1.1")) {
+			res = error(_("could not turn on GVFS helper"));
+			goto cleanup;
+		}
+		if (cache_server_url &&
+		    set_config("gvfs.cache-server=%s", cache_server_url)) {
+			res = error(_("could not configure cache server"));
+			goto cleanup;
+		}
+	} else {
+		if (set_config("core.useGVFSHelper=false") ||
+		    set_config("remote.origin.promisor=true") ||
+		    set_config("remote.origin.partialCloneFilter=blob:none")) {
+			res = error(_("could not configure partial clone in "
+				      "'%s'"), dir);
+			goto cleanup;
+		}
 	}
 
 	if (!full_clone &&
@@ -729,6 +837,7 @@ cleanup:
 	free(enlistment);
 	free(dir);
 	strbuf_release(&buf);
+	free(default_cache_server_url);
 	return res;
 }
 
@@ -841,6 +950,7 @@ static int cmd_diagnose(int argc, const char **argv)
 	time_t now = time(NULL);
 	struct tm tm;
 	struct strbuf path = STRBUF_INIT, buf = STRBUF_INIT;
+	char *cache_server_url = NULL;
 	int res = 0;
 
 	argc = parse_options(argc, argv, NULL, options,
@@ -864,6 +974,10 @@ static int cmd_diagnose(int argc, const char **argv)
 	get_version_info(&buf, 1);
 
 	strbuf_addf(&buf, "Enlistment root: %s\n", the_repository->worktree);
+
+	git_config_get_string("gvfs.cache-server", &cache_server_url);
+	strbuf_addf(&buf, "Cache Server: %s\n\n",
+		    cache_server_url ? cache_server_url : "None");
 	get_disk_info(&buf);
 	fwrite(buf.buf, buf.len, 1, stdout);
 
@@ -904,6 +1018,7 @@ diagnose_cleanup:
 	strbuf_release(&tmp_dir);
 	strbuf_release(&path);
 	strbuf_release(&buf);
+	free(cache_server_url);
 
 	return res;
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1326,6 +1326,12 @@ int cmd_main(int argc, const char **argv)
 	struct strbuf scalar_usage = STRBUF_INIT;
 	int i;
 
+	if (is_unattended()) {
+		setenv("GIT_ASKPASS", "", 0);
+		setenv("GIT_TERMINAL_PROMPT", "false", 0);
+		git_config_push_parameter("credential.interactive=never");
+	}
+
 	while (argc > 1 && *argv[1] == '-') {
 		if (!strcmp(argv[1], "-C")) {
 			if (argc < 3)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -385,7 +385,7 @@ static int stage(const char *git_dir, struct strbuf *buf, const char *path)
 	return res;
 }
 
-static int stage_file(const char *git_dir, const char *path)
+static int stage_file(const char *git_dir, const char *path, size_t skip_chars)
 {
 	struct strbuf buf = STRBUF_INIT;
 	int res;
@@ -393,13 +393,14 @@ static int stage_file(const char *git_dir, const char *path)
 	if (strbuf_read_file(&buf, path, 0) < 0)
 		return error(_("could not read '%s'"), path);
 
-	res = stage(git_dir, &buf, path);
+	res = stage(git_dir, &buf, path + skip_chars);
 
 	strbuf_release(&buf);
 	return res;
 }
 
-static int stage_directory(const char *git_dir, const char *path, int recurse)
+static int stage_directory(const char *git_dir,
+			   const char *path, size_t skip_chars, int recurse)
 {
 	int at_root = !*path;
 	DIR *dir = opendir(at_root ? "." : path);
@@ -422,9 +423,10 @@ static int stage_directory(const char *git_dir, const char *path, int recurse)
 		strbuf_setlen(&buf, len);
 		strbuf_addstr(&buf, e->d_name);
 
-		if ((e->d_type == DT_REG && stage_file(git_dir, buf.buf)) ||
+		if ((e->d_type == DT_REG &&
+		     stage_file(git_dir, buf.buf, skip_chars)) ||
 		    (e->d_type == DT_DIR && recurse &&
-		     stage_directory(git_dir, buf.buf, recurse)))
+		     stage_directory(git_dir, buf.buf, skip_chars, recurse)))
 			res = -1;
 	}
 
@@ -1159,12 +1161,33 @@ static int cmd_diagnose(int argc, const char **argv)
 	if ((res = stage(tmp_dir.buf, &buf, "objects-local.txt")))
 		goto diagnose_cleanup;
 
-	if ((res = stage_directory(tmp_dir.buf, ".git", 0)) ||
-	    (res = stage_directory(tmp_dir.buf, ".git/hooks", 0)) ||
-	    (res = stage_directory(tmp_dir.buf, ".git/info", 0)) ||
-	    (res = stage_directory(tmp_dir.buf, ".git/logs", 1)) ||
-	    (res = stage_directory(tmp_dir.buf, ".git/objects/info", 0)))
+	if ((res = stage_directory(tmp_dir.buf, ".git", 0, 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/hooks", 0, 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/info", 0, 0)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/logs", 0, 1)) ||
+	    (res = stage_directory(tmp_dir.buf, ".git/objects/info", 0, 0)))
 		goto diagnose_cleanup;
+
+	if (shared_cache) {
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/pack", shared_cache);
+		strbuf_reset(&buf);
+		dir_file_stats(&buf, path.buf);
+		if ((res = stage(tmp_dir.buf, &buf, "packs-cached.txt")))
+			goto diagnose_cleanup;
+
+		strbuf_reset(&buf);
+		loose_objs_stats(&buf, shared_cache);
+		if ((res = stage(tmp_dir.buf, &buf, "objects-cached.txt")))
+			goto diagnose_cleanup;
+
+		strbuf_reset(&path);
+		strbuf_addf(&path, "%s/info", shared_cache);
+		if (is_directory(path.buf) &&
+		    (res = stage_directory(tmp_dir.buf,
+					   path.buf, path.len - 4, 0)))
+			goto diagnose_cleanup;
+	}
 
 	res = index_to_zip(tmp_dir.buf);
 

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -1,0 +1,47 @@
+scalar(1)
+=========
+
+NAME
+----
+scalar - an opinionated repository management tool
+
+SYNOPSIS
+--------
+[verse]
+scalar <command> [<options>]
+
+DESCRIPTION
+-----------
+
+Scalar is an opinionated repository management tool. By creating new
+repositories or registering existing repositories with Scalar, your Git
+experience will speed up. Scalar sets advanced Git config settings,
+maintains your repositories in the background, and helps reduce data sent
+across the network.
+
+An important Scalar concept is the enlistment: this is the top-level directory
+of the project. It contains the subdirectory `src/` which is a Git worktree.
+This encourages the separation between tracked files (inside `src/`) and
+untracked files (outside `src/`).
+
+The command implements various subcommands, and different options depending
+on the subcommand. With the exception of `clone` and `list`, all subcommands
+expect to be run in an enlistment.
+
+The following options can be specified _before_ the subcommand:
+
+-C <directory>::
+    Before running the subcommand, change the working directory. This
+    option imitates the same option of linkgit:git[1].
+
+-c <key>=<value>::
+    For the duration of running the specified subcommand, configure this
+    setting. This option imitates the same option of linkgit:git[1].
+
+SEE ALSO
+--------
+linkgit:git-clone[1], linkgit:git-maintenance[1].
+
+Scalar
+---
+Associated with the linkgit:git[1] suite

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -13,6 +13,10 @@ scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
+scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]
+scalar reconfigure [ --all | <enlistment> ]
+scalar diagnose [<enlistment>]
+scalar delete <enlistment>
 
 DESCRIPTION
 -----------
@@ -107,6 +111,54 @@ unregister [<enlistment>]::
     Remove the specified repository from the list of repositories
     registered with Scalar. This stops the scheduled maintenance and the
     built-in FSMonitor.
+
+Run
+~~~
+
+scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) [<enlistment>]::
+    Run the given maintenance task (or all tasks, if `all` was specified).
+    Except for `all` and `config`, this subcommand simply hands off to
+    linkgit:git-maintenance[1] (mapping `fetch` to `prefetch` and
+    `pack-files` to `incremental-repack`).
++
+These tasks are run automatically as part of the scheduled maintenance,
+as soon as the repository is registered with Scalar. It should therefore
+not be necessary to run this command manually.
++
+The `config` task is specific to Scalar and configures all those
+opinionated default settings that make Git work more efficiently with
+large repositories. As this task is run as part of `scalar clone`
+automatically, explicit invocations of this task are rarely needed.
+
+Reconfigure
+~~~~~~~~~~~
+
+After a Scalar upgrade, or when the configuration of a Scalar enlistment
+was somehow corrupted or changed by mistake, this command allows to
+reconfigure the enlistment.
+
+With the `--all` option, all enlistments currently registered with Scalar
+will be reconfigured. This option is meant to to be run every time Scalar
+was upgraded.
+
+Diagnose
+~~~~~~~~
+
+diagnose [<enlistment>]::
+    When reporting issues with Scalar, it is often helpful to provide the
+    information gathered by this command, including logs and certain
+    statistics describing the data shape of the current enlistment.
++
+The output of this command is a `.zip` file that is written into
+a directory adjacent to the worktree in the `src` directory.
+
+Delete
+~~~~~~
+
+delete <enlistment>::
+    This command lets you delete an existing Scalar enlistment from your
+    local file system, unregistering the repository and stopping any file
+    watcher daemons (FSMonitor).
 
 SEE ALSO
 --------

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -9,7 +9,8 @@ SYNOPSIS
 --------
 [verse]
 scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
-         [--no-fetch-commits-and-trees] <url> [<enlistment>]
+         [--no-fetch-commits-and-trees] [--local-cache-path <path>]
+         [--cache-server-url <url>] <url> [<enlistment>]
 scalar list
 scalar register [<enlistment>]
 scalar unregister [<enlistment>]
@@ -87,6 +88,17 @@ cloning. If the HEAD at the remote did not point at any branch when
     The default behavior is to clone all commit and tree objects, with blob
     objects being fetched on demand. With the `--no-fetch-commits-and-trees`
     option, commit and tree objects are also fetched only as needed.
+
+--local-cache-path <path>::
+    Override the path to the local cache root directory; Pre-fetched objects
+    are stored into a repository-dependent subdirectory of that path.
++
+The default is `<drive>:\.scalarCache` on Windows (on the same drive as the
+clone), and `~/.scalarCache` on macOS.
+
+--cache-server-url <url>::
+    Retrieve missing objects from the specified remote, which is expected to
+    understand the GVFS protocol.
 
 List
 ~~~~

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -10,6 +10,9 @@ SYNOPSIS
 [verse]
 scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
          [--no-fetch-commits-and-trees] <url> [<enlistment>]
+scalar list
+scalar register [<enlistment>]
+scalar unregister [<enlistment>]
 
 DESCRIPTION
 -----------
@@ -80,6 +83,30 @@ cloning. If the HEAD at the remote did not point at any branch when
     The default behavior is to clone all commit and tree objects, with blob
     objects being fetched on demand. With the `--no-fetch-commits-and-trees`
     option, commit and tree objects are also fetched only as needed.
+
+List
+~~~~
+
+list::
+    To see which repositories are currently registered by the service, run
+    `scalar list`. This command, like `clone`, does not need to be run
+    inside a Git worktree.
+
+Register
+~~~~~~~~
+
+register [<enlistment>]::
+    Adds a repository to the list of registered repositories. If
+    `<enlistment>` is not provided, then the enlistment associated with the
+    current working directory is registered.
+
+Unregister
+~~~~~~~~~~
+
+unregister [<enlistment>]::
+    Remove the specified repository from the list of repositories
+    registered with Scalar. This stops the scheduled maintenance and the
+    built-in FSMonitor.
 
 SEE ALSO
 --------

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -8,7 +8,8 @@ scalar - an opinionated repository management tool
 SYNOPSIS
 --------
 [verse]
-scalar <command> [<options>]
+scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]
+         [--no-fetch-commits-and-trees] <url> [<enlistment>]
 
 DESCRIPTION
 -----------
@@ -37,6 +38,48 @@ The following options can be specified _before_ the subcommand:
 -c <key>=<value>::
     For the duration of running the specified subcommand, configure this
     setting. This option imitates the same option of linkgit:git[1].
+
+COMMANDS
+--------
+
+Clone
+~~~~~
+
+clone [<options>] <url> [<enlistment>]::
+    Clones the specified repository, similar to linkgit:git-clone[1]. By
+    default, only commit and tree objects are cloned. Once finished, the
+    worktree is located at `<enlistment>/src`.
++
+The sparse-checkout feature is enabled (except when run with `--full-clone`)
+and the only files present are those in the top-level directory. Use
+`git sparse-checkout set` to expand the set of directories you want to see,
+or `git sparse-checkout disable` to expand to all files (see
+linkgit:git-sparse-checkout[1] for more details). You can explore the
+subdirectories outside your sparse-checkout by using `git ls-tree HEAD`.
+
+-b <name>::
+--branch <name>::
+	Instead of checking out the branch pointed to by the cloned repository's
+    HEAD, check out the `<name>` branch instead.
+
+--[no-]single-branch::
+	Clone only the history leading to the tip of a single branch,
+	either specified by the `--branch` option or the primary
+	branch remote's `HEAD` points at.
++
+Further fetches into the resulting repository will only update the
+remote-tracking branch for the branch this option was used for the initial
+cloning. If the HEAD at the remote did not point at any branch when
+`--single-branch` clone was made, no remote-tracking branch is created.
+
+--[no-]full-clone::
+    A sparse-checkout is initialized by default. This behavior can be turned
+    off via `--no-full-clone`.
+
+--[no-]fetch-commits-and-trees::
+    The default behavior is to clone all commit and tree objects, with blob
+    objects being fetched on demand. With the `--no-fetch-commits-and-trees`
+    option, commit and tree objects are also fetched only as needed.
 
 SEE ALSO
 --------

--- a/contrib/scalar/scalar.txt
+++ b/contrib/scalar/scalar.txt
@@ -18,6 +18,7 @@ scalar run ( all | config | commit-graph | fetch | loose-objects | pack-files ) 
 scalar reconfigure [ --all | <enlistment> ]
 scalar diagnose [<enlistment>]
 scalar delete <enlistment>
+scalar cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]
 
 DESCRIPTION
 -----------
@@ -171,6 +172,27 @@ delete <enlistment>::
     This command lets you delete an existing Scalar enlistment from your
     local file system, unregistering the repository and stopping any file
     watcher daemons (FSMonitor).
+
+Cache-server
+~~~~~~~~~~~~
+
+cache-server ( --get | --set <url> | --list [<remote>] ) [<enlistment>]::
+    This command lets you query or set the GVFS-enabled cache server used
+    to fetch missing objects.
+
+--get::
+    This is the default command mode: query the currently-configured cache
+    server URL, if any.
+
+--list::
+    Access the `gvfs/info` endpoint of the specified remote (default:
+    `origin`) to figure out which cache servers are available, if any.
++
+In contrast to the `--get` command mode (which only accesses the local
+repository), this command mode triggers a request via the network that
+potentially requires authentication. If authentication is required, the
+configured credential helper is employed (see linkgit:git-credential[1]
+for details).
 
 SEE ALSO
 --------

--- a/contrib/scalar/t/Makefile
+++ b/contrib/scalar/t/Makefile
@@ -1,0 +1,78 @@
+# Run scalar tests
+#
+# Copyright (c) 2005,2021 Junio C Hamano, Johannes Schindelin
+#
+
+-include ../../../config.mak.autogen
+-include ../../../config.mak
+
+SHELL_PATH ?= $(SHELL)
+PERL_PATH ?= /usr/bin/perl
+RM ?= rm -f
+PROVE ?= prove
+DEFAULT_TEST_TARGET ?= test
+TEST_LINT ?= test-lint
+
+ifdef TEST_OUTPUT_DIRECTORY
+TEST_RESULTS_DIRECTORY = $(TEST_OUTPUT_DIRECTORY)/test-results
+else
+TEST_RESULTS_DIRECTORY = ../../../t/test-results
+endif
+
+# Shell quote;
+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
+PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
+TEST_RESULTS_DIRECTORY_SQ = $(subst ','\'',$(TEST_RESULTS_DIRECTORY))
+
+T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
+
+all: $(DEFAULT_TEST_TARGET)
+
+test: $(TEST_LINT)
+	$(MAKE) aggregate-results-and-cleanup
+
+prove: $(TEST_LINT)
+	@echo "*** prove ***"; GIT_CONFIG=.git/config $(PROVE) --exec '$(SHELL_PATH_SQ)' $(GIT_PROVE_OPTS) $(T) :: $(GIT_TEST_OPTS)
+	$(MAKE) clean-except-prove-cache
+
+$(T):
+	@echo "*** $@ ***"; GIT_CONFIG=.git/config '$(SHELL_PATH_SQ)' $@ $(GIT_TEST_OPTS)
+
+clean-except-prove-cache:
+	$(RM) -r 'trash directory'.* '$(TEST_RESULTS_DIRECTORY_SQ)'
+	$(RM) -r valgrind/bin
+
+clean: clean-except-prove-cache
+	$(RM) .prove
+
+test-lint: test-lint-duplicates test-lint-executable test-lint-shell-syntax
+
+test-lint-duplicates:
+	@dups=`echo $(T) | tr ' ' '\n' | sed 's/-.*//' | sort | uniq -d` && \
+		test -z "$$dups" || { \
+		echo >&2 "duplicate test numbers:" $$dups; exit 1; }
+
+test-lint-executable:
+	@bad=`for i in $(T); do test -x "$$i" || echo $$i; done` && \
+		test -z "$$bad" || { \
+		echo >&2 "non-executable tests:" $$bad; exit 1; }
+
+test-lint-shell-syntax:
+	@'$(PERL_PATH_SQ)' ../../../t/check-non-portable-shell.pl $(T)
+
+aggregate-results-and-cleanup: $(T)
+	$(MAKE) aggregate-results
+	$(MAKE) clean
+
+aggregate-results:
+	for f in '$(TEST_RESULTS_DIRECTORY_SQ)'/t*-*.counts; do \
+		echo "$$f"; \
+	done | '$(SHELL_PATH_SQ)' ../../../t/aggregate-results.sh
+
+valgrind:
+	$(MAKE) GIT_TEST_OPTS="$(GIT_TEST_OPTS) --valgrind"
+
+test-results:
+	mkdir -p test-results
+
+.PHONY: $(T) aggregate-results clean valgrind

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -65,4 +65,12 @@ test_expect_success 'scalar clone' '
 	)
 '
 
+test_expect_success 'scalar reconfigure' '
+	git init one/src &&
+	scalar register one &&
+	git -C one/src config core.preloadIndex false &&
+	scalar reconfigure one &&
+	test true = "$(git -C one/src config core.preloadIndex)"
+'
+
 test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -70,6 +70,9 @@ test_expect_success 'scalar reconfigure' '
 	scalar register one &&
 	git -C one/src config core.preloadIndex false &&
 	scalar reconfigure one &&
+	test true = "$(git -C one/src config core.preloadIndex)" &&
+	git -C one/src config core.preloadIndex false &&
+	scalar reconfigure -a &&
 	test true = "$(git -C one/src config core.preloadIndex)"
 '
 

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -45,12 +45,16 @@ test_expect_success 'set up repository to clone' '
 
 test_expect_success 'scalar clone' '
 	second=$(git rev-parse --verify second:second.t) &&
-	scalar clone "file://$(pwd)" cloned &&
+	scalar clone "file://$(pwd)" cloned --single-branch &&
 	(
 		cd cloned/src &&
 
 		git config --get --global --fixed-value maintenance.repo \
 			"$(pwd)" &&
+
+		git for-each-ref --format="%(refname)" refs/remotes/origin/ >actual &&
+		echo "refs/remotes/origin/parallel" >expect &&
+		test_cmp expect actual &&
 
 		test_path_is_missing 1/2 &&
 		test_must_fail git rev-list --missing=print $second &&

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -14,4 +14,19 @@ test_expect_success 'scalar shows a usage' '
 	test_expect_code 129 scalar -h
 '
 
+test_expect_success 'scalar unregister' '
+	git init vanish/src &&
+	scalar register vanish/src &&
+	git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/vanish/src" &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/vanish/src" scalar.repos &&
+	rm -rf vanish/src/.git &&
+	scalar unregister vanish &&
+	test_must_fail git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/vanish/src" &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/vanish/src" scalar.repos
+'
+
 test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -77,6 +77,8 @@ test_expect_success UNZIP 'scalar diagnose' '
 	unzip -p "$zip_path" diagnostics.log >out &&
 	test_file_not_empty out &&
 	unzip -p "$zip_path" packs-local.txt >out &&
+	test_file_not_empty out &&
+	unzip -p "$zip_path" objects-local.txt >out &&
 	test_file_not_empty out
 '
 

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -65,6 +65,19 @@ test_expect_success 'scalar clone' '
 	)
 '
 
+SQ="'"
+test_expect_success UNZIP 'scalar diagnose' '
+	scalar diagnose cloned >out &&
+	sed -n "s/.*$SQ\\(.*\\.zip\\)$SQ.*/\\1/p" <out >zip_path &&
+	zip_path=$(cat zip_path) &&
+	test -n "$zip_path" &&
+	unzip -v "$zip_path" &&
+	folder=${zip_path%.zip} &&
+	test_path_is_missing "$folder" &&
+	unzip -p "$zip_path" diagnostics.log >out &&
+	test_file_not_empty out
+'
+
 test_expect_success 'scalar reconfigure' '
 	git init one/src &&
 	scalar register one &&

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -13,6 +13,13 @@ PATH=$(pwd)/..:$PATH
 GIT_TEST_MAINT_SCHEDULER="crontab:test-tool crontab ../cron.txt"
 export GIT_TEST_MAINT_SCHEDULER
 
+# Do not write any files outside the trash directory
+Scalar_UNATTENDED=1
+export Scalar_UNATTENDED
+
+GIT_ASKPASS=true
+export GIT_ASKPASS
+
 test_lazy_prereq BUILTIN_FSMONITOR '
 	git version --build-options | grep -q "feature:.*fsmonitor--daemon"
 '

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -75,6 +75,8 @@ test_expect_success UNZIP 'scalar diagnose' '
 	folder=${zip_path%.zip} &&
 	test_path_is_missing "$folder" &&
 	unzip -p "$zip_path" diagnostics.log >out &&
+	test_file_not_empty out &&
+	unzip -p "$zip_path" packs-local.txt >out &&
 	test_file_not_empty out
 '
 

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -13,8 +13,19 @@ PATH=$(pwd)/..:$PATH
 GIT_TEST_MAINT_SCHEDULER="crontab:test-tool crontab ../cron.txt"
 export GIT_TEST_MAINT_SCHEDULER
 
+test_lazy_prereq BUILTIN_FSMONITOR '
+	git version --build-options | grep -q "feature:.*fsmonitor--daemon"
+'
+
 test_expect_success 'scalar shows a usage' '
 	test_expect_code 129 scalar -h
+'
+
+test_expect_success BUILTIN_FSMONITOR 'scalar register starts fsmon daemon' '
+	git init test/src &&
+	test_must_fail git -C test/src fsmonitor--daemon status &&
+	scalar register test/src &&
+	git -C test/src fsmonitor--daemon status
 '
 
 test_expect_success 'scalar unregister' '

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+test_description='test the `scalar` command'
+
+TEST_DIRECTORY=$(pwd)/../../../t
+export TEST_DIRECTORY
+
+# Make it work with --no-bin-wrappers
+PATH=$(pwd)/..:$PATH
+
+. ../../../t/test-lib.sh
+
+test_expect_success 'scalar shows a usage' '
+	test_expect_code 129 scalar -h
+'
+
+test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -120,4 +120,88 @@ test_expect_success 'scalar delete with enlistment' '
 	test_path_is_missing cloned
 '
 
+GIT_TEST_ALLOW_GVFS_VIA_HTTP=1
+export GIT_TEST_ALLOW_GVFS_VIA_HTTP
+
+test_set_port GIT_TEST_GVFS_PROTOCOL_PORT
+HOST_PORT=127.0.0.1:$GIT_TEST_GVFS_PROTOCOL_PORT
+PID_FILE="$(pwd)"/pid-file.pid
+SERVER_LOG="$(pwd)"/OUT.server.log
+
+test_atexit '
+	test -f "$PID_FILE" || return 0
+
+	# The server will shutdown automatically when we delete the pid-file.
+	rm -f "$PID_FILE"
+
+	test -z "$verbose$verbose_log" || {
+		echo "server log:"
+		cat "$SERVER_LOG"
+	}
+
+	# Give it a few seconds to shutdown (mainly to completely release the
+	# port before the next test start another instance and it attempts to
+	# bind to it).
+	for k in $(test_seq 5)
+	do
+		grep -q "Starting graceful shutdown" "$SERVER_LOG" &&
+		return 0 ||
+		sleep 1
+	done
+
+	echo "stop_gvfs_protocol_server: timeout waiting for server shutdown"
+	return 1
+'
+
+start_gvfs_enabled_http_server () {
+	GIT_HTTP_EXPORT_ALL=1 \
+	test-gvfs-protocol --verbose \
+		--listen=127.0.0.1 \
+		--port=$GIT_TEST_GVFS_PROTOCOL_PORT \
+		--reuseaddr \
+		--pid-file="$PID_FILE" \
+		2>"$SERVER_LOG" &
+
+	for k in 0 1 2 3 4
+	do
+		if test -f "$PID_FILE"
+		then
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}
+
+test_expect_success 'start GVFS-enabled server' '
+	git config uploadPack.allowFilter false &&
+	git config uploadPack.allowAnySHA1InWant false &&
+	start_gvfs_enabled_http_server
+'
+
+test_expect_success '`scalar clone` with GVFS-enabled server' '
+	: the fake cache server requires fake authentication &&
+	git config --global core.askPass true &&
+	scalar clone --single-branch -- http://$HOST_PORT/ using-gvfs &&
+
+	: verify that the shared cache has been configured &&
+	cache_key="url_$(printf "%s" http://$HOST_PORT/ |
+		tr A-Z a-z |
+		test-tool sha1)" &&
+	echo "$(pwd)/using-gvfs/.scalarCache/$cache_key" >expect &&
+	git -C using-gvfs/src config gvfs.sharedCache >actual &&
+	test_cmp expect actual &&
+
+	second=$(git rev-parse --verify second:second.t) &&
+	(
+		cd using-gvfs/src &&
+		test_path_is_missing 1/2 &&
+		GIT_TRACE=$PWD/trace.txt git cat-file blob $second >actual &&
+		: verify that the gvfs-helper was invoked to fetch it &&
+		test_i18ngrep gvfs-helper trace.txt &&
+		echo "second" >expect &&
+		test_cmp expect actual
+	)
+'
+
 test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -93,4 +93,13 @@ test_expect_success 'scalar reconfigure' '
 	test true = "$(git -C one/src config core.preloadIndex)"
 '
 
+test_expect_success 'scalar delete without enlistment shows a usage' '
+	test_expect_code 129 scalar delete
+'
+
+test_expect_success 'scalar delete with enlistment' '
+	scalar delete cloned &&
+	test_path_is_missing cloned
+'
+
 test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -10,6 +10,9 @@ PATH=$(pwd)/..:$PATH
 
 . ../../../t/test-lib.sh
 
+GIT_TEST_MAINT_SCHEDULER="crontab:test-tool crontab ../cron.txt"
+export GIT_TEST_MAINT_SCHEDULER
+
 test_expect_success 'scalar shows a usage' '
 	test_expect_code 129 scalar -h
 '
@@ -27,6 +30,35 @@ test_expect_success 'scalar unregister' '
 		maintenance.repo "$(pwd)/vanish/src" &&
 	scalar list >scalar.repos &&
 	! grep -F "$(pwd)/vanish/src" scalar.repos
+'
+
+test_expect_success 'set up repository to clone' '
+	test_commit first &&
+	test_commit second &&
+	test_commit third &&
+	git switch -c parallel first &&
+	mkdir -p 1/2 &&
+	test_commit 1/2/3 &&
+	git config uploadPack.allowFilter true &&
+	git config uploadPack.allowAnySHA1InWant true
+'
+
+test_expect_success 'scalar clone' '
+	second=$(git rev-parse --verify second:second.t) &&
+	scalar clone "file://$(pwd)" cloned &&
+	(
+		cd cloned/src &&
+
+		git config --get --global --fixed-value maintenance.repo \
+			"$(pwd)" &&
+
+		test_path_is_missing 1/2 &&
+		test_must_fail git rev-list --missing=print $second &&
+		git rev-list $second &&
+		git cat-file blob $second >actual &&
+		echo "second" >expect &&
+		test_cmp expect actual
+	)
 '
 
 test_done

--- a/dir.c
+++ b/dir.c
@@ -2962,6 +2962,8 @@ static int cmp_icase(char a, char b)
 {
 	if (a == b)
 		return 0;
+	if (is_dir_sep(a))
+		return is_dir_sep(b) ? 0 : -1;
 	if (ignore_case)
 		return toupper(a) - toupper(b);
 	return a - b;

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -202,6 +202,12 @@
 //            [2] Documentation/technical/long-running-process-protocol.txt
 //            [3] See GIT_TRACE_PACKET
 //
+//     endpoint
+//
+//            Fetch the given endpoint from the main Git server (specifying
+//            `gvfs/config` as endpoint is idempotent to the `config`
+//            command mentioned above).
+//
 //////////////////////////////////////////////////////////////////
 
 #include "cache.h"
@@ -3097,18 +3103,20 @@ static void do_req__with_fallback(const char *url_component,
  *
  * Return server's response buffer.  This is probably a raw JSON string.
  */
-static void do__http_get__gvfs_config(struct gh__response_status *status,
-				      struct strbuf *config_data)
+static void do__http_get__simple_endpoint(struct gh__response_status *status,
+					  struct strbuf *response,
+					  const char *endpoint,
+					  const char *tr2_label)
 {
 	struct gh__request_params params = GH__REQUEST_PARAMS_INIT;
 
-	strbuf_addstr(&params.tr2_label, "GET/config");
+	strbuf_addstr(&params.tr2_label, tr2_label);
 
 	params.b_is_post = 0;
 	params.b_write_to_file = 0;
 	/* cache-servers do not handle gvfs/config REST calls */
 	params.b_permit_cache_server_if_defined = 0;
-	params.buffer = config_data;
+	params.buffer = response;
 	params.objects_mode = GH__OBJECTS_MODE__NONE;
 
 	params.object_count = 1; /* a bit of a lie */
@@ -3130,13 +3138,20 @@ static void do__http_get__gvfs_config(struct gh__response_status *status,
 		 * see any need to report progress on the upload side of
 		 * the GET.  So just report progress on the download side.
 		 */
-		strbuf_addstr(&params.progress_base_phase3_msg,
-			      "Receiving gvfs/config");
+		strbuf_addf(&params.progress_base_phase3_msg,
+			    "Receiving %s", endpoint);
 	}
 
-	do_req__with_fallback("gvfs/config", &params, status);
+	do_req__with_fallback(endpoint, &params, status);
 
 	gh__request_params__release(&params);
+}
+
+static void do__http_get__gvfs_config(struct gh__response_status *status,
+				      struct strbuf *config_data)
+{
+	return do__http_get__simple_endpoint(status, config_data, "gvfs/config",
+					     "GET/config");
 }
 
 static void setup_gvfs_objects_progress(struct gh__request_params *params,
@@ -3579,6 +3594,35 @@ static enum gh__error_code do_sub_cmd__config(int argc, const char **argv)
 
 	gh__response_status__release(&status);
 	strbuf_release(&config_data);
+
+	return ec;
+}
+
+static enum gh__error_code do_sub_cmd__endpoint(int argc, const char **argv)
+{
+	struct gh__response_status status = GH__RESPONSE_STATUS_INIT;
+	struct strbuf data = STRBUF_INIT;
+	enum gh__error_code ec = GH__ERROR_CODE__OK;
+	const char *endpoint;
+
+	if (argc != 2)
+		return GH__ERROR_CODE__ERROR;
+	endpoint = argv[1];
+
+	trace2_cmd_mode(endpoint);
+
+	finish_init(0);
+
+	do__http_get__simple_endpoint(&status, &data, endpoint, endpoint);
+	ec = status.ec;
+
+	if (ec == GH__ERROR_CODE__OK)
+		printf("%s\n", data.buf);
+	else
+		error("config: %s", status.error_message.buf);
+
+	gh__response_status__release(&status);
+	strbuf_release(&data);
 
 	return ec;
 }
@@ -4073,6 +4117,9 @@ static enum gh__error_code do_sub_cmd(int argc, const char **argv)
 
 	if (!strcmp(argv[0], "config"))
 		return do_sub_cmd__config(argc, argv);
+
+	if (!strcmp(argv[0], "endpoint"))
+		return do_sub_cmd__endpoint(argc, argv);
 
 	if (!strcmp(argv[0], "prefetch"))
 		return do_sub_cmd__prefetch(argc, argv);

--- a/t/helper/test-gvfs-protocol.c
+++ b/t/helper/test-gvfs-protocol.c
@@ -1480,6 +1480,8 @@ done:
 
 static enum worker_result dispatch(struct req *req)
 {
+	static regex_t *smart_http_regex;
+	static int initialized;
 	const char *method;
 	enum worker_result wr;
 
@@ -1526,6 +1528,53 @@ static enum worker_result dispatch(struct req *req)
 
 		if (!strcmp(method, "GET"))
 			return do__gvfs_prefetch__get(req);
+	}
+
+	if (!initialized) {
+		smart_http_regex = xmalloc(sizeof(*smart_http_regex));
+		if (regcomp(smart_http_regex, "^/(HEAD|info/refs|"
+			    "objects/info/[^/]+|git-(upload|receive)-pack)$",
+			    REG_EXTENDED)) {
+			warning("could not compile smart HTTP regex");
+			smart_http_regex = NULL;
+		}
+		initialized = 1;
+	}
+
+	if (smart_http_regex &&
+	    !regexec(smart_http_regex, req->uri_base.buf, 0, NULL, 0)) {
+		const char *ok = "HTTP/1.1 200 OK\r\n";
+		struct child_process cp = CHILD_PROCESS_INIT;
+		int i, res;
+
+		if (write(1, ok, strlen(ok)) < 0)
+			return error(_("could not send '%s'"), ok);
+
+		strvec_pushf(&cp.env_array, "REQUEST_METHOD=%s", method);
+		strvec_pushf(&cp.env_array, "PATH_TRANSLATED=%s",
+			     req->uri_base.buf);
+		/* Prevent MSYS2 from "converting to a Windows path" */
+		strvec_pushf(&cp.env_array,
+			     "MSYS2_ENV_CONV_EXCL=PATH_TRANSLATED");
+		strvec_push(&cp.env_array, "SERVER_PROTOCOL=HTTP/1.1");
+		if (req->quest_args.len)
+			strvec_pushf(&cp.env_array, "QUERY_STRING=%s",
+				     req->quest_args.buf);
+		for (i = 0; i < req->header_list.nr; i++) {
+			const char *header = req->header_list.items[i].string;
+			if (!strncasecmp("Content-Type: ", header, 14))
+				strvec_pushf(&cp.env_array, "CONTENT_TYPE=%s",
+					     header + 14);
+			else if (!strncasecmp("Content-Length: ", header, 16))
+				strvec_pushf(&cp.env_array, "CONTENT_LENGTH=%s",
+					     header + 16);
+		}
+		cp.git_cmd = 1;
+		strvec_push(&cp.args, "http-backend");
+		res = run_command(&cp);
+		close(1);
+		close(0);
+		return !!res;
 	}
 
 	return send_http_error(1, 501, "Not Implemented", -1,

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -578,6 +578,23 @@ test_expect_success 'start and stop macOS maintenance' '
 	test_line_count = 0 actual
 '
 
+test_expect_success 'use launchctl list to prevent extra work' '
+	# ensure we are registered
+	GIT_TEST_MAINT_SCHEDULER=launchctl:./print-args git maintenance start &&
+
+	# do it again on a fresh args file
+	rm -f args &&
+	GIT_TEST_MAINT_SCHEDULER=launchctl:./print-args git maintenance start &&
+
+	ls "$HOME/Library/LaunchAgents" >actual &&
+	cat >expect <<-\EOF &&
+	list org.git-scm.git.hourly
+	list org.git-scm.git.daily
+	list org.git-scm.git.weekly
+	EOF
+	test_cmp expect args
+'
+
 test_expect_success 'start and stop Windows maintenance' '
 	write_script print-args <<-\EOF &&
 	echo $* >>args


### PR DESCRIPTION
[Scalar](https://github.com/microsoft/scalar#readme) is, in its own words, "an opinionated repository management tool". It builds on top of Git and aims to make it easy and effortless to work with large repositories.

Originally built using .NET, with the take-home lessons from VFS for Git, Scalar provides sort of a laboratory for experimenting with tactics and strategies to help Git scale better. Many recent scalability improvements in Git originate from Scalar, for example:

- partial clone
- sparse checkout (cone mode)
- commit graphs
- multi-pack indices
- scheduled maintenance
- prefetch
- ...

While providing an experimentation lab outside of Git, the intention of the Scalar project always was to ship its improvements into core Git (i.e. to "upstream" them). As the list above demonstrates, it worked.

It worked so much that there are essentially only very few bits and pieces that are not (yet) upstreamed. The remaining parts fall roughly into these categories:

- The `scalar` executable itself
- The concept of an "enlistment", where the Git-tracked files live in the `src/` subdirectory (which is the actual Git worktree), to encourage clear separation of tracked vs untracked files
- A list of registered Scalar enlistments that is maintained independently from the list of Git repositories registered with `git maintenance`
- A set of recommended config settings that get configured upon `scalar clone` or `scalar register`
- Support for side-stepping the missing partial clone support in Azure Repos by using the GVFS protocol instead via the `gvfs-helper`

While the `gvfs-helper` part is very unlikely to ever make it into core Git, the remainder can easily be contributed in the form of `contrib/scalar/`.

This Pull Request adds these parts, in a neatly-structured thicket of topic branches, and it concludes the effort of three developers and almost two months.