### PR TITLE
Fix the built-in FSMonitor, and run Scalar's Functional Tests as part of the automated builds

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -1,0 +1,216 @@
+name: Scalar Functional Tests
+
+env:
+  SCALAR_REPOSITORY: dscho/scalar
+  SCALAR_REF: vfs-2.32.0
+  DEBUG_WITH_TMATE: false
+
+on:
+  push:
+    branches: [ vfs-* ]
+  pull_request:
+    branches: [ vfs-* ]
+
+jobs:
+  scalar:
+    name: "Scalar Functional Tests"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Order by runtime (in descending order)
+        os: [windows-2019, macos-10.15, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        features: [false, experimental]
+        exclude:
+          # The built-in FSMonitor is not (yet) supported on Linux
+          - os: ubuntu-16.04
+            features: experimental
+          - os: ubuntu-18.04
+            features: experimental
+          - os: ubuntu-20.04
+            features: experimental
+    runs-on: ${{ matrix.os }}
+
+    env:
+      BUILD_FRAGMENT: bin/Release/netcoreapp3.1
+
+    steps:
+      - name: Check out Git's source code
+        uses: actions/checkout@v2
+
+      - name: Setup build tools on Windows
+        if: runner.os == 'Windows'
+        uses: git-for-windows/setup-git-for-windows-sdk@v1
+
+      - name: Provide a minimal `install` on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          test -x /usr/bin/install ||
+          tr % '\t' >/usr/bin/install <<-\EOF
+          #!/bin/sh
+
+          cmd=cp
+          while test $# != 0
+          do
+          %case "$1" in
+          %-d) cmd="mkdir -p";;
+          %-m) shift;; # ignore mode
+          %*) break;;
+          %esac
+          %shift
+          done
+
+          exec $cmd "$@"
+          EOF
+
+      - name: Install build dependencies for Git (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get -q -y install libssl-dev libcurl4-openssl-dev gettext
+
+      - name: Build and install Git
+        shell: bash
+        env:
+          NO_TCLTK: Yup
+        run: |
+          # We do require a VFS version
+          def_ver="$(sed -n 's/DEF_VER=\(.*vfs.*\)/\1/p' GIT-VERSION-GEN)"
+          test -n "$def_ver"
+
+          # Ensure that `git version` reflects DEF_VER
+          case "$(git describe --match "v[0-9]*vfs*" HEAD)" in
+          ${def_ver%%.vfs.*}.vfs.*) ;; # okay, we can use this
+          *) git -c user.name=ci -c user.email=ci@github tag -m for-testing ${def_ver}.NNN.g$(git rev-parse --short HEAD);;
+          esac
+
+          SUDO=
+          extra=
+          case "${{ runner.os }}" in
+          Windows)
+            extra=DESTDIR=/c/Progra~1/Git
+            cygpath -aw "/c/Program Files/Git/cmd" >>$GITHUB_PATH
+            ;;
+          Linux)
+            SUDO=sudo
+            extra=prefix=/usr
+            ;;
+          macOS)
+            SUDO=sudo
+            extra=prefix=/usr/local
+            ;;
+          esac
+
+          $SUDO make -j5 $extra install
+
+      - name: Ensure that we use the built Git (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          cmd /c where git
+          git version
+          if ((git version) -like "*.vfs.*") { echo Good } else { exit 1 }
+
+      - name: Check out Scalar's source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+          path: scalar
+          repository: ${{ env.SCALAR_REPOSITORY }}
+          ref: ${{ env.SCALAR_REF }}
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.302
+
+      - name: Install dependencies
+        run: dotnet restore
+        working-directory: scalar
+        env:
+          DOTNET_NOLOGO: 1
+
+      - name: Build
+        working-directory: scalar
+        run: dotnet build --configuration Release --no-restore -p:UseAppHost=true # Force generation of executable on macOS.
+
+      - name: Setup platform (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          echo "BUILD_PLATFORM=${{ runner.os }}" >>$GITHUB_ENV
+          echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.features }}" >>$GITHUB_ENV
+
+      - name: Setup platform (Mac)
+        if: runner.os == 'macOS'
+        run: |
+          echo 'BUILD_PLATFORM=Mac' >>$GITHUB_ENV
+          echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.features }}" >>$GITHUB_ENV
+
+      - name: Setup platform (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "BUILD_PLATFORM=${{ runner.os }}" >>$env:GITHUB_ENV
+          echo 'BUILD_FILE_EXT=.exe' >>$env:GITHUB_ENV
+          echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.features }}" >>$env:GITHUB_ENV
+
+      - name: Configure feature.scalar
+        run: git config --global feature.scalar ${{ matrix.features }}
+
+      - id: functional_test
+        name: Functional test
+        timeout-minutes: 60
+        working-directory: scalar
+        shell: bash
+        run: |
+          export GIT_TRACE2_EVENT="$PWD/$TRACE2_BASENAME/Event"
+          export GIT_TRACE2_PERF="$PWD/$TRACE2_BASENAME/Perf"
+          export GIT_TRACE2_EVENT_BRIEF=true
+          export GIT_TRACE2_PERF_BRIEF=true
+          mkdir -p "$TRACE2_BASENAME"
+          mkdir -p "$TRACE2_BASENAME/Event"
+          mkdir -p "$TRACE2_BASENAME/Perf"
+          git version --build-options
+          cd ../out
+          PATH="$PWD/Scalar/$BUILD_FRAGMENT:$PWD/Scalar.Service/$BUILD_FRAGMENT:$PATH"
+          Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --test-git-on-path --timeout=300000 --full-suite
+
+      - name: Force-stop FSMonitor daemons and Git processes (Windows)
+        if: runner.os == 'Windows' && matrix.features == 'experimental' && (success() || failure())
+        shell: bash
+        run: |
+          set -x
+          wmic process get CommandLine,ExecutablePath,HandleCount,Name,ParentProcessID,ProcessID
+          wmic process where "CommandLine Like '%fsmonitor--daemon %run'" delete
+          wmic process where "ExecutablePath Like '%git.exe'" delete
+
+      - id: trace2_zip_unix
+        if: runner.os != 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+        name: Zip Trace2 Logs (Unix)
+        shell: bash
+        working-directory: scalar
+        run: zip -q -r $TRACE2_BASENAME.zip $TRACE2_BASENAME/
+
+      - id: trace2_zip_windows
+        if: runner.os == 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+        name: Zip Trace2 Logs (Windows)
+        working-directory: scalar
+        run: Compress-Archive -DestinationPath ${{ env.TRACE2_BASENAME }}.zip -Path ${{ env.TRACE2_BASENAME }}
+
+      - name: Archive Trace2 Logs
+        if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows.conclusion == 'success' )
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TRACE2_BASENAME }}.zip
+          path: scalar/${{ env.TRACE2_BASENAME }}.zip
+          retention-days: 3
+
+      # The GitHub Action `action-tmate` allows developers to connect to the running agent
+      # using SSH (it will be a `tmux` session; on Windows agents it will be inside the MSYS2
+      # environment in `C:\msys64`, therefore it can be slightly tricky to interact with
+      # Git for Windows, which runs a slightly incompatible MSYS2 runtime).
+      - name: action-tmate
+        if: env.DEBUG_WITH_TMATE == 'true' && failure()
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true

