### PR TITLE
scalar clone: display the cache server URL that is used (if any)

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1007,6 +1007,9 @@ static int cmd_clone(int argc, const char **argv)
 			res = error(_("could not configure cache server"));
 			goto cleanup;
 		}
+		if (cache_server_url)
+			fprintf(stderr, "Cache server URL: %s\n",
+				cache_server_url);
 	} else {
 		if (set_config("core.useGVFSHelper=false") ||
 		    set_config("remote.origin.promisor=true") ||


### PR DESCRIPTION
The Scalar.NET version of `scalar clone` helpfully displayed any cache server URL that was used; This is such useful information that we want to do the same in Scalar/C.