### PR TITLE
diff: enable and test the sparse index

### DIFF
--- a/builtin/diff.c
+++ b/builtin/diff.c
@@ -437,6 +437,9 @@ int cmd_diff(int argc, const char **argv, const char *prefix)
 
 	prefix = setup_git_directory_gently(&nongit);
 
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
+
 	if (!no_index) {
 		/*
 		 * Treat git diff with at least one path outside of the

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -387,6 +387,39 @@ test_expect_success 'diff --staged' '
 	test_all_match git diff --staged
 '
 
+test_expect_success 'diff partially-staged' '
+	init_repos &&
+
+	# Add file within cone
+	test_all_match git sparse-checkout set deep &&
+	run_on_all 'echo >deep/testfile' &&
+	test_all_match git add deep/testfile &&
+	run_on_all 'echo a new line >>deep/testfile' &&
+
+	test_all_match git diff &&
+	test_all_match git diff --staged &&
+
+	# Add file outside cone
+	test_all_match git reset --hard &&
+	run_on_all mkdir newdirectory &&
+	run_on_all 'echo >newdirectory/testfile' &&
+	test_all_match git sparse-checkout set newdirectory &&
+	test_all_match git add newdirectory/testfile &&
+	run_on_all 'echo a new line >>newdirectory/testfile' &&
+	test_all_match git sparse-checkout set &&
+
+	test_all_match git diff &&
+	test_all_match git diff --staged &&
+
+	# Merge conflict outside cone
+	test_all_match git reset --hard &&
+	test_all_match git checkout merge-left &&
+	test_all_match test_must_fail git merge merge-right &&
+
+	test_all_match git diff &&
+	test_all_match git diff --staged
+'
+
 # NEEDSWORK: sparse-checkout behaves differently from full-checkout when
 # running this test with 'df-conflict-2' after 'df-conflict-1'.
 test_expect_success 'diff with renames and conflicts' '
@@ -822,6 +855,12 @@ test_expect_success 'sparse-index is not expanded' '
 	ensure_not_expanded reset base -- folder1 &&
 
 	ensure_not_expanded reset --hard update-deep &&
+
+	echo a test change >>sparse-index/README.md &&
+	ensure_not_expanded diff &&
+	git -C sparse-index add README.md &&
+	ensure_not_expanded diff --staged &&
+
 	ensure_not_expanded checkout -f update-deep &&
 	(
 		sane_unset GIT_TEST_MERGE_ALGORITHM &&


### PR DESCRIPTION
Enable the sparse index within the 'git diff' command. Its implementation
already safely integrates with the sparse index because it shares code with the
'git status' and 'git checkout' commands that were already integrated. The most
interesting thing to do is to add tests that verify that 'git diff' behaves
correctly when the sparse index is enabled. These cases are...

1. The index is not expanded for `diff` and `diff --staged` (which both
involve reading from the index).
2. `diff` and `diff --staged` behave the same in full
checkout, sparse checkout, and sparse index repositories in the following
partially-staged scenarios (i.e. the index, HEAD, and working directory
differ at a given path):
    1. Path is within sparse-checkout cone.
    2. Path is outside sparse-checkout cone.
    3. A merge conflict exists for paths outside sparse-checkout cone.

Signed-off-by: Lessley Dennington <lessleydennington@gmail.com>