### PR TITLE
Remove Ubuntu 16.04 from test matrix

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,15 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2019, macos-10.15, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [windows-2019, macos-10.15, ubuntu-18.04, ubuntu-20.04]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...
         features: [ignored]
         exclude:
           # The built-in FSMonitor is not (yet) supported on Linux
-          - os: ubuntu-16.04
-            features: experimental
           - os: ubuntu-18.04
             features: experimental
           - os: ubuntu-20.04


### PR DESCRIPTION
This platform has been dropped from GitHub Actions, so it is showing up as skipped.

Drop this platform and use a `fixup!` so it is squashed in the 2.34 rebase.