### PR TITLE
Remove sparse index expansions from untracked file stashes

### DIFF
--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1185,6 +1185,9 @@ test_expect_success 'sparse-index is not expanded' '
 	ensure_not_expanded stash apply stash@{0} &&
 	ensure_not_expanded stash drop stash@{0} &&
 
+	ensure_not_expanded stash -u &&
+	ensure_not_expanded stash pop &&
+
 	ensure_not_expanded stash create &&
 	oid=$(git -C sparse-index stash create) &&
 	ensure_not_expanded stash store -m "test" $oid &&
@@ -1299,28 +1302,6 @@ test_expect_success 'sparse index is not expanded: read-tree' '
 	ensure_not_expanded commit -m "test" &&
 
 	ensure_not_expanded read-tree --prefix=deep/deeper2 -u deepest
-'
-
-# NEEDSWORK: although the full repository's index is _not_ expanded as part of
-# stash, a temporary index, which is _not_ sparse, is created when stashing and
-# applying a stash of untracked files. As a result, the test reports that it
-# finds an instance of `ensure_full_index`, but it does not carry with it the
-# performance implications of expanding the full repository index.
-test_expect_success 'sparse index is not expanded: stash -u' '
-	init_repos &&
-
-	mkdir -p sparse-index/folder1 &&
-	echo >>sparse-index/README.md &&
-	echo >>sparse-index/a &&
-	echo >>sparse-index/folder1/new &&
-
-	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
-		git -C sparse-index stash -u &&
-	test_region index ensure_full_index trace2.txt &&
-
-	GIT_TRACE2_EVENT="$(pwd)/trace2.txt" GIT_TRACE2_EVENT_NESTING=10 \
-		git -C sparse-index stash pop &&
-	test_region index ensure_full_index trace2.txt
 '
 
 # NEEDSWORK: similar to `git add`, untracked files outside of the sparse

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1945,6 +1945,30 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 		}
 	}
 
+	/*
+	 * After unpacking trees, the index will be marked "sparse" if any sparse
+	 * directories have been encountered. However, the index may still be
+	 * sparse if there are no sparse directories. To make sure the index is
+	 * marked "sparse" as often as possible, the index is marked sparse if
+	 * all of the following are true:
+	 * - the command in progress allows use of a sparse index
+	 * - the index is not already sparse
+	 * - cone-mode sparse checkout with sparse index is enabled for the repo
+	 * - all index entries are inside of the sparse checkout cone
+	 */
+	if (!repo->settings.command_requires_full_index && !o->result.sparse_index &&
+	    core_apply_sparse_checkout && core_sparse_checkout_cone && repo->settings.sparse_index) {
+		o->result.sparse_index = COLLAPSED;
+		for (i = 0; i < o->result.cache_nr; i++) {
+			struct cache_entry *ce = o->result.cache[i];
+
+			if (!path_in_cone_modesparse_checkout(ce->name, &o->result)) {
+				o->result.sparse_index = COMPLETELY_FULL;
+				break;
+			}
+		}
+	}
+
 	ret = check_updates(o, &o->result) ? (-2) : 0;
 	if (o->dst_index) {
 		move_index_extensions(&o->result, o->src_index);


### PR DESCRIPTION
## Changes
- Reduce the conditions in which the index is expanded in `checkout-index --sparse` (it's only needed if a sparse directory is present to expand)
- Update `unpack_trees` to set the result to "sparse" if it does not meet any conditions that require a full index
- Move the `stash -u` & `stash pop` test out of its own custom test case and into `sparse index is not expanded`
  - It no longer expands any index, temporary or not, if all files in the stash are in the checkout cone

## Performance
Overall, there weren't substantial differences in the performance of `stash`. That's more-or-less expected - the index expansions removed only apply to the "temporary" untracked file indexes, which are substantially smaller than the regular repository index.

```
Test                                                              ms/vfs-2.33.0     remove-index-expansions
-----------------------------------------------------------------------------------------------------------
2000.2: git stash && git stash pop (full-v3)                      4.10(2.77+1.17)   3.92(2.69+1.13) -4.4%  
2000.3: git stash && git stash pop (full-v4)                      3.85(2.61+1.11)   4.19(2.83+1.18) +8.8%  
2000.4: git stash && git stash pop (sparse-v3)                    1.39(0.34+1.87)   1.47(0.35+1.85) +5.8%  
2000.5: git stash && git stash pop (sparse-v4)                    1.44(0.33+1.83)   1.48(0.35+1.78) +2.8%  
2000.6: echo >>new && git stash -u && git stash pop (full-v3)     4.68(3.10+1.54)   4.88(3.19+1.60) +4.3%  
2000.7: echo >>new && git stash -u && git stash pop (full-v4)     4.32(2.95+1.36)   4.24(2.88+1.30) -1.9%  
2000.8: echo >>new && git stash -u && git stash pop (sparse-v3)   1.60(0.39+1.84)   1.77(0.44+2.03) +10.6% 
2000.9: echo >>new && git stash -u && git stash pop (sparse-v4)   1.74(0.43+1.98)   1.76(0.44+2.23) +1.1%
```