### PR TITLE
Fix cURL linking issue in Mac installer from tag-to-release build

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -219,8 +219,6 @@ jobs:
       # `gettext` is keg-only
       LDFLAGS: -L/usr/local/opt/gettext/lib
       CFLAGS: -I/usr/local/opt/gettext/include
-      # Link with cURL
-      CURL_LDFLAGS: -lcurl
       # To make use of the catalogs...
       XML_CATALOG_FILES: /usr/local/etc/xml/catalog
       # Enable a bit stricter compile flags
@@ -232,7 +230,7 @@ jobs:
       - name: Install git dependencies
         run: |
           set -x
-          brew install -v automake asciidoc xmlto
+          brew install automake asciidoc xmlto
           brew link --force gettext
       - name: Clone git
         uses: actions/checkout@v2
@@ -258,8 +256,9 @@ jobs:
               exit 1
           }
 
-          VERSION="${{ needs.prereqs.outputs.tag_version }}"
-          export VERSION
+          # Configure the environment
+          export CURL_LDFLAGS=$(curl-config --libs)
+          export VERSION="${{ needs.prereqs.outputs.tag_version }}"
 
           dir=git_osx_installer/git-$VERSION
           test ! -e $dir ||


### PR DESCRIPTION
Don't want to disrupt the 2.33.0 release, so this should (probably?) wait until after the main branch has been updated (then I'll also update the target of this pull request).

`CURL_LDFLAGS` was previously hardcoded to the incorrect value (`-lcurl`), now pointing to the `brew`-installed `libcurl`.