### PR TITLE
[FOR TESTING] Enable Untracked Cache, Disable FS Monitor

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2019, macos-10.15, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [windows-2019]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -120,23 +120,7 @@ static int set_recommended_config(int reconfigure)
 		{ "core.FSCache", "true", 1 },
 		{ "core.multiPackIndex", "true", 1 },
 		{ "core.preloadIndex", "true", 1 },
-#ifndef WIN32
 		{ "core.untrackedCache", "true", 1 },
-#else
-		/*
-		 * Unfortunately, Scalar's Functional Tests demonstrated
-		 * that the untracked cache feature is unreliable on Windows
-		 * (which is a bummer because that platform would benefit the
-		 * most from it). For some reason, freshly created files seem
-		 * not to update the directory's `lastModified` time
-		 * immediately, but the untracked cache would need to rely on
-		 * that.
-		 *
-		 * Therefore, with a sad heart, we disable this very useful
-		 * feature on Windows.
-		 */
-		{ "core.untrackedCache", "false", 1 },
-#endif
 		{ "core.bare", "false", 1 },
 		{ "core.logAllRefUpdates", "true", 1 },
 		{ "credential.https://dev.azure.com.useHttpPath", "true", 1 },

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -160,12 +160,6 @@ static int set_recommended_config(int reconfigure)
 		{ "maintenance.incremental-repack.enabled", "true" },
 		{ "maintenance.incremental-repack.auto", "0" },
 		{ "maintenance.incremental-repack.schedule", "daily" },
-#ifdef HAVE_FSMONITOR_DAEMON_BACKEND
-		/*
-		 * Enable the built-in FSMonitor on supported platforms.
-		 */
-		{ "core.useBuiltinFSMonitor", "true" },
-#endif
 		{ "core.configWriteLockTimeoutMS", "150" },
 		{ NULL, NULL },
 	};


### PR DESCRIPTION
One more commit than #381: disable the FS Monitor after enabling untracked cache. Checking for failures in the Scalar functional tests.