### PR TITLE
Improve `next_cache_entry` cache traversal performance

### DIFF
--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -113,6 +113,7 @@ test_perf_on_all git commit -a -m A
 test_perf_on_all git checkout -f -
 test_perf_on_all git reset
 test_perf_on_all git reset --hard
+test_perf_on_all git reset -- does-not-exist
 test_perf_on_all git read-tree -mu HEAD
 test_perf_on_all git checkout-index -f --all
 test_perf_on_all git update-index --add --remove

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -665,17 +665,24 @@ static void mark_ce_used_same_name(struct cache_entry *ce,
 	}
 }
 
-static struct cache_entry *next_cache_entry(struct unpack_trees_options *o)
+static struct cache_entry *next_cache_entry(struct unpack_trees_options *o, int *hint)
 {
 	const struct index_state *index = o->src_index;
 	int pos = o->cache_bottom;
 
+	if (*hint > pos)
+		pos = *hint;
+
 	while (pos < index->cache_nr) {
 		struct cache_entry *ce = index->cache[pos];
-		if (!(ce->ce_flags & CE_UNPACKED))
+		if (!(ce->ce_flags & CE_UNPACKED)) {
+			*hint = pos + 1;
 			return ce;
+		}
 		pos++;
 	}
+
+	*hint = pos;
 	return NULL;
 }
 
@@ -1386,12 +1393,13 @@ static int unpack_callback(int n, unsigned long mask, unsigned long dirmask, str
 
 	/* Are we supposed to look at the index too? */
 	if (o->merge) {
+		int hint = -1;
 		while (1) {
 			int cmp;
 			struct cache_entry *ce;
 
 			if (o->diff_index_cached)
-				ce = next_cache_entry(o);
+				ce = next_cache_entry(o, &hint);
 			else
 				ce = find_cache_entry(info, p);
 
@@ -1720,7 +1728,7 @@ static int verify_absent(const struct cache_entry *,
 int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options *o)
 {
 	struct repository *repo = the_repository;
-	int i, ret;
+	int i, hint, ret;
 	static struct cache_entry *dfc;
 	struct pattern_list pl;
 	int free_pattern_list = 0;
@@ -1852,13 +1860,15 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		info.pathspec = o->pathspec;
 
 		if (o->prefix) {
+			hint = -1;
+
 			/*
 			 * Unpack existing index entries that sort before the
 			 * prefix the tree is spliced into.  Note that o->merge
 			 * is always true in this case.
 			 */
 			while (1) {
-				struct cache_entry *ce = next_cache_entry(o);
+				struct cache_entry *ce = next_cache_entry(o, &hint);
 				if (!ce)
 					break;
 				if (ce_in_traverse_path(ce, &info))
@@ -1879,8 +1889,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 
 	/* Any left-over entries in the index? */
 	if (o->merge) {
+		hint = -1;
 		while (1) {
-			struct cache_entry *ce = next_cache_entry(o);
+			struct cache_entry *ce = next_cache_entry(o, &hint);
 			if (!ce)
 				break;
 			if (unpack_index_entry(ce, o) < 0)


### PR DESCRIPTION
## Changes
- Update `next_cache_entry` to accept a "cached" starting position for index search
  - Because `next_cache_entry` searches the `src_index`, which shouldn't be modified in-place over the course of `unpack_trees`, the first search position for the next `next_cache_entry` call can be `last_position + 1`

This might also help with `git blame` performance, if it's using `unpack_trees` (CC: @ldennington).

## Performance
This change ultimately only had an effect on sparse index checkouts, as demonstrated by the performance test results:

```
Test                                              ms/vfs-2.33.0     HEAD                  
------------------------------------------------------------------------------------------
2000.2: git reset -- does-not-exist (full-v3)     0.79(0.38+0.30)   0.91(0.43+0.34) +15.2%
2000.3: git reset -- does-not-exist (full-v4)     0.80(0.38+0.29)   0.85(0.40+0.35) +6.2% 
2000.4: git reset -- does-not-exist (sparse-v3)   0.76(0.43+0.69)   0.44(0.08+0.67) -42.1%
2000.5: git reset -- does-not-exist (sparse-v4)   0.71(0.40+0.65)   0.41(0.09+0.65) -42.3%
```

The reason appears to be because, in full indexes, `mark_ce_used` will advance `cache_bottom` such that, in `next_cache_entry`, already-checked entries are skipped. In sparse indexes, however, the presence of sparse directory entries will block the `cache_bottom` from advancing, so already-checked cache entries are _not_ skipped in `next_cache_entry`. Since the cache tree still needs `cache_bottom` to not advance (per 17a1bb570bcd165a3dc1c28c441bee45a941bb12), the transient `hint` position lets `next_cache_entry` shortcut already-checked entries even for a sparse index.