### PR TITLE
WIP: try multiple cookies to solve MacOS scalar function test failures

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,7 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2019, macos-10.15, ubuntu-18.04, ubuntu-20.04]
+        # os: [windows-2019, macos-10.15, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, macos-10.15, macos-10.15, macos-latest, macos-latest, macos-latest]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...


### PR DESCRIPTION
A test to force the daemon to suspend client requests long enough to get more than 1 cookie to see if draining the FS queue helps avoid the random failures in the scalar functional test suite.