### PR TITLE
FSMonitor: deepening a directory causes confusing events (Take 2)

### DIFF
--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -198,9 +198,26 @@ int fsmonitor_is_trivial_response(const struct strbuf *query_result)
 static void fsmonitor_refresh_callback(struct index_state *istate, char *name)
 {
 	int i, len = strlen(name);
+	int pos = index_name_pos(istate, name, len);
+
+	trace_printf_key(&trace_fsmonitor,
+			 "fsmonitor_refresh_callback '%s' (pos %d)",
+			 name, pos);
+
 	if (name[len - 1] == '/') {
-		const char *rel;
-		int pos = index_name_pos(istate, name, len);
+		/*
+		 * The daemon can decorate directory events, such as
+		 * moves or renames, with a trailing slash if the OS
+		 * FS Event contains sufficient information, such as
+		 * MacOS.
+		 *
+		 * Use this to invalidate the entire cone under that
+		 * directory.
+		 *
+		 * We do not expect an exact match because the index
+		 * does not normally contain directory entries, so we
+		 * start at the insertion point and scan.
+		 */
 		if (pos < 0)
 			pos = -pos - 1;
 
@@ -208,19 +225,41 @@ static void fsmonitor_refresh_callback(struct index_state *istate, char *name)
 		for (i = pos; i < istate->cache_nr; i++) {
 			if (!starts_with(istate->cache[i]->name, name))
 				break;
-			/* Only mark the immediate children in the folder */
-			rel = istate->cache[i]->name + len;
-			if (!strchr(rel, '/'))
-				istate->cache[i]->ce_flags &= ~CE_FSMONITOR_VALID;
+			istate->cache[i]->ce_flags &= ~CE_FSMONITOR_VALID;
 		}
-		/* Need to remove the / from the path for the untracked cache */
-		name[len - 1] = '\0';
-	} else {
-		int pos = index_name_pos(istate, name, len);
 
-		if (pos >= 0) {
-			struct cache_entry *ce = istate->cache[pos];
-			ce->ce_flags &= ~CE_FSMONITOR_VALID;
+		/*
+		 * We need to remove the traling "/" from the path
+		 * for the untracked cache.
+		 */
+		name[len - 1] = '\0';
+	} else if (pos >= 0) {
+		/*
+		 * We have an exact match for this path and can just
+		 * invalidate it.
+		 */
+		istate->cache[pos]->ce_flags &= ~CE_FSMONITOR_VALID;
+	} else {
+		/*
+		 * The path is not a tracked file -or- it is a
+		 * directory event on a platform that cannot
+		 * distinguish between file and directory events in
+		 * the event handler, such as Windows.
+		 *
+		 * Scan as if it is a directory and invalidate the
+		 * cone under it.  (But remember to ignore items
+		 * between "name" and "name/", such as "name-" and
+		 * "name.".
+		 */
+		pos = -pos - 1;
+
+		for (i = pos; i < istate->cache_nr; i++) {
+			if (!starts_with(istate->cache[i]->name, name))
+				break;
+			if ((unsigned char)istate->cache[i]->name[len] > '/')
+				break;
+			if (istate->cache[i]->name[len] == '/')
+				istate->cache[i]->ce_flags &= ~CE_FSMONITOR_VALID;
 		}
 	}
 
@@ -228,7 +267,6 @@ static void fsmonitor_refresh_callback(struct index_state *istate, char *name)
 	 * Mark the untracked cache dirty even if it wasn't found in the index
 	 * as it could be a new untracked file.
 	 */
-	trace_printf_key(&trace_fsmonitor, "fsmonitor_refresh_callback '%s'", name);
 	untracked_cache_invalidate_path(istate, name, 0);
 }
 

--- a/t/t7527-builtin-fsmonitor.sh
+++ b/t/t7527-builtin-fsmonitor.sh
@@ -687,6 +687,15 @@ do
 		matrix_try $uc_val $fsm_val rename_files
 		matrix_try $uc_val $fsm_val file_to_directory
 		matrix_try $uc_val $fsm_val directory_to_file
+
+		if test $fsm_val = true
+		then
+			test_expect_success "Matrix[uc:$uc_val][fsm:$fsm_val] disable fsmonitor at end" '
+				test_might_fail git config --unset core.useBuiltinFSMonitor &&
+				git update-index --no-fsmonitor &&
+				test_might_fail git fsmonitor--daemon stop 2>/dev/null
+			'
+		fi
 	done
 done
 


### PR DESCRIPTION
This PR replaces #443 because I couldn't get Actions to refresh the base after it was moved forward.
Also this version uses a cherry-picked copy of my original branch because I couldn't get Actions to treat this as a fresh build.