### PR TITLE
Sparse index: integrate with `clean` and `stash -u`

### DIFF
--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -1010,6 +1010,9 @@ int cmd_clean(int argc, const char **argv, const char *prefix)
 		dir.flags |= DIR_KEEP_UNTRACKED_CONTENTS;
 	}
 
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
+
 	if (read_cache() < 0)
 		die(_("index file corrupt"));
 	enable_fscache(active_nr);

--- a/builtin/stash.c
+++ b/builtin/stash.c
@@ -350,7 +350,7 @@ static int restore_untracked(struct object_id *u_tree)
 
 	child_process_init(&cp);
 	cp.git_cmd = 1;
-	strvec_pushl(&cp.args, "checkout-index", "--all", NULL);
+	strvec_pushl(&cp.args, "checkout-index", "--all", "--sparse", NULL);
 	strvec_pushf(&cp.env_array, "GIT_INDEX_FILE=%s",
 		     stash_index_path.buf);
 

--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -107,6 +107,7 @@ test_perf_on_all () {
 
 test_perf_on_all git status
 test_perf_on_all 'git stash && git stash pop'
+test_perf_on_all 'echo >>new && git stash -u && git stash pop'
 test_perf_on_all git add -A
 test_perf_on_all git add .
 test_perf_on_all git commit -a -m A

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1301,6 +1301,46 @@ test_expect_success 'sparse index is not expanded: read-tree' '
 	ensure_not_expanded read-tree --prefix=deep/deeper2 -u deepest
 '
 
+# NEEDSWORK: although the full repository's index is _not_ expanded as part of
+# stash, a temporary index, which is _not_ sparse, is created when stashing and
+# applying a stash of untracked files. As a result, the test reports that it
+# finds an instance of `ensure_full_index`, but it does not carry with it the
+# performance implications of expanding the full repository index.
+test_expect_success 'sparse index is not expanded: stash -u' '
+	init_repos &&
+
+	mkdir -p sparse-index/folder1 &&
+	echo >>sparse-index/README.md &&
+	echo >>sparse-index/a &&
+	echo >>sparse-index/folder1/new &&
+
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index stash -u &&
+	test_region index ensure_full_index trace2.txt &&
+
+	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
+		git -C sparse-index stash pop &&
+	test_region index ensure_full_index trace2.txt
+'
+
+# NEEDSWORK: similar to `git add`, untracked files outside of the sparse
+# checkout definition are successfully stashed and unstashed.
+test_expect_success 'stash -u outside sparse checkout definition' '
+	init_repos &&
+
+	write_script edit-contents <<-\EOF &&
+	echo text >>$1
+	EOF
+
+	run_on_sparse mkdir -p folder1 &&
+	run_on_all ../edit-contents folder1/new &&
+	test_all_match git stash -u &&
+	test_all_match git status --porcelain=v2 &&
+
+	test_all_match git stash pop -q &&
+	test_all_match git status --porcelain=v2
+'
+
 # NEEDSWORK: a sparse-checkout behaves differently from a full checkout
 # in this scenario, but it shouldn't.
 test_expect_success 'reset mixed and checkout orphan' '

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1068,23 +1068,42 @@ test_expect_success 'clean' '
 	test_all_match git commit -m "ignore bogus files" &&
 
 	run_on_sparse mkdir folder1 &&
+	run_on_all mkdir -p deep/untracked-deep &&
 	run_on_all touch folder1/bogus &&
+	run_on_all touch folder1/untracked &&
+	run_on_all touch deep/untracked-deep/bogus &&
+	run_on_all touch deep/untracked-deep/untracked &&
 
 	test_all_match git status --porcelain=v2 &&
 	test_all_match git clean -f &&
 	test_all_match git status --porcelain=v2 &&
 	test_sparse_match ls &&
 	test_sparse_match ls folder1 &&
+	run_on_all test_path_exists folder1/bogus &&
+	run_on_all test_path_is_missing folder1/untracked &&
+	run_on_all test_path_exists deep/untracked-deep/bogus &&
+	run_on_all test_path_exists deep/untracked-deep/untracked &&
+
+	test_all_match git clean -fd &&
+	test_all_match git status --porcelain=v2 &&
+	test_sparse_match ls &&
+	test_sparse_match ls folder1 &&
+	run_on_all test_path_exists folder1/bogus &&
+	run_on_all test_path_exists deep/untracked-deep/bogus &&
+	run_on_all test_path_is_missing deep/untracked-deep/untracked &&
 
 	test_all_match git clean -xf &&
 	test_all_match git status --porcelain=v2 &&
 	test_sparse_match ls &&
 	test_sparse_match ls folder1 &&
+	run_on_all test_path_is_missing folder1/bogus &&
+	run_on_all test_path_exists deep/untracked-deep/bogus &&
 
 	test_all_match git clean -xdf &&
 	test_all_match git status --porcelain=v2 &&
 	test_sparse_match ls &&
 	test_sparse_match ls folder1 &&
+	run_on_all test_path_is_missing deep/untracked-deep/bogus &&
 
 	test_sparse_match test_path_is_dir folder1
 '
@@ -1201,6 +1220,8 @@ test_expect_success 'sparse-index is not expanded' '
 	ensure_not_expanded diff &&
 	git -C sparse-index add README.md &&
 	ensure_not_expanded diff --staged &&
+
+	ensure_not_expanded clean -fd &&
 
 	ensure_not_expanded checkout -f update-deep &&
 	(


### PR DESCRIPTION
## Changes
- Integrate sparse index changes into `git clean`
- Clean up & document behavior in `git stash -u`
  - Fix bug in handling of outside-of-cone untracked files
  - Add index expansion & performance test
    - In the index expansion test, `git stash -u` _does_ "expand the index". However, the index expanded is separate from the repository index, temporarily storing only the untracked files. The performance tests below also seem to confirm that this index expansion has a minimal effect on the execution time.

## Performance
The performance results aren't as dramatic as in the [first `stash` pull request](https://github.com/microsoft/git/pull/428#issuecomment-924025823) (potentially because of background processes on my machine?), but still demonstrate a) a substantial improvement in performance from full to sparse index, and b) adding the `--sparse` flag to `checkout-index` doesn't cause major slowdowns:

```
Test                                                              ms/vfs-2.33.0     sparse-index/clean    
----------------------------------------------------------------------------------------------------------
2000.2: git stash && git stash pop (full-v3)                      3.93(2.65+1.19)   4.16(2.78+1.25) +5.9% 
2000.3: git stash && git stash pop (full-v4)                      3.97(2.71+1.18)   4.02(2.81+1.14) +1.3% 
2000.4: git stash && git stash pop (sparse-v3)                    1.38(0.32+1.66)   1.34(0.33+1.81) -2.9% 
2000.5: git stash && git stash pop (sparse-v4)                    1.38(0.33+1.76)   1.34(0.32+1.69) -2.9% 
2000.6: echo >>new && git stash -u && git stash pop (full-v3)     4.49(3.00+1.44)   4.41(2.95+1.43) -1.8% 
2000.7: echo >>new && git stash -u && git stash pop (full-v4)     4.48(3.02+1.42)   4.43(3.00+1.39) -1.1% 
2000.8: echo >>new && git stash -u && git stash pop (sparse-v3)   1.81(0.57+2.05)   1.62(0.40+1.95) -10.5%
2000.9: echo >>new && git stash -u && git stash pop (sparse-v4)   1.86(0.58+2.05)   1.67(0.42+1.99) -10.2%
```