### PR TITLE
scalar: use microsoft/scalar:main for tests

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -1,8 +1,8 @@
 name: Scalar Functional Tests
 
 env:
-  SCALAR_REPOSITORY: derrickstolee/scalar
-  SCALAR_REF: test-scalar-in-c
+  SCALAR_REPOSITORY: microsoft/scalar
+  SCALAR_REF: main
   DEBUG_WITH_TMATE: false
   SCALAR_TEST_SKIP_VSTS_INFO: true
 


### PR DESCRIPTION
We were using derrickstolee/scalar:test-scalar-in-c as a temporary
branch while we review microsoft/scalar#505 and ensure that it works as
a vehicle for tests in microsoft/git. That work is complete, so let's
update our ref to point to the official repo.