### PR TITLE
ensure that the version is based on a new-enough `.vfs.` tag

### DIFF
--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -16,6 +16,11 @@ elif test -d ${GIT_DIR:-.git} -o -f .git &&
 	case "$VN" in
 	*$LF*) (exit 1) ;;
 	v[0-9]*)
+		if test "${VN%%.vfs.*}" != "${DEF_VER%%.vfs.*}"
+		then
+			echo "Found version $VN, which is not based on $DEF_VER" >&2
+			exit 1
+		fi
 		git update-index -q --refresh
 		test -z "$(git diff-index --name-only HEAD --)" ||
 		VN="$VN-dirty" ;;


### PR DESCRIPTION
I managed to fool myself into a lengthy debug session because Scalar's Functional Tests were broken with my rebase to v2.32.0-rc3. Turns out that it is really, really important that the version number is correct, otherwise Scalar will assume that there is no `git maintenance` built-in and then go on to do unexpected things.