### PR TITLE
Fix broken apt-get bionic deployments

### DIFF
--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -91,5 +91,5 @@ jobs:
         run: |
           for id in ${{ secrets.BIONIC_REPO_ID }} ${{ secrets.HIRSUTE_REPO_ID }}
           do
-            repoclient -v v3 -c config.json package add --check --wait 300 "${{steps.get-asset.outputs.name}}" -r $id
+            repoclient -v v2 -c config.json package add --check --wait 300 "${{steps.get-asset.outputs.name}}" -r $id
           done


### PR DESCRIPTION
Our attempted deployments to the Ubuntu 18.04 (bionic) repo at
packages.microsoft.com have been failing with the following error:

"Apt repo only supports 'amd64'- based packages. 'undefined' is not
supported."

This was odd, since deployments of the same package to the Ubuntu 20.04
(hirsute) repo have been succeeding. Although the root cause of this problem
is still unknown, we discovered we can work around it by deploying to the
`v2` packages.microsoft.com endpoint instead of `v3`.