--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -694,7 +694,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 					 "fsmonitor: invalid V2 protocol token '%s'",
 					 command);
 			do_trivial = 1;
-			do_cookie = 1;
 
 		} else {
 			/*

--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -672,7 +672,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 		 */
 		do_flush = 1;
 		do_trivial = 1;
-		do_cookie = 1;
 
 	} else if (!skip_prefix(command, "builtin:", &p)) {
 		/* assume V1 timestamp or garbage */

--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -685,7 +685,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 				  "fsmonitor: unsupported V1 protocol '%s'"),
 				 command);
 		do_trivial = 1;
-		do_cookie = 1;
 
 	} else {
 		/* We have "builtin:*" */

--- a/fsmonitor-ipc.c
+++ b/fsmonitor-ipc.c
@@ -44,7 +44,7 @@ int fsmonitor_ipc__send_query(const char *since_token,
 	trace2_region_enter("fsm_client", "query", NULL);
 
 	trace2_data_string("fsm_client", NULL, "query/command",
-			   since_token ? since_token : "(null-token)");
+			   since_token);
 
 try_again:
 	state = ipc_client_try_connect(fsmonitor_ipc__get_path(), &options,
@@ -53,7 +53,7 @@ try_again:
 	switch (state) {
 	case IPC_STATE__LISTENING:
 		ret = ipc_client_send_command_to_connection(
-			connection, since_token, since_token ? strlen(since_token) : 0, answer);
+			connection, since_token, strlen(since_token), answer);
 		ipc_client_close_connection(connection);
 
 		trace2_data_intmax("fsm_client", NULL,

--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -290,8 +290,9 @@ void refresh_fsmonitor(struct index_state *istate)
 	trace_printf_key(&trace_fsmonitor, "refresh fsmonitor");
 
 	if (r->settings.use_builtin_fsmonitor > 0) {
-		query_success = !fsmonitor_ipc__send_query(
-			istate->fsmonitor_last_update, &query_result);
+		query_success = istate->fsmonitor_last_update &&
+			!fsmonitor_ipc__send_query(istate->fsmonitor_last_update,
+						   &query_result);
 		if (query_success) {
 			/*
 			 * The response contains a series of nul terminated


### PR DESCRIPTION
Without Scalar's Functional Tests, I would not have caught two bugs causing segmentation faults in the built-in FSMonitor (which I have fixed in time for Git for Windows v2.32.0) nor the bug where the FSMonitor just _hangs_ (which I unfortunately did not catch in time for Git for Windows v2.32.0, but at least we can fix it in v2.32.0.vfs.*).

However, running the Functional Tests locally, I could not reproduce the bugs! The hang simply did not happen here, and the segmentation faults were only triggered when Trace2 was enabled (which I had not done locally). Therefore, the (epic) bug hunt really boiled down to running Scalar's Functional Tests using GitHub Actions, over and over and over again.

It was a bit cumbersome to run the tests using GitHub Actions, though, because the original setup required a successful run of the Azure Pipeline `build git installers` to build full installers for a given `microsoft/git` branch (which would have been a PR branch such as `refs/pull/348/head`), and then a PR branch of `microsoft/scalar` to point to that successful build. Not only does that take 30-45 minutes simply to build the installers, but there are three manual steps involved, each gated on the success of the previous step.

This PR adds a new GitHub workflow that makes all of that testing a lot nicer: just push a PR branch of `microsoft/git` and Scalar's Functional Tests will be built and run as part of the automated builds.

I used this very workflow to investigate the remaining problems of `vfs-2.32.0` that were demonstrated by Scalar's Functional Tests:
- I first ran it with `vfs-2.32.0` (plus this workflow), then reverted the built-in FSMonitor v1 -> v2 changes and ran it again, to verify that the problems were due to this upgrade (as opposed to independent changes coming in via v2.31.1 -> v2.32.0).
- Then, I added the built-in FSMonitor v1 -> v2 changes back, incrementally, to see where things break.
- To use my time efficiently, I pushed these incremental changes without waiting for the Functional Tests to finish.
- That way, two days and 55 runs later (each of which took between 25-60 minutes), I could pinpoint the exact change that caused the regression.

The result is the trio of `fixup! fsmonitor--daemon: use a cookie file to sync with file system` patches, which fixes the hang in Scalar's Functional Tests.

While at it, I also realized that the two fixups to built-in FSMonitor v2 that I integrated into Git for Windows v2.32.0 were actually only work-arounds, and in this PR I also provide a fix for the root cause (`fixup! fsmonitor: introduce `core.useBuiltinFSMonitor` to call the daemon via IPC`, which ensures that `fsmonitor_ipc__send_query()` is never called with a `since_token` that is `NULL`).