### PR TITLE
write-or-die: revert fsync_or_die() change on Windows

### DIFF
--- a/write-or-die.c
+++ b/write-or-die.c
@@ -57,7 +57,11 @@ void fprintf_or_die(FILE *f, const char *fmt, ...)
 
 void fsync_or_die(int fd, const char *msg)
 {
+#ifdef WIN32
+	if (fsync(fd) < 0) {
+#else
 	while (fsync(fd) < 0) {
+#endif
 		if (errno != EINTR)
 			die_errno("fsync error on '%s'", msg);
 	}


### PR DESCRIPTION
This method was changed in cccdfd22 (fsync(): be prepared to see EINTR,
2021-06-04) rather late in the v2.32.0 cycle and seems to be causing a
problem with the FS Monitor feature.

I found this by diffing the last successful run of the Scalar functional
tests against the `v2.32.0.vfs.0.0` tag, focused on `*.c` files.