### PR TITLE
sparse-index diff integration: initial attempt

### DIFF
--- a/builtin/diff.c
+++ b/builtin/diff.c
@@ -436,6 +436,9 @@ int cmd_diff(int argc, const char **argv, const char *prefix)
 	}
 
 	prefix = setup_git_directory_gently(&nongit);
+	
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 
 	if (!no_index) {
 		/*

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -693,6 +693,11 @@ test_expect_success 'sparse-index is not expanded' '
 	echo >>sparse-index/untracked.txt &&
 	ensure_not_expanded add . &&
 
+	echo "a test change" >> sparse-index/README.md &&
+	ensure_not_expanded diff &&
+	git -C sparse-index add README.md &&
+	ensure_not_expanded diff --staged &&
+
 	ensure_not_expanded checkout -f update-deep &&
 	(
 		sane_unset GIT_TEST_MERGE_ALGORITHM &&


### PR DESCRIPTION
THIS CHANGE IS NOT IN FINAL FORM AND IS CURRENTLY JUST INTENDED FOR
FEEDBACK. To understand the context laid out below I have purposefully
included both source and test changes in this initial commit. Based on
the feedback I get, I will either split this commit or create
an entirely new branch with the necessary changes when it is ready to
officially submit.

This change enables running the `diff` builtin command without
expanding the full index in a cone-mode sparse checkout. It is an attempt
to add the basic infrastructure to "light up" sparse index for the
command. However, based on some testing, this may need to change.

After reviewing #417, I decided to add `ensure_full_index` to this
initial commit in an attempt to maintain current behavior. However,
as I started building and testing with and without this update, I
noticed unexpected results.

The `ensure_not_expanded` tests I added are passing with
`ensure_full_index` both enabled and disabled. That felt wrong, so I
used `TRACE2` to try and understand what was happening and have attached
the results below.

It looks as though no code paths in `diff.c` are actually being used.
On the bright side, however, it doesn't look as though `ensure_full_index`
is ever being called. I recognize my lack of knowledge wrt `cache-tree`
and `read-cache` may be the reason I'm unsure what the correct path
forward is. In light of this, any guidance is appreciated.