### PR TITLE
blame: enable and test the sparse index

### DIFF
--- a/builtin/blame.c
+++ b/builtin/blame.c
@@ -902,6 +902,8 @@ int cmd_blame(int argc, const char **argv, const char *prefix)
 	long anchor;
 	const int hexsz = the_hash_algo->hexsz;
 
+	prepare_repo_settings(the_repository);
+	the_repository->settings.command_requires_full_index = 0;
 	setup_default_color_by_age();
 	git_config(git_blame_config, &output_option);
 	repo_init_revisions(the_repository, &revs, NULL);

--- a/t/perf/p2000-sparse-operations.sh
+++ b/t/perf/p2000-sparse-operations.sh
@@ -121,5 +121,7 @@ test_perf_on_all git update-index --add --remove
 test_perf_on_all git diff
 test_perf_on_all git diff --staged
 test_perf_on_all git sparse-checkout reapply
+test_perf_on_all git blame $SPARSE_CONE/a
+test_perf_on_all git blame $SPARSE_CONE/f3/a
 
 test_done

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -488,13 +488,14 @@ test_expect_success 'blame with pathspec inside sparse definition' '
 
 # TODO: blame currently does not support blaming files outside of the
 # sparse definition. It complains that the file doesn't exist locally.
-test_expect_failure 'blame with pathspec outside sparse definition' '
+test_expect_success 'blame with pathspec outside sparse definition' '
 	init_repos &&
 
-	test_all_match git blame folder1/a &&
-	test_all_match git blame folder2/a &&
-	test_all_match git blame deep/deeper2/a &&
-	test_all_match git blame deep/deeper2/deepest/a
+	test_sparse_match git sparse-checkout set &&
+	test_sparse_match test_must_fail git blame folder1/a &&
+	test_sparse_match test_must_fail git blame folder2/a &&
+	test_sparse_match test_must_fail git blame deep/deeper2/a &&
+	test_sparse_match test_must_fail git blame deep/deeper2/deepest/a
 '
 
 # TODO: This behaves correctly in microsoft/git. Why?

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1322,6 +1322,15 @@ test_expect_success 'stash -u outside sparse checkout definition' '
 	test_all_match git status --porcelain=v2
 '
 
+test_expect_success 'sparse index is not expanded: blame' '
+	init_repos &&
+
+	ensure_not_expanded blame a &&
+	ensure_not_expanded blame deep/a &&
+	ensure_not_expanded blame deep/deeper1/a &&
+	ensure_not_expanded blame deep/deeper1/deepest/a
+'
+
 # NEEDSWORK: a sparse-checkout behaves differently from a full checkout
 # in this scenario, but it shouldn't.
 test_expect_success 'reset mixed and checkout orphan' '


### PR DESCRIPTION
Enable the sparse index for the 'git blame' command. The index was already
not expanded with this command, so the most interesting thing to do is
to add tests that verify that 'git blame' behaves correctly when the sparse
index is enabled and that its performance improves. More specifically, these
cases are...

1. The index is not expanded for `blame` when given paths in the sparse
checkout cone at multiple levels.
2. Performance measurably improves for `blame` with sparse index when
given paths in the sparse checkout cone at multiple levels.

The following are the performance results comparing the branch with
sparse index enabled for `blame` with the vfs-2.33.0 branch in the
microsoft/git repository:

```
Test                                       msft/vfs-2.33.0   sparse-index-blame
-----------------------------------------------------------------------------------
2000.2: git blame f2/f4/a (full-v3)        0.31(0.21+0.09)   0.32(0.21+0.10) +3.2%
2000.3: git blame f2/f4/a (full-v4)        0.29(0.19+0.08)   0.31(0.21+0.08) +6.9%
2000.4: git blame f2/f4/a (sparse-v3)      0.55(0.38+0.14)   0.23(0.14+0.07) -58.2%
2000.5: git blame f2/f4/a (sparse-v4)      0.57(0.40+0.16)   0.23(0.15+0.07) -59.6%
2000.6: git blame f2/f4/f3/a (full-v3)     0.77(0.56+0.20)   0.85(0.60+0.22) +10.4%
2000.7: git blame f2/f4/f3/a (full-v4)     0.78(0.56+0.20)   0.81(0.59+0.21) +3.8%
2000.8: git blame f2/f4/f3/a (sparse-v3)   1.07(0.78+0.28)   0.72(0.52+0.19) -32.7%
2000.9: git blame f2/f4/f3/a (sparse-v4)   1.05(0.78+0.26)   0.73(0.51+0.19) -30.5%
```

We do not include paths outside the sparse checkout cone because blame
currently does not support blaming files outside of the sparse
definition.