### PR TITLE
Redo fixup for null fsmonitor_last_update

### DIFF
--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -290,9 +290,10 @@ void refresh_fsmonitor(struct index_state *istate)
 	trace_printf_key(&trace_fsmonitor, "refresh fsmonitor");
 
 	if (r->settings.use_builtin_fsmonitor > 0) {
-		query_success = istate->fsmonitor_last_update &&
-			!fsmonitor_ipc__send_query(istate->fsmonitor_last_update,
-						   &query_result);
+		query_success = !fsmonitor_ipc__send_query(
+			istate->fsmonitor_last_update ?
+			istate->fsmonitor_last_update : "builtin:fake",
+			&query_result);
 		if (query_success) {
 			/*
 			 * The response contains a series of nul terminated


### PR DESCRIPTION
If `istate->fsmonitor_last_update` is null, substitute a fake value for the token
but continue to try to talk to the daemon.  The result from the daemon will be
a trivial response, but it will include a new valid token so that the next request
will have a valid reference token.

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>

