### PR TITLE
vfs: disable the built-in FSMonitor

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -59,7 +59,8 @@ void prepare_repo_settings(struct repository *r)
 		r->settings.core_multi_pack_index = value;
 	UPDATE_DEFAULT_BOOL(r->settings.core_multi_pack_index, 1);
 
-	if (!repo_config_get_bool(r, "core.usebuiltinfsmonitor", &value) && value)
+	if (!git_config_get_virtualfilesystem() &&
+	    !repo_config_get_bool(r, "core.usebuiltinfsmonitor", &value) && value)
 		r->settings.use_builtin_fsmonitor = 1;
 
 	if (!repo_config_get_bool(r, "feature.manyfiles", &value) && value) {

--- a/t/t1093-virtualfilesystem.sh
+++ b/t/t1093-virtualfilesystem.sh
@@ -368,4 +368,14 @@ test_expect_success 'folder with same prefix as file' '
 	test_cmp expected actual
 '
 
+test_expect_success 'virtualfilsystem hook disables built-in FSMonitor ' '
+	clean_repo &&
+	test_config core.usebuiltinfsmonitor true &&
+	write_script .git/hooks/virtualfilesystem <<-\EOF &&
+		printf "dir1/\0"
+	EOF
+	git status &&
+	test_must_fail git fsmonitor--daemon status
+'
+
 test_done


### PR DESCRIPTION
When using a virtual file system layer, the FSMonitor does not make sense. Therefore, let's disable it in VFS for Git enlistments.