### PR TITLE
.github: continue pestering until user upgrades

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -190,10 +190,10 @@ jobs:
           b=/usr/src/build-extra &&
 
           filename=$b/git-update-git-for-windows.config
-          tr % '\t' >$filename <<-\EOF
+          tr % '\t' >$filename <<-\EOF &&
           [update]
           %fromFork = microsoft/git
-          EOF &&
+          EOF
 
           sed -i -e '/^#include "file-list.iss"/a\
           Source: {#SourcePath}\\..\\'$filename'; DestDir: {app}\\mingw64\\bin; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore' \

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -201,6 +201,16 @@ jobs:
           Type: files; Name: {app}\\{#MINGW_BITNESS}\\bin\\git-update-git-for-windows.config\
           Type: dirifempty; Name: {app}\\{#MINGW_BITNESS}\\bin' \
             $b/installer/install.iss
+      - name: Set alerts to continue until upgrade is taken
+        shell: bash
+        run: |
+          set -x
+
+          b=/usr/src/build-extra &&
+
+          sed -i -e \
+            's/recently_seen="\$(get_recently_seen)"/recently_seen="bogus-to-keep-pestering"/' \
+            $b/git-extra/git-update-git-for-windows
       - name: Set the installer Publisher to the Git Fundamentals team
         shell: bash
         run: |


### PR DESCRIPTION
In 'git-update-git-for-windows', there is a recently_seen variable that
is loaded from Git config. This is intended to allow users to say "No, I
don't want that version of Git for Windows." If users say no, then they
are not reminded. Ever.

We want users of microsoft/git to be notified repeately until they
upgrade. The first notification might be dismissed because they don't
want to interrupt their work. They should get the picture within a few
reminders and upgrade in a timely fashion.

---

I tested this by running the `sed` command in my copy of `git-for-windows/build-extra`, and then replacing my installed version of `git-update-git-for-windows` in `C:\Program Files\Git\mingw64\bin`. Along the way, I discovered a bug in the script and created git-for-windows/build-extra#382. If you do your own testing, you will likely need that fix, too.

I also noticed a misplaced `&&` due to copying some existing scripts out of the workflow into a bash script so I could test all of the scripts simultaneously.