### PR TITLE
README: fix `winget` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ since `winget` is available by default on preview versions of Windows.
 To install with Winget, run
 
 ```shell
-winget install microsoft/git
+winget install --id microsoft.git
 ```
 
 Double-check that you have the right version by running these commands,


### PR DESCRIPTION
By using the '--id' option, we get around any collisions that might happen
in the msstore. See https://github.com/microsoft/VFSForGit/pull/1756 for a
similar resolution to this problem on that side.