### PR TITLE
[DO NOT MERGE] Hotfix candidate: disable sparse index

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -116,9 +116,9 @@ void prepare_repo_settings(struct repository *r)
 	r->settings.command_requires_full_index = 1;
 
 	/*
-	 * Initialize this as on.
+	 * Initialize this as off.
 	 */
-	r->settings.sparse_index = 1;
-	if (!repo_config_get_bool(r, "index.sparse", &value) && !value)
-		r->settings.sparse_index = 0;
+	r->settings.sparse_index = 0;
+	if (!repo_config_get_bool(r, "index.sparse", &value) && value)
+		r->settings.sparse_index = 1;
 }

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -110,7 +110,7 @@ int set_sparse_index_config(struct repository *repo, int enable)
 	char *config_path = repo_git_path(repo, "config.worktree");
 	res = git_config_set_in_file_gently(config_path,
 					    "index.sparse",
-					    enable ? "true" : "false");
+					    enable ? "true" : NULL);
 	free(config_path);
 
 	prepare_repo_settings(repo);

--- a/t/helper/test-read-cache.c
+++ b/t/helper/test-read-cache.c
@@ -39,6 +39,7 @@ int cmd__read_cache(int argc, const char **argv)
 	int table = 0, expand = 0;
 
 	initialize_the_repository();
+	setup_git_directory();
 	prepare_repo_settings(r);
 	r->settings.command_requires_full_index = 0;
 
@@ -53,7 +54,6 @@ int cmd__read_cache(int argc, const char **argv)
 
 	if (argc == 1)
 		cnt = strtol(argv[0], NULL, 0);
-	setup_git_directory();
 	git_config(git_default_config, NULL);
 
 	for (i = 0; i < cnt; i++) {

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -215,7 +215,7 @@ test_expect_success 'sparse-index enabled and disabled' '
 	test-tool -C repo read-cache --table >cache &&
 	! grep " tree " cache &&
 	git -C repo config --list >config &&
-	test_cmp_config -C repo false index.sparse
+	! grep index.sparse config
 '
 
 test_expect_success 'cone mode: init and set' '

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -147,7 +147,6 @@ init_repos () {
 	git -C sparse-index reset --hard &&
 
 	# initialize sparse-checkout definitions
-	git -C sparse-checkout config index.sparse false &&
 	git -C sparse-checkout sparse-checkout init --cone &&
 	git -C sparse-checkout sparse-checkout set deep &&
 	git -C sparse-index sparse-checkout init --cone --sparse-index &&

--- a/t/t7817-grep-sparse-checkout.sh
+++ b/t/t7817-grep-sparse-checkout.sh
@@ -49,7 +49,7 @@ test_expect_success 'setup' '
 		echo "text" >B/b &&
 		git add A B &&
 		git commit -m sub &&
-		git sparse-checkout init --cone --no-sparse-index &&
+		git sparse-checkout init --cone &&
 		git sparse-checkout set B
 	) &&
 


### PR DESCRIPTION
This is the first of two possible hotfixes for the performance issue in v2.33.0.vfs.0.0 due to #450.

This takes our latest vfs-2.33.0 branch and reverts #414, so we are not shipping the sparse index prematurely.

It does have these benefits:

* The fix for #450 is already included.
* The fixes for installer issues from #442 and #445 are included.

It also has some risks:

* It includes v5 of the FS Monitor feature, which is currently being tested in the bug bash.
* There are other sparse index changes that might have side-effects.

I'm less concerned about these risks because we have some confidence in the bug bash release, v2.33.0.vfs.0.2.