### PR TITLE
Handle Scalar enlistments without `src` subdirectory

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1520,7 +1520,7 @@ static int cmd_unregister(int argc, const char **argv)
 		strbuf_release(&path);
 	}
 
-	setup_enlistment_directory(argc, argv, usage, options);
+	setup_enlistment_directory(argc, argv, usage, options, NULL);
 
 	return unregister_dir();
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1457,7 +1457,7 @@ static int cmd_run(int argc, const char **argv)
 
 	argc--;
 	argv++;
-	setup_enlistment_directory(argc, argv, usagestr, options);
+	setup_enlistment_directory(argc, argv, usagestr, options, NULL);
 	strbuf_release(&buf);
 
 	if (i == 0)

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -19,55 +19,91 @@ static int is_unattended(void) {
 	return git_env_bool("Scalar_UNATTENDED", 0);
 }
 
+/*
+ * Remove the deepest subdirectory in the provided path string. Path must not
+ * include a trailing path separator. Returns 1 if parent directory found,
+ * otherwise 0.
+ */
+static int strbuf_parentdir(struct strbuf *buf)
+{
+	size_t len = buf->len;
+	size_t offset = offset_1st_component(buf->buf);
+	char *path_sep = find_last_dir_sep(buf->buf + offset);
+	strbuf_setlen(buf, path_sep ? path_sep - buf->buf : offset);
+
+	return buf->len < len;
+}
+
 static void setup_enlistment_directory(int argc, const char **argv,
 				       const char * const *usagestr,
-				       const struct option *options)
+				       const struct option *options,
+				       struct strbuf *enlistment_root)
 {
+	struct strbuf path = STRBUF_INIT;
+	char *root;
+	int enlistment_found = 0;
+
 	if (startup_info->have_repository)
 		BUG("gitdir already set up?!?");
 
 	if (argc > 1)
 		usage_with_options(usagestr, options);
 
+	/* find the worktree, determine its corresponding root */
 	if (argc == 1) {
-		char *src = xstrfmt("%s/src", argv[0]);
-		const char *dir = is_directory(src) ? src : argv[0];
-
-		if (chdir(dir) < 0)
-			die_errno(_("could not switch to '%s'"), dir);
-
-		free(src);
-	} else {
-		/* find the worktree, and ensure that it is named `src` */
-		struct strbuf path = STRBUF_INIT;
-
-		if (strbuf_getcwd(&path) < 0)
-			die(_("need a working directory"));
-
-		for (;;) {
-			size_t len = path.len;
-
-			strbuf_addstr(&path, "/src/.git");
-			if (is_git_directory(path.buf)) {
-				strbuf_setlen(&path, len);
-				strbuf_addstr(&path, "/src");
-				if (chdir(path.buf) < 0)
-					die_errno(_("could not switch to '%s'"),
-						  path.buf);
-				strbuf_release(&path);
-				break;
-			}
-
-			while (len > 0 && !is_dir_sep(path.buf[--len]))
-				; /* keep looking for parent directory */
-
-			if (!len)
-				die(_("could not find enlistment root"));
-
-			strbuf_setlen(&path, len);
-		}
+		strbuf_add_absolute_path(&path, argv[0]);
+	} else if (strbuf_getcwd(&path) < 0) {
+		die(_("need a working directory"));
 	}
 
+	strbuf_trim_trailing_dir_sep(&path);
+	do {
+		const size_t len = path.len;
+
+		/* check if currently in enlistment root with src/ workdir */
+		strbuf_addstr(&path, "/src/.git");
+		if (is_git_directory(path.buf)) {
+			strbuf_strip_suffix(&path, "/.git");
+
+			if (enlistment_root)
+				strbuf_add(enlistment_root, path.buf, len);
+
+			enlistment_found = 1;
+			break;
+		}
+
+		/* reset to original path */
+		strbuf_setlen(&path, len);
+
+		/* check if currently in workdir */
+		strbuf_addstr(&path, "/.git");
+		if (is_git_directory(path.buf)) {
+			strbuf_setlen(&path, len);
+
+			if (enlistment_root) {
+				/*
+				 * If the worktree's directory's name is `src`, the enlistment is the
+				 * parent directory, otherwise it is identical to the worktree.
+				 */
+				root = strip_path_suffix(path.buf, "src");
+				strbuf_addstr(enlistment_root, root ? root : path.buf);
+				free(root);
+			}
+
+			enlistment_found = 1;
+			break;
+		}
+
+		strbuf_setlen(&path, len);
+	} while (strbuf_parentdir(&path));
+
+	if (!enlistment_found)
+		die(_("could not find enlistment root"));
+
+	if (chdir(path.buf) < 0)
+		die_errno(_("could not switch to '%s'"), path.buf);
+
+	strbuf_release(&path);
 	setup_git_directory();
 }
 
