### PR TITLE
fixup! scalar register: set recommended config settings

### DIFF
--- a/contrib/scalar/scalar.c
+++ b/contrib/scalar/scalar.c
@@ -183,6 +183,7 @@ static int set_recommended_config(int reconfigure)
 		{ "commitGraph.generationVersion", "1" },
 		{ "core.autoCRLF", "false" },
 		{ "core.safeCRLF", "false" },
+		{ "fetch.showForcedUpdates", "false" },
 		{ "maintenance.gc.enabled", "false" },
 		{ "maintenance.prefetch.enabled", "true" },
 		{ "maintenance.prefetch.auto", "0" },


### PR DESCRIPTION
[We added this option in Git 2.23.0](https://github.com/git/git/commit/cdbd70c43773d534aa81ea2c83905a45ff0e74e4) to reduce `git fetch` times due to checking for forced updates of remote refs. Apparently, we never set it ourselves and instead it was being set by another tool.

Correct this error.