### PR TITLE
sparse-index: fix crash in status

### DIFF
--- a/sparse-index.c
+++ b/sparse-index.c
@@ -295,6 +295,7 @@ void ensure_full_index(struct index_state *istate)
 
 	/* Copy back into original index. */
 	memcpy(&istate->name_hash, &full->name_hash, sizeof(full->name_hash));
+	memcpy(&istate->dir_hash, &full->dir_hash, sizeof(full->dir_hash));
 	istate->sparse_index = 0;
 	free(istate->cache);
 	istate->cache = full->cache;


### PR DESCRIPTION
This fixes a crash that was observed in `git status` during some hashmap lookups with corrupted hashmap entries.