### PR TITLE
sparse-index: introduce GIT_TEST_FAIL_ENSURE_FULL_INDEX

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -37,6 +37,7 @@ jobs:
 
     env:
       BUILD_FRAGMENT: bin/Release/netcoreapp3.1
+      GIT_TEST_FAIL_ENSURE_FULL_INDEX: 1
 
     steps:
       - name: Check out Git's source code

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -251,6 +251,16 @@ void ensure_full_index(struct index_state *istate)
 	if (!istate->repo)
 		istate->repo = the_repository;
 
+	if (!istate->repo->settings.command_requires_full_index) {
+		static int fail_on_expand = -1;
+
+		if (fail_on_expand < 0)
+			fail_on_expand = git_env_bool("GIT_TEST_FAIL_ENSURE_FULL_INDEX", 0);
+
+		if (fail_on_expand)
+			die("sparse index will expand in an integrated command");
+	}
+
 	trace2_region_enter("index", "ensure_full_index", istate->repo);
 
 	/* initialize basics of new index */


### PR DESCRIPTION
To be extra sure that our integrated commands do not expand in normal
cases, create a GIT_TEST_FAIL_ENSURE_FULL_INDEX that fails inside
ensure_full_index() if the repo settings indicate we are in an
integrated command. Enable this for the Scalar functional tests.

Inspired by a conversation with @dscho.