### PR TITLE
Sparse index: integrate with `git stash`

### DIFF
--- a/builtin/am.c
+++ b/builtin/am.c
@@ -1585,7 +1585,7 @@ static int fall_back_threeway(const struct am_state *state, const char *index_pa
 	if (state->quiet)
 		o.verbosity = 0;
 
-	if (merge_recursive_generic(&o, &our_tree, &their_tree, 1, bases, &result)) {
+	if (merge_recursive_generic(&o, &our_tree, &their_tree, 1, bases, merge_recursive, &result)) {
 		repo_rerere(the_repository, state->allow_rerere_autoupdate);
 		free(their_tree_name);
 		return error(_("Failed to merge in the changes."));

--- a/builtin/merge-recursive.c
+++ b/builtin/merge-recursive.c
@@ -81,7 +81,7 @@ int cmd_merge_recursive(int argc, const char **argv, const char *prefix)
 	if (o.verbosity >= 3)
 		printf(_("Merging %s with %s\n"), o.branch1, o.branch2);
 
-	failed = merge_recursive_generic(&o, &h1, &h2, bases_count, bases, &result);
+	failed = merge_recursive_generic(&o, &h1, &h2, bases_count, bases, merge_recursive, &result);
 
 	free(better1);
 	free(better2);

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -1703,6 +1703,9 @@ int cmd_stash(int argc, const char **argv, const char *prefix)
 	argc = parse_options(argc, argv, prefix, options, git_stash_usage,
 			     PARSE_OPT_KEEP_UNKNOWN | PARSE_OPT_KEEP_DASHDASH);
 
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
+
 	index_file = get_index_file();
 	strbuf_addf(&stash_index_path, "%s.stash.%" PRIuMAX, index_file,
 		    (uintmax_t)pid);

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -7,6 +7,7 @@
 #include "cache-tree.h"
 #include "unpack-trees.h"
 #include "merge-recursive.h"
+#include "merge-ort-wrappers.h"
 #include "strvec.h"
 #include "run-command.h"
 #include "dir.h"
@@ -541,7 +542,7 @@ static int do_apply_stash(const char *prefix, struct stash_info *info,
 	bases[0] = &info->b_tree;
 
 	ret = merge_recursive_generic(&o, &c_tree, &info->w_tree, 1, bases,
-				      merge_recursive, &result);
+				      merge_ort_recursive, &result);
 	if (ret) {
 		rerere(0);
 

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -541,7 +541,7 @@ static int do_apply_stash(const char *prefix, struct stash_info *info,
 	bases[0] = &info->b_tree;
 
 	ret = merge_recursive_generic(&o, &c_tree, &info->w_tree, 1, bases,
-				      &result);
+				      merge_recursive, &result);
 	if (ret) {
 		rerere(0);
 

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -4652,7 +4652,8 @@ void merge_incore_recursive(struct merge_options *opt,
 	trace2_region_enter("merge", "incore_recursive", opt->repo);
 
 	/* We set the ancestor label based on the merge_bases */
-	assert(opt->ancestor == NULL);
+	assert(opt->ancestor == NULL ||
+	       !strcmp(opt->ancestor, "constructed merge base"));
 
 	trace2_region_enter("merge", "merge_start", opt->repo);
 	merge_start(opt, result);

--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -3785,6 +3785,7 @@ int merge_recursive_generic(struct merge_options *opt,
 			    const struct object_id *merge,
 			    int num_merge_bases,
 			    const struct object_id **merge_bases,
+			    recursive_merge_fn_t merge_fn,
 			    struct commit **result)
 {
 	int clean;
@@ -3808,8 +3809,7 @@ int merge_recursive_generic(struct merge_options *opt,
 	}
 
 	repo_hold_locked_index(opt->repo, &lock, LOCK_DIE_ON_ERROR);
-	clean = merge_recursive(opt, head_commit, next_commit, ca,
-				result);
+	clean = merge_fn(opt, head_commit, next_commit, ca, result);
 	if (clean < 0) {
 		rollback_lock_file(&lock);
 		return clean;

--- a/merge-recursive.h
+++ b/merge-recursive.h
@@ -51,6 +51,12 @@ struct merge_options {
 	struct merge_options_internal *priv;
 };
 
+typedef int (*recursive_merge_fn_t)(struct merge_options *opt,
+				    struct commit *h1,
+				    struct commit *h2,
+				    struct commit_list *merge_bases,
+				    struct commit **result);
+
 void init_merge_options(struct merge_options *opt, struct repository *repo);
 
 /* parse the option in s and update the relevant field of opt */
@@ -103,7 +109,7 @@ int merge_recursive(struct merge_options *opt,
 
 /*
  * merge_recursive_generic can operate on trees instead of commits, by
- * wrapping the trees into virtual commits, and calling merge_recursive().
+ * wrapping the trees into virtual commits, and calling the provided merge_fn.
  * It also writes out the in-memory index to disk if the merge is successful.
  *
  * Outputs:
@@ -118,6 +124,7 @@ int merge_recursive_generic(struct merge_options *opt,
 			    const struct object_id *merge,
 			    int num_merge_bases,
 			    const struct object_id **merge_bases,
+			    recursive_merge_fn_t merge_fn,
 			    struct commit **result);
 
 #endif

--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -106,6 +106,7 @@ test_perf_on_all () {
 }
 
 test_perf_on_all git status
+test_perf_on_all 'git stash && git stash pop'
 test_perf_on_all git add -A
 test_perf_on_all git add .
 test_perf_on_all git commit -a -m A

--- a/t/perf/run
+++ b/t/perf/run
@@ -74,7 +74,7 @@ set_git_test_installed () {
 	mydir=$1
 
 	mydir_abs=$(cd $mydir && pwd)
-	mydir_abs_wrappers="$mydir_abs_wrappers/bin-wrappers"
+	mydir_abs_wrappers="$mydir_abs/bin-wrappers"
 	if test -d "$mydir_abs_wrappers"
 	then
 		GIT_TEST_INSTALLED=$mydir_abs_wrappers

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1159,6 +1159,16 @@ test_expect_success 'sparse-index is not expanded' '
 	echo >>sparse-index/untracked.txt &&
 	ensure_not_expanded add . &&
 
+	echo >>sparse-index/a &&
+	ensure_not_expanded stash &&
+	ensure_not_expanded stash list &&
+	ensure_not_expanded stash show stash@{0} &&
+	ensure_not_expanded stash drop stash@{0} &&
+
+	ensure_not_expanded stash create &&
+	oid=$(git -C sparse-index stash create) &&
+	ensure_not_expanded stash store -m "test" $oid &&
+	ensure_not_expanded reset --hard &&
 	ensure_not_expanded checkout-index -f a &&
 	ensure_not_expanded checkout-index -f --all &&
 	for ref in update-deep update-folder1 update-folder2 update-deep

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1163,12 +1163,15 @@ test_expect_success 'sparse-index is not expanded' '
 	ensure_not_expanded stash &&
 	ensure_not_expanded stash list &&
 	ensure_not_expanded stash show stash@{0} &&
+	ensure_not_expanded stash apply stash@{0} &&
 	ensure_not_expanded stash drop stash@{0} &&
 
 	ensure_not_expanded stash create &&
 	oid=$(git -C sparse-index stash create) &&
 	ensure_not_expanded stash store -m "test" $oid &&
 	ensure_not_expanded reset --hard &&
+	ensure_not_expanded stash pop &&
+
 	ensure_not_expanded checkout-index -f a &&
 	ensure_not_expanded checkout-index -f --all &&
 	for ref in update-deep update-folder1 update-folder2 update-deep

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -621,7 +621,7 @@ test_expect_success 'reset with wildcard pathspec' '
 
 	test_all_match git checkout -b reset-test update-deep &&
 	test_all_match git reset --hard update-folder1 &&
-	test_all_match git reset base -- */a &&
+	test_all_match git reset base -- \*/a &&
 	test_all_match git status --porcelain=v2
 '
 


### PR DESCRIPTION
## Changes
- bugfix for the `reset with wildcard pathspec` test in `t1092`
  - pathspec was being resolved _before_ the git command was executed, the `*` needed to be escaped
- bugfix for `t/perf/run` (courtesy of @derrickstolee)
- new performance & `ensure_not_expanded` tests for `git stash`
- minor refactor to `merge_recursive_generic` to allow a custom merge function
- using the change to `merge_recursive_generic`, swapped out the merge function used in `git stash apply`/`git stash pop`
- the usual changes to repo settings to enable sparse index for `cmd_stash`

## Performance
Measuring this via performance tests yielded some confusing results. When `p2000` was run on _just_ this branch, there was a clear improvement in sparse vs full index (5 timing trials per test):

```
Test                                             this tree      
----------------------------------------------------------------
2000.2: git stash && git stash pop (full-v3)     4.77(2.87+1.42)
2000.3: git stash && git stash pop (full-v4)     5.21(3.15+1.48)
2000.4: git stash && git stash pop (sparse-v3)   1.83(0.41+2.08)
2000.5: git stash && git stash pop (sparse-v4)   1.75(0.43+2.05)
```

However, when run comparing different commits (also with 5 trials each), there was basically no difference in the last column (testing the same as above):

```
Test                                             f28fc0188d495     18844c9f657              de87f1d2d702            52ac0489e8fb            HEAD                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------
2000.2: git stash && git stash pop (full-v3)     4.93(3.21+1.42)   5.02(3.28+1.48) +1.8%    4.86(3.13+1.45) -1.4%   4.82(3.12+1.44) -2.2%   5.24(3.38+1.55) +6.3% 
2000.3: git stash && git stash pop (full-v4)     4.25(2.83+1.23)   4.91(3.14+1.45) +15.5%   4.47(2.97+1.27) +5.2%   4.61(2.97+1.37) +8.5%   4.85(3.10+1.44) +14.1%
2000.4: git stash && git stash pop (sparse-v3)   8.86(5.92+2.76)   8.92(6.08+2.69) +0.7%    8.58(5.76+2.63) -3.2%   8.25(5.59+2.49) -6.9%   5.08(2.87+2.83) -42.7%
2000.5: git stash && git stash pop (sparse-v4)   8.05(5.47+2.49)   9.40(6.30+2.85) +16.8%   8.72(5.87+2.68) +8.3%   8.38(5.66+2.52) +4.1%   5.00(2.82+2.86) -37.9%
```

The above tested commits are:
- merge `git reset` with sparse index
- merge `git checkout-index` with sparse index
- merge `git update-index` with sparse index
- merge `git read-tree` with sparse index
- the tip of this branch

The `t1092` tests confirm that the index should not be expanded (and a manual check of the trace2 results from running the commands in the `p2000` test do not show the index being expanded), so I'm not sure what's going on there. In any event, the index does not appear to be expanded, so in practice that should _probably_ match up with what happens in the first set of performance test results (I think).