### PR TITLE
Bump update-winget version

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.4
+      uses: mjcheetham/update-winget@v1.4.1
       with:
         id: Microsoft.Git
         token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Since it looks like we'll be doing 1 more release with the `update-winget` action, bumping the version to include [this fix](https://github.com/mjcheetham/update-winget/pull/199), which will ensure our `winget-pkgs` PR has a description (instead of `null`).
