### PR TITLE
HACK: try to add FSMonitor tracing to existing Trace2 logs

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -176,7 +176,7 @@ jobs:
           mkdir -p "$TRACE2_BASENAME"
           mkdir -p "$TRACE2_BASENAME/Event"
           mkdir -p "$TRACE2_BASENAME/Perf"
-          export GIT_TRACE_FSMONITOR="$TRACE2_BASENAME/Perf/HackFSMonitorTrace.log"
+          export GIT_TRACE_FSMONITOR="$GIT_TRACE2_PERF/HackFSMonitorTrace.log"
           git version --build-options
           cd ../out
           Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --test-git-on-path --timeout=300000 --full-suite

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -176,6 +176,7 @@ jobs:
           mkdir -p "$TRACE2_BASENAME"
           mkdir -p "$TRACE2_BASENAME/Event"
           mkdir -p "$TRACE2_BASENAME/Perf"
+          export GIT_TRACE_FSMONITOR="$TRACE2_BASENAME/Perf/HackFSMonitorTrace.log"
           git version --build-options
           cd ../out
           Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --test-git-on-path --timeout=300000 --full-suite

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1773,6 +1773,7 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 
 	o->result.fsmonitor_last_update =
 		xstrdup_or_null(o->src_index->fsmonitor_last_update);
+	o->result.fsmonitor_has_run_once = o->src_index->fsmonitor_has_run_once;
 
 	/*
 	 * Sparse checkout loop #1: set NEW_SKIP_WORKTREE on existing entries


### PR DESCRIPTION
DO NOT MERGE.

A test case to try to add extra tracing to the scalar functional test run.