### PR TITLE
scalar: enable untracked cache unconditionally

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -35,6 +35,7 @@ jobs:
 
     env:
       BUILD_FRAGMENT: bin/Release/netcoreapp3.1
+      GIT_FORCE_UNTRACKED_CACHE: 1
 
     steps:
       - name: Check out Git's source code

--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -156,23 +156,7 @@ static int set_recommended_config(int reconfigure)
 		{ "core.FSCache", "true", 1 },
 		{ "core.multiPackIndex", "true", 1 },
 		{ "core.preloadIndex", "true", 1 },
-#ifndef WIN32
 		{ "core.untrackedCache", "true", 1 },
-#else
-		/*
-		 * Unfortunately, Scalar's Functional Tests demonstrated
-		 * that the untracked cache feature is unreliable on Windows
-		 * (which is a bummer because that platform would benefit the
-		 * most from it). For some reason, freshly created files seem
-		 * not to update the directory's `lastModified` time
-		 * immediately, but the untracked cache would need to rely on
-		 * that.
-		 *
-		 * Therefore, with a sad heart, we disable this very useful
-		 * feature on Windows.
-		 */
-		{ "core.untrackedCache", "false", 1 },
-#endif
 		{ "core.bare", "false", 1 },
 		{ "core.logAllRefUpdates", "true", 1 },
 		{ "credential.https://dev.azure.com.useHttpPath", "true", 1 },

--- a/dir.c
+++ b/dir.c
@@ -2994,7 +2994,9 @@ int read_directory(struct dir_struct *dir, struct index_state *istate,
 
 		if (force_untracked_cache < 0)
 			force_untracked_cache =
-				git_env_bool("GIT_FORCE_UNTRACKED_CACHE", 0);
+				git_env_bool("GIT_FORCE_UNTRACKED_CACHE", -1);
+		if (force_untracked_cache < 0)
+			force_untracked_cache = (istate->repo->settings.core_untracked_cache == UNTRACKED_CACHE_WRITE);
 		if (force_untracked_cache &&
 			dir->untracked == istate->untracked &&
 		    (dir->untracked->dir_opened ||


### PR DESCRIPTION
No matter what I try, I cannot get the untracked cache to fail on Windows. Here are the things that are done in this pull request:

1. Scalar enables the untracked cache unconditionally via `core.untrackedCache = true`. This was previously set to `false` on Windows.
2. Set `GIT_FORCE_UNTRACKED_CACHE=1` for the Scalar functional tests.
3. Update the `core.untrackedCache` config variable to be as strong as the `GIT_FORCE_UNTRACKED_CACHE` environment variable.