### PR TITLE
gvfs-helper: always keep index-pack silent

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1840,13 +1840,19 @@ static void my_run_index_pack(struct gh__request_params *params,
 
 	strvec_push(&ip.args, "git");
 	strvec_push(&ip.args, "index-pack");
-	if (gh__cmd_opts.show_progress)
+
+	if (gh__cmd_opts.show_progress) {
 		strvec_push(&ip.args, "-v");
+		ip.err = 0;
+	} else {
+		ip.err = -1;
+		ip.no_stderr = 1;
+	}
+
 	strvec_pushl(&ip.args, "-o", temp_path_idx->buf, NULL);
 	strvec_push(&ip.args, temp_path_pack->buf);
 	ip.no_stdin = 1;
 	ip.out = -1;
-	ip.err = -1;
 
 	if (pipe_command(&ip, NULL, 0, &ip_stdout, 0, NULL, 0)) {
 		unlink(temp_path_pack->buf);


### PR DESCRIPTION
Due to how we are calling 'git index-pack' and piping stdout, I found an
instance where our 'git index-pack' subcommand is timing out. Since we
are using pipe_command() to get the stdout and use that hash to create
a new filename, the 'ip.stderr = -1' line breaks the expected behavior,
especially when providing '-v'.

Let's be more careful about stderr when cloning.

The case I saw was for using the prefetch endpoint on Azure Repos on a
repo that doesn't have configured cache servers. The pack-file was over
1GB so the progress indicator reliably hit a problem.