### PR TITLE
Fix installer builds

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -313,7 +313,7 @@ jobs:
       # Enable a bit stricter compile flags
       DEVELOPER: 1
       # For the osx-installer build
-      OSX_VERSION: 10.6
+      OSX_VERSION: 10.15
       V: 1
     steps:
       - name: Install git dependencies
@@ -370,13 +370,13 @@ jobs:
 
           PATH=/usr/local/bin:/System/Library/Frameworks:$PATH \
           make -C git_osx_installer \
-              OSX_VERSION=10.6 C_INCLUDE_PATH="$C_INCLUDE_PATH" V=1 \
-              build/intel-universal-snow-leopard/git-$VERSION/osx-built-keychain ||
+              OSX_VERSION=10.15 C_INCLUDE_PATH="$C_INCLUDE_PATH" V=1 \
+              build/intel-x86_64-catalina/git-$VERSION/osx-built-keychain ||
             die "Build failed"
 
           PATH=/usr/local/bin:$PATH \
           make -C git_osx_installer \
-              OSX_VERSION=10.6 C_INCLUDE_PATH="$C_INCLUDE_PATH" V=1 image ||
+              OSX_VERSION=10.15 C_INCLUDE_PATH="$C_INCLUDE_PATH" V=1 image ||
             die "Build failed"
 
           mkdir -p artifacts

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Clone build-extra
         shell: bash
         run: |
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
+          git clone --filter=blob:none --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
       - name: Clone git
         shell: bash
         run: |
@@ -170,7 +170,7 @@ jobs:
       - name: Clone build-extra
         shell: bash
         run: |
-          git clone --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
+          git clone --filter=blob:none --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
       - name: Prepare home directory for code-signing
         env:
           CODESIGN_P12: ${{secrets.CODESIGN_P12}}
@@ -207,9 +207,13 @@ jobs:
           set -x
 
           b=/usr/src/build-extra &&
+          str="recently_seen=.*\$" &&
 
-          sed -i -e \
-            's/recently_seen="\$(get_recently_seen)"/recently_seen="bogus-to-keep-pestering"/' \
+          echo $b/git-extra/git-update-git-for-windows &&
+          cat $b/git-extra/git-update-git-for-windows &&
+
+          sed -i -e '/^# when confirmation to do so is given./a\
+            use_recently_seen=no' \
             $b/git-extra/git-update-git-for-windows
       - name: Set the installer Publisher to the Git Fundamentals team
         shell: bash

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -196,7 +196,7 @@ jobs:
           EOF
 
           sed -i -e '/^#include "file-list.iss"/a\
-          Source: {#SourcePath}\\..\\'$filename'; DestDir: {app}\\mingw64\\bin; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore' \
+          Source: {#SourcePath}\\..\\git-update-git-for-windows.config; DestDir: {app}\\mingw64\\bin; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore' \
             -e '/^Type: dirifempty; Name: {app}\\{#MINGW_BITNESS}$/i\
           Type: files; Name: {app}\\{#MINGW_BITNESS}\\bin\\git-update-git-for-windows.config\
           Type: dirifempty; Name: {app}\\{#MINGW_BITNESS}\\bin' \


### PR DESCRIPTION
I was working last week to update the `git-update-git-for-windows` script to repeat daily reminders to upgrade. I did not succeed in doing that, but I found some other issues that are resolved in this PR:

1. We can speed up the Windows installer builds by using partial clone of the `git-for-windows/build-extra` repo.
2. There is a `filename` variable that doesn't work in one place. Use the literal path instead.
3. The macOS builds need an explicit version update to compile with FS Monitor due to compatibility issues with older versions of macOS. This required some changes to `derrickstolee/git_osx_installer`, too.

These changes were integrated in [a successful run of the `build-git-installers` workflow](https://github.com/microsoft/git/actions/runs/1321667808).