### PR TITLE
Sparse index: integrate with `read-tree`

### DIFF
--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -217,8 +217,7 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 	if (opts.merge && !opts.index_only)
 		setup_work_tree();
 
-	/* TODO: audit sparse index behavior in unpack_trees */
-	if (opts.skip_sparse_checkout || opts.prefix)
+	if (opts.skip_sparse_checkout)
 		ensure_full_index(&the_index);
 
 	if (opts.merge) {

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -168,11 +168,14 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 	argc = parse_options(argc, argv, cmd_prefix, read_tree_options,
 			     read_tree_usage, 0);
 
-	hold_locked_index(&lock_file, LOCK_DIE_ON_ERROR);
-
 	prefix_set = opts.prefix ? 1 : 0;
 	if (1 < opts.merge + opts.reset + prefix_set)
 		die("Which one? -m, --reset, or --prefix?");
+
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
+
+	hold_locked_index(&lock_file, LOCK_DIE_ON_ERROR);
 
 	/*
 	 * NEEDSWORK
@@ -214,6 +217,10 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 	if (opts.merge && !opts.index_only)
 		setup_work_tree();
 
+	/* TODO: audit sparse index behavior in unpack_trees */
+	if (opts.skip_sparse_checkout || opts.prefix)
+		ensure_full_index(&the_index);
+
 	if (opts.merge) {
 		switch (stage - 1) {
 		case 0:
@@ -223,11 +230,21 @@ int cmd_read_tree(int argc, const char **argv, const char *cmd_prefix)
 			opts.fn = opts.prefix ? bind_merge : oneway_merge;
 			break;
 		case 2:
+			/*
+			 * TODO: update twoway_merge to handle edit/edit conflicts in
+			 * sparse directories.
+			 */
+			ensure_full_index(&the_index);
 			opts.fn = twoway_merge;
 			opts.initial_checkout = is_cache_unborn();
 			break;
 		case 3:
 		default:
+			/*
+			 * TODO: update threeway_merge to handle edit/edit conflicts in
+			 * sparse directories.
+			 */
+			ensure_full_index(&the_index);
 			opts.fn = threeway_merge;
 			break;
 		}

--- a/cache-tree.c
+++ b/cache-tree.c
@@ -800,6 +800,17 @@ out:
 	return ret;
 }
 
+static void prime_cache_tree_sparse_dir(struct repository *r,
+					struct cache_tree *it,
+					struct tree *tree,
+					struct strbuf *tree_path)
+{
+
+	oidcpy(&it->oid, &tree->object.oid);
+	it->entry_count = 1;
+	return;
+}
+
 static void prime_cache_tree_rec(struct repository *r,
 				 struct cache_tree *it,
 				 struct tree *tree,
@@ -811,21 +822,6 @@ static void prime_cache_tree_rec(struct repository *r,
 	int cnt;
 
 	oidcpy(&it->oid, &tree->object.oid);
-
-	/*
-	 * If this entry is outside the sparse-checkout cone, then it might be
-	 * a sparse directory entry. Check the index to ensure it is by looking
-	 * for an entry with the exact same name as the tree. If no matching sparse
-	 * entry is found, a staged or conflicted entry is preventing this
-	 * directory from collapsing to a sparse directory entry, so the cache
-	 * tree expansion should continue.
-	 */
-	if (r->index->sparse_index &&
-	    !path_in_cone_modesparse_checkout(tree_path->buf, r->index) &&
-	    index_name_pos(r->index, tree_path->buf, tree_path->len) >= 0) {
-		it->entry_count = 1;
-		return;
-	}
 
 	init_tree_desc(&desc, tree->buffer, tree->size);
 	cnt = 0;
@@ -846,7 +842,18 @@ static void prime_cache_tree_rec(struct repository *r,
 			strbuf_add(&subtree_path, entry.path, entry.pathlen);
 			strbuf_addch(&subtree_path, '/');
 
-			prime_cache_tree_rec(r, sub->cache_tree, subtree, &subtree_path);
+			/*
+			* If a sparse index is in use, the directory being processed may be
+			* sparse. To confirm that, we can check whether an entry with that
+			* exact name exists in the index. If it does, the created subtree
+			* should be sparse. Otherwise, cache tree expansion should continue
+			* as normal.
+			*/
+			if (r->index->sparse_index &&
+			    index_entry_exists(r->index, subtree_path.buf, subtree_path.len))
+				prime_cache_tree_sparse_dir(r, sub->cache_tree, subtree, &subtree_path);
+			else
+				prime_cache_tree_rec(r, sub->cache_tree, subtree, &subtree_path);
 			cnt += sub->cache_tree->entry_count;
 		}
 	}

--- a/cache.h
+++ b/cache.h
@@ -834,6 +834,16 @@ struct cache_entry *index_file_next_match(struct index_state *istate, struct cac
 int index_name_pos(struct index_state *, const char *name, int namelen);
 
 /*
+ * Determines whether an entry with the given name exists within the
+ * given index. The return value is 1 if an exact match is found, otherwise
+ * it is 0. Note that, unlike index_name_pos, this function does not expand
+ * the index if it is sparse. If an item exists within the full index but it
+ * is contained within a sparse directory (and not in the sparse index), 0 is
+ * returned.
+ */
+int index_entry_exists(struct index_state *, const char *name, int namelen);
+
+/*
  * Some functions return the negative complement of an insert position when a
  * precise match was not found but a position was found where the entry would
  * need to be inserted. This helper protects that logic from any integer

--- a/read-cache.c
+++ b/read-cache.c
@@ -564,7 +564,10 @@ int cache_name_stage_compare(const char *name1, int len1, int stage1, const char
 	return 0;
 }
 
-static int index_name_stage_pos(struct index_state *istate, const char *name, int namelen, int stage)
+static int index_name_stage_pos(struct index_state *istate,
+				const char *name, int namelen,
+				int stage,
+				int search_sparse)
 {
 	int first, last;
 
@@ -583,7 +586,7 @@ static int index_name_stage_pos(struct index_state *istate, const char *name, in
 		first = next+1;
 	}
 
-	if (istate->sparse_index &&
+	if (search_sparse && istate->sparse_index &&
 	    first > 0) {
 		/* Note: first <= istate->cache_nr */
 		struct cache_entry *ce = istate->cache[first - 1];
@@ -599,7 +602,7 @@ static int index_name_stage_pos(struct index_state *istate, const char *name, in
 		    ce_namelen(ce) < namelen &&
 		    !strncmp(name, ce->name, ce_namelen(ce))) {
 			ensure_full_index(istate);
-			return index_name_stage_pos(istate, name, namelen, stage);
+			return index_name_stage_pos(istate, name, namelen, stage, search_sparse);
 		}
 	}
 
@@ -608,7 +611,12 @@ static int index_name_stage_pos(struct index_state *istate, const char *name, in
 
 int index_name_pos(struct index_state *istate, const char *name, int namelen)
 {
-	return index_name_stage_pos(istate, name, namelen, 0);
+	return index_name_stage_pos(istate, name, namelen, 0, 1);
+}
+
+int index_entry_exists(struct index_state *istate, const char *name, int namelen)
+{
+	return index_name_stage_pos(istate, name, namelen, 0, 0) >= 0;
 }
 
 int remove_index_entry_at(struct index_state *istate, int pos)
@@ -1235,7 +1243,7 @@ static int has_dir_name(struct index_state *istate,
 			 */
 		}
 
-		pos = index_name_stage_pos(istate, name, len, stage);
+		pos = index_name_stage_pos(istate, name, len, stage, 1);
 		if (pos >= 0) {
 			/*
 			 * Found one, but not so fast.  This could
@@ -1332,7 +1340,7 @@ static int add_index_entry_with_check(struct index_state *istate, struct cache_e
 		strcmp(ce->name, istate->cache[istate->cache_nr - 1]->name) > 0)
 		pos = index_pos_to_insert_pos(istate->cache_nr);
 	else
-		pos = index_name_stage_pos(istate, ce->name, ce_namelen(ce), ce_stage(ce));
+		pos = index_name_stage_pos(istate, ce->name, ce_namelen(ce), ce_stage(ce), 1);
 
 	/*
 	 * Cache tree path should be invalidated only after index_name_stage_pos,
@@ -1374,7 +1382,7 @@ static int add_index_entry_with_check(struct index_state *istate, struct cache_e
 		if (!ok_to_replace)
 			return error(_("'%s' appears as both a file and as a directory"),
 				     ce->name);
-		pos = index_name_stage_pos(istate, ce->name, ce_namelen(ce), ce_stage(ce));
+		pos = index_name_stage_pos(istate, ce->name, ce_namelen(ce), ce_stage(ce), 1);
 		pos = -pos-1;
 	}
 	return pos + 1;

--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -112,6 +112,7 @@ test_perf_on_all git commit -a -m A
 test_perf_on_all git checkout -f -
 test_perf_on_all git reset
 test_perf_on_all git reset --hard
+test_perf_on_all git read-tree -mu HEAD
 test_perf_on_all git checkout-index -f --all
 test_perf_on_all git update-index --add --remove
 test_perf_on_all git diff

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1250,6 +1250,17 @@ test_expect_success 'sparse index is not expanded: update-index' '
 	ensure_not_expanded update-index --add --remove --again
 '
 
+test_expect_success 'sparse index is not expanded: read-tree' '
+	init_repos &&
+
+	ensure_not_expanded checkout -b test-branch update-folder1 &&
+	for MERGE_TREES in "update-folder2"
+	do
+		ensure_not_expanded read-tree -mu $MERGE_TREES &&
+		ensure_not_expanded reset --hard HEAD || return 1
+	done
+'
+
 # NEEDSWORK: a sparse-checkout behaves differently from a full checkout
 # in this scenario, but it shouldn't.
 test_expect_success 'reset mixed and checkout orphan' '

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -995,7 +995,7 @@ test_expect_success 'sparse-index is expanded and converted back' '
 	init_repos &&
 
 	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
-		git -C sparse-index -c core.fsmonitor="" read-tree -mu HEAD &&
+		git -C sparse-index -c core.fsmonitor="" mv a b &&
 	test_region index convert_to_sparse trace2.txt &&
 	test_region index ensure_full_index trace2.txt
 '

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1258,7 +1258,13 @@ test_expect_success 'sparse index is not expanded: read-tree' '
 	do
 		ensure_not_expanded read-tree -mu $MERGE_TREES &&
 		ensure_not_expanded reset --hard HEAD || return 1
-	done
+	done &&
+
+	rm -rf sparse-index/deep/deeper2 &&
+	ensure_not_expanded add . &&
+	ensure_not_expanded commit -m "test" &&
+
+	ensure_not_expanded read-tree --prefix=deep/deeper2 -u deepest
 '
 
 # NEEDSWORK: a sparse-checkout behaves differently from a full checkout

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -775,6 +775,122 @@ test_expect_success 'update-index --cacheinfo' '
 	test_sparse_match git status --porcelain=v2
 '
 
+test_expect_success 'read-tree --merge with files outside sparse definition' '
+	init_repos &&
+
+	test_all_match git checkout -b test-branch update-folder1 &&
+	for MERGE_TREES in "base HEAD update-folder2" \
+			   "update-folder1 update-folder2" \
+			   "update-folder2"
+	do
+		# Clean up and remove on-disk files
+		test_all_match git reset --hard HEAD &&
+		test_sparse_match git sparse-checkout reapply &&
+
+		# Although the index matches, without --no-sparse-checkout, outside-of-
+		# definition files will not exist on disk for sparse checkouts
+		test_all_match git read-tree -mu $MERGE_TREES &&
+		test_all_match git status --porcelain=v2 &&
+		test_path_is_missing sparse-checkout/folder2 &&
+		test_path_is_missing sparse-index/folder2 &&
+
+		test_all_match git read-tree --reset -u HEAD &&
+		test_all_match git status --porcelain=v2 &&
+
+		test_all_match git read-tree -mu --no-sparse-checkout $MERGE_TREES &&
+		test_all_match git status --porcelain=v2 &&
+		test_cmp sparse-checkout/folder2/a sparse-index/folder2/a &&
+		test_cmp sparse-checkout/folder2/a full-checkout/folder2/a || return 1
+	done
+'
+
+test_expect_success 'read-tree --merge with edit/edit conflicts in sparse directories' '
+	init_repos &&
+
+	# Merge of multiple changes to same directory (but not same files) should
+	# succeed
+	test_all_match git read-tree -mu base rename-base update-folder1 &&
+	test_all_match git status --porcelain=v2 &&
+
+	test_all_match git reset --hard &&
+
+	test_all_match git read-tree -mu rename-base update-folder2 &&
+	test_all_match git status --porcelain=v2 &&
+
+	test_all_match git reset --hard &&
+
+	test_all_match test_must_fail git read-tree -mu base update-folder1 rename-out-to-in &&
+	test_all_match test_must_fail git read-tree -mu rename-out-to-in update-folder1
+'
+
+test_expect_success 'read-tree --merge with modified file outside definition' '
+	init_repos &&
+
+	write_script edit-contents <<-\EOF &&
+	echo text >>$1
+	EOF
+
+	test_all_match git checkout -b test-branch update-folder1 &&
+	run_on_sparse mkdir -p folder2 &&
+	run_on_all ../edit-contents folder2/a &&
+
+	# With manually-modified file, full-checkout cannot merge, but it is ignored
+	# in sparse checkouts
+	test_must_fail git -C full-checkout read-tree -mu update-folder2 &&
+	test_sparse_match git read-tree -mu update-folder2 &&
+	test_sparse_match git status --porcelain=v2 &&
+
+	# Reset only the sparse checkouts to "undo" the merge. All three checkouts
+	# now have matching indexes and matching folder2/a on disk.
+	test_sparse_match git read-tree --reset -u HEAD &&
+
+	# When --no-sparse-checkout is specified, sparse checkouts identify the file
+	# on disk and prevent the merge
+	test_all_match test_must_fail git read-tree -mu --no-sparse-checkout update-folder2
+'
+
+test_expect_success 'read-tree --prefix outside sparse definition' '
+	init_repos &&
+
+	# Cannot read-tree --prefix with a single argument when files exist within
+	# prefix
+	test_all_match test_must_fail git read-tree --prefix=folder1/ -u update-folder1 &&
+
+	test_all_match git read-tree --prefix=folder2/0 -u rename-base &&
+	test_path_is_missing sparse-checkout/folder2 &&
+	test_path_is_missing sparse-index/folder2 &&
+
+	test_all_match git read-tree --reset -u HEAD &&
+	test_all_match git read-tree --prefix=folder2/0 -u --no-sparse-checkout rename-base &&
+	test_cmp sparse-checkout/folder2/0/a sparse-index/folder2/0/a &&
+	test_cmp sparse-checkout/folder2/0/a full-checkout/folder2/0/a
+'
+
+# TODO: predating any sparse index compatibility changes to `read-tree`, this
+# merge fails due to a status difference between the sparse index and non-sparse
+# index checkouts. Specifically, `folder2/0` (a directory) appears modified in
+# the sparse index, but `folder2/0/a` (correctly?) appears instead as a
+# modified entry in the non-sparse index checkouts.
+test_expect_failure 'read-tree --merge with directory-file conflicts' '
+	init_repos &&
+
+	test_all_match git checkout -b test-branch rename-base &&
+
+	# Although the index matches, without --no-sparse-checkout, outside-of-
+	# definition files will not exist on disk for sparse checkouts
+	test_sparse_match git read-tree -mu rename-out-to-out &&
+	test_sparse_match git status --porcelain=v2 &&
+	test_path_is_missing sparse-checkout/folder2 &&
+	test_path_is_missing sparse-index/folder2 &&
+
+	test_sparse_match git read-tree --reset -u HEAD &&
+	test_sparse_match git status --porcelain=v2 &&
+
+	test_sparse_match git read-tree -mu --no-sparse-checkout rename-out-to-out &&
+	test_sparse_match git status --porcelain=v2 &&
+	test_cmp sparse-checkout/folder2/0/1 sparse-index/folder2/0/1
+'
+
 test_expect_success 'merge, cherry-pick, and rebase' '
 	init_repos &&
 

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -390,11 +390,15 @@ test_expect_success 'diff --staged' '
 test_expect_success 'diff partially-staged' '
 	init_repos &&
 
+	write_script edit-contents <<-\EOF &&
+	echo text >>$1
+	EOF
+
 	# Add file within cone
 	test_all_match git sparse-checkout set deep &&
-	run_on_all 'echo >deep/testfile' &&
+	run_on_all ../edit-contents deep/testfile &&
 	test_all_match git add deep/testfile &&
-	run_on_all 'echo a new line >>deep/testfile' &&
+	run_on_all ../edit-contents deep/testfile &&
 
 	test_all_match git diff &&
 	test_all_match git diff --staged &&
@@ -402,10 +406,10 @@ test_expect_success 'diff partially-staged' '
 	# Add file outside cone
 	test_all_match git reset --hard &&
 	run_on_all mkdir newdirectory &&
-	run_on_all 'echo >newdirectory/testfile' &&
+	run_on_all ../edit-contents newdirectory/testfile &&
 	test_all_match git sparse-checkout set newdirectory &&
 	test_all_match git add newdirectory/testfile &&
-	run_on_all 'echo a new line >>newdirectory/testfile' &&
+	run_on_all ../edit-contents newdirectory/testfile &&
 	test_all_match git sparse-checkout set &&
 
 	test_all_match git diff &&

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1050,7 +1050,7 @@ test_expect_success 'sparse-index is not expanded' '
 	do
 		echo >>sparse-index/README.md &&
 		ensure_not_expanded reset --mixed $ref
-		ensure_not_expanded reset --hard $ref
+		ensure_not_expanded reset --hard $ref || return 1
 	done &&
 
 	ensure_not_expanded reset --hard update-deep &&

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -866,12 +866,7 @@ test_expect_success 'read-tree --prefix outside sparse definition' '
 	test_cmp sparse-checkout/folder2/0/a full-checkout/folder2/0/a
 '
 
-# TODO: predating any sparse index compatibility changes to `read-tree`, this
-# merge fails due to a status difference between the sparse index and non-sparse
-# index checkouts. Specifically, `folder2/0` (a directory) appears modified in
-# the sparse index, but `folder2/0/a` (correctly?) appears instead as a
-# modified entry in the non-sparse index checkouts.
-test_expect_failure 'read-tree --merge with directory-file conflicts' '
+test_expect_success 'read-tree --merge with directory-file conflicts' '
 	init_repos &&
 
 	test_all_match git checkout -b test-branch rename-base &&

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1741,6 +1741,58 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		ensure_full_index(o->dst_index);
 	}
 
+	/*
+	 * If the prefix is equal to or contained within a sparse directory, the
+	 * index needs to be expanded to traverse with the specified prefix. Note
+	 * that only the src_index is checked because the prefix is only specified
+	 * in cases where src_index == dst_index.
+	 */
+	if (o->prefix && o->src_index->sparse_index) {
+		int i, ce_len;
+		struct cache_entry *ce;
+		int prefix_len = strlen(o->prefix);
+
+		if (prefix_len > 0) {
+			for (i = 0; i < o->src_index->cache_nr; i++) {
+				ce = o->src_index->cache[i];
+				ce_len = ce_namelen(ce);
+
+				if (!S_ISSPARSEDIR(ce->ce_mode))
+					continue;
+
+				/*
+				 * Normalize comparison length for cache entry vs. prefix -
+				 * either may have a trailing slash, which we do not want to
+				 * compare (can assume both are directories).
+				 */
+				if (ce->name[ce_len - 1] == '/')
+					ce_len--;
+				if (o->prefix[prefix_len - 1] == '/')
+					prefix_len--;
+
+				/*
+				 * If prefix length is shorter, then it is either a parent to
+				 * this sparse directory, or a completely different path. In
+				 * either case, we don't need to expand the index
+				 */
+				if (prefix_len < ce_len)
+					continue;
+
+				/*
+				 * Avoid the case of expanding the index with a prefix
+				 * a/beta for a sparse directory a/b.
+				 */
+				if (ce_len < prefix_len && o->prefix[ce_len] != '/')
+					continue;
+
+				if (!strncmp(ce->name, o->prefix, ce_len)) {
+					ensure_full_index(o->src_index);
+					break;
+				}
+			}
+		}
+	}
+
 	if (!core_apply_sparse_checkout || !o->update)
 		o->skip_sparse_checkout = 1;
 	if (!o->skip_sparse_checkout && !o->pl) {

--- a/wt-status.c
+++ b/wt-status.c
@@ -651,6 +651,13 @@ static void wt_status_collect_changes_index(struct wt_status *s)
 	rev.diffopt.detect_rename = s->detect_rename >= 0 ? s->detect_rename : rev.diffopt.detect_rename;
 	rev.diffopt.rename_limit = s->rename_limit >= 0 ? s->rename_limit : rev.diffopt.rename_limit;
 	rev.diffopt.rename_score = s->rename_score >= 0 ? s->rename_score : rev.diffopt.rename_score;
+
+	/*
+	 * The `recursive` flag must be set to properly perform a diff on sparse
+	 * directory entries, if they exist
+	 */
+	rev.diffopt.flags.recursive = 1;
+
 	copy_pathspec(&rev.prune_data, &s->pathspec);
 	run_diff_index(&rev, 1);
 	object_array_clear(&rev.pending);


### PR DESCRIPTION
This pull request is more-or-less split into "fixups" and "integrating sparse index with `read-tree`".

## Fixups
- Fix syntax in some of the `diff` tests (I can't seem to get `echo` to work in the tests, so it's replaced with a custom `edit-contents`)
- Fix `git status` reporting differences nested in sparse directory
  - In the test relevant to this commit, `git status` was previously reporting changes nested inside of a sparse directory as the whole directory being "modified" (but _only_ in the sparse index). Fixed by setting the `recursive` flag when performing the diff
- Modify the way `prime_cache_tree_rec` identifies sparse directories when rebuilding the cache tree
  - The previous implementation was breaking when `read-tree` was sparse-enabled in the `t1091` tests. The prior checks used weren't correctly identifying sparse cache entries in the case that the sparse patterns were broken.
- Change the test looking for sparse index expand and collapse to use `git mv` (which, as far as I can tell, isn't slated for integration with sparse index in the immediate future)
  - This one is a `fixup???` since the commit message for the original would need to be changed, since it calls out `read-tree` by name

## `read-tree`
Other than the standard changes to enable sparse index:
- Expand the index when `--no-sparse-checkout` is provided
  - The option effectively removes the `skip-worktree` flag from all entries, which eventually leads to the command attempting to checkout a sparse directory
- Expand the index when the prefix is equivalent to or is nested inside a sparse directory
  -  When `--prefix` is specified, it forces the `traverse_path` in `unpack_trees`/`traverse_trees` to start at the given prefix. However, the operation of those functions implicitly assumes (requires?) that the traverse path is something it has actually traversed into (which it can't be for a sparse directory). So, if the prefix is a sparse directory (e.g., `folder1` in the `t1092` tests) or is nested in one (e.g., `folder2/0`), the prefix is expanded before continuing with `unpack_trees`

## Performance testing
```
Test                                                   ms/vfs-2.33.0     HEAD                  
-----------------------------------------------------------------------------------------------
2000.2: git status (full-v3)                           0.74(0.28+0.37)   0.97(0.35+0.44) +31.1%
2000.3: git status (full-v4)                           0.80(0.30+0.39)   0.92(0.46+0.40) +15.0%
2000.4: git status (sparse-v3)                         0.56(0.11+0.69)   0.50(0.10+0.71) -10.7%
2000.5: git status (sparse-v4)                         0.54(0.12+0.80)   0.51(0.11+0.72) -5.6% 
2000.22: git reset (full-v3)                           0.78(0.35+0.36)   0.77(0.35+0.27) -1.3% 
2000.23: git reset (full-v4)                           0.84(0.47+0.25)   0.90(0.49+0.29) +7.1% 
2000.24: git reset (sparse-v3)                         0.36(0.07+0.77)   0.46(0.09+1.09) +27.8%
2000.25: git reset (sparse-v4)                         0.40(0.09+0.65)   0.44(0.09+0.63) +10.0%
2000.26: git reset --hard (full-v3)                    1.03(0.61+0.39)   1.11(0.62+0.43) +7.8% 
2000.27: git reset --hard (full-v4)                    1.12(0.65+0.40)   1.18(0.70+0.41) +5.4% 
2000.28: git reset --hard (sparse-v3)                  0.51(0.08+0.31)   0.63(0.10+0.39) +23.5%
2000.29: git reset --hard (sparse-v4)                  0.49(0.08+0.30)   0.56(0.09+0.33) +14.3%
2000.30: git read-tree -mu HEAD (full-v3)              1.29(0.96+0.30)   1.45(1.12+0.34) +12.4%
2000.31: git read-tree -mu HEAD (full-v4)              1.28(0.96+0.30)   1.41(1.10+0.33) +10.2%
2000.32: git read-tree -mu HEAD (sparse-v3)            1.66(1.25+0.40)   0.13(0.07+0.05) -92.2%
2000.33: git read-tree -mu HEAD (sparse-v4)            1.61(1.22+0.38)   0.13(0.07+0.05) -91.9%
```