### PR TITLE
fixup! fixup! winget tag specification

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -21,7 +21,7 @@ jobs:
           Publisher: The Git Client Team at GitHub
           Moniker: microsoft-git
           PackageUrl: https://aka.ms/ms-git
-          Tags: 
+          Tags:
           - microsoft-git
           License: GPLv2
           ShortDescription: |


### PR DESCRIPTION
The builds are now complaining about a trailing whitespace introduced in #387. Not sure how it passed those builds, but this fixes it.