@@ -1299,7 +1335,7 @@ static int cmd_register(int argc, const char **argv)
 	argc = parse_options(argc, argv, NULL, options,
 			     usage, 0);
 
-	setup_enlistment_directory(argc, argv, usage, options);
+	setup_enlistment_directory(argc, argv, usage, options, NULL);
 
 	return register_dir();
 }

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1371,7 +1371,7 @@ static int cmd_reconfigure(int argc, const char **argv)
 			     usage, 0);
 
 	if (!all) {
-		setup_enlistment_directory(argc, argv, usage, options);
+		setup_enlistment_directory(argc, argv, usage, options, NULL);
 
 		return set_recommended_config(1);
 	}

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1628,7 +1628,7 @@ static int cmd_cache_server(int argc, const char **argv)
 		usage_msg_opt(_("--get/--set/--list are mutually exclusive"),
 			      usage, options);
 
-	setup_enlistment_directory(argc, argv, usage, options);
+	setup_enlistment_directory(argc, argv, usage, options, NULL);
 
 	if (list) {
 		const char *name = list, *url = list;

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -1221,9 +1221,9 @@ static int cmd_diagnose(int argc, const char **argv)
 	argc = parse_options(argc, argv, NULL, options,
 			     usage, 0);
 
-	setup_enlistment_directory(argc, argv, usage, options);
+	setup_enlistment_directory(argc, argv, usage, options, &buf);
 
-	strbuf_addstr(&buf, "../.scalarDiagnostics/scalar_");
+	strbuf_addstr(&buf, "/.scalarDiagnostics/scalar_");
 	strbuf_addftime(&buf, "%Y%m%d_%H%M%S", localtime_r(&now, &tm), 0, 0);
 	if (run_git("init", "-q", "-b", "dummy", "--bare", buf.buf, NULL)) {
 		res = error(_("could not initialize temporary repository: %s"),

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -204,4 +204,39 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 	)
 '
 
+test_expect_success '`scalar register` & `unregister` with existing repo' '
+	git init existing &&
+	scalar register existing &&
+	git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/existing" &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/existing" scalar.repos &&
+	scalar unregister existing &&
+	test_must_fail git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/existing" &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/existing" scalar.repos
+'
+
+test_expect_success '`scalar unregister` with existing repo, deleted .git' '
+	scalar register existing &&
+	rm -rf existing/.git &&
+	scalar unregister existing &&
+	test_must_fail git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/existing" &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/existing" scalar.repos
+'
+
+test_expect_success '`scalar register` existing repo with `src` folder' '
+	git init existing &&
+	mkdir -p existing/src &&
+	scalar register existing/src &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/existing" scalar.repos &&
+	scalar unregister existing &&
+	scalar list >scalar.repos &&
+	! grep -F "$(pwd)/existing" scalar.repos
+'
+
 test_done

--- a/contrib/scalar/t/t9099-scalar.sh
+++ b/contrib/scalar/t/t9099-scalar.sh
@@ -204,6 +204,17 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 	)
 '
 
+test_expect_success '`scalar register` parallel to worktree' '
+	git init test-repo/src &&
+	mkdir -p test-repo/out &&
+	scalar register test-repo/out &&
+	git config --get --global --fixed-value \
+		maintenance.repo "$(pwd)/test-repo/src" &&
+	scalar list >scalar.repos &&
+	grep -F "$(pwd)/test-repo/src" scalar.repos &&
+	scalar delete test-repo
+'
+
 test_expect_success '`scalar register` & `unregister` with existing repo' '
 	git init existing &&
 	scalar register existing &&
@@ -237,6 +248,13 @@ test_expect_success '`scalar register` existing repo with `src` folder' '
 	scalar unregister existing &&
 	scalar list >scalar.repos &&
 	! grep -F "$(pwd)/existing" scalar.repos
+'
+
+test_expect_success '`scalar delete` with existing repo' '
+	git init existing &&
+	scalar register existing &&
+	scalar delete existing &&
+	test_path_is_missing existing
 '
 
 test_done


### PR DESCRIPTION
Updates to allow Scalar commands to work properly on enlistments that are not cloned into a `src` subdirectory (e.g., if `scalar register` is run on a `git clone`'d repository). 

Added regression tests + ran manual tests with `scalar diagnose` to ensure diagnostics directory was created in the enlistment directory both with and without `src` subdirectory.