### PR TITLE
Make sparse index the default

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -95,9 +95,9 @@ void prepare_repo_settings(struct repository *r)
 	r->settings.command_requires_full_index = 1;
 
 	/*
-	 * Initialize this as off.
+	 * Initialize this as on.
 	 */
-	r->settings.sparse_index = 0;
-	if (!repo_config_get_bool(r, "index.sparse", &value) && value)
-		r->settings.sparse_index = 1;
+	r->settings.sparse_index = 1;
+	if (!repo_config_get_bool(r, "index.sparse", &value) && !value)
+		r->settings.sparse_index = 0;
 }

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -105,7 +105,7 @@ int set_sparse_index_config(struct repository *repo, int enable)
 	char *config_path = repo_git_path(repo, "config.worktree");
 	res = git_config_set_in_file_gently(config_path,
 					    "index.sparse",
-					    enable ? "true" : NULL);
+					    enable ? "true" : "false");
 	free(config_path);
 
 	prepare_repo_settings(repo);

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -215,7 +215,7 @@ test_expect_success 'sparse-index enabled and disabled' '
 	test-tool -C repo read-cache --table >cache &&
 	! grep " tree " cache &&
 	git -C repo config --list >config &&
-	! grep index.sparse config
+	test_cmp_config -C repo false index.sparse
 '
 
 test_expect_success 'cone mode: init and set' '

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -147,6 +147,7 @@ init_repos () {
 	git -C sparse-index reset --hard &&
 
 	# initialize sparse-checkout definitions
+	git -C sparse-checkout config index.sparse false &&
 	git -C sparse-checkout sparse-checkout init --cone &&
 	git -C sparse-checkout sparse-checkout set deep &&
 	git -C sparse-index sparse-checkout init --cone --sparse-index &&

--- a/t/t7817-grep-sparse-checkout.sh
+++ b/t/t7817-grep-sparse-checkout.sh
@@ -49,7 +49,7 @@ test_expect_success 'setup' '
 		echo "text" >B/b &&
 		git add A B &&
 		git commit -m sub &&
-		git sparse-checkout init --cone &&
+		git sparse-checkout init --cone --no-sparse-index &&
 		git sparse-checkout set B
 	) &&
 


### PR DESCRIPTION
This branch is exactly #410, but with one more commit: enabling the sparse index by default in d59110a81b42fe80cae0b788869c28c3b1eb8785.

Having this in the `vfs-2.33.0` branch helps build confidence that the sparse index is doing what it should be doing by running in the Scalar functional tests and in our test branches.

If we want to cut a new `microsoft/git` release without enabling the sparse index, we can simply revert this commit.