### PR TITLE
Fix winget tag specification

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -21,7 +21,8 @@ jobs:
           Publisher: The Git Client Team at GitHub
           Moniker: microsoft-git
           PackageUrl: https://aka.ms/ms-git
-          Tags: [ microsoft-git ]
+          Tags: 
+          - microsoft-git
           License: GPLv2
           ShortDescription: |
             Git distribution to support monorepo scenarios.


### PR DESCRIPTION
According to a [recent PR](https://github.com/microsoft/winget-pkgs/pull/18410), the recommended format for winget tags has changed. Updating our manifest according to the new specification.