### PR TITLE
sparse-checkout: avoid crash when switching between cone and non-cone

### DIFF
--- a/builtin/sparse-checkout.c
+++ b/builtin/sparse-checkout.c
@@ -613,12 +613,20 @@ static void add_patterns_cone_mode(int argc, const char **argv,
 	add_patterns_from_input(pl, argc, argv);
 
 	memset(&existing, 0, sizeof(existing));
-	existing.use_cone_patterns = core_sparse_checkout_cone;
+	existing.use_cone_patterns = 1;
 
 	if (add_patterns_from_file_to_list(sparse_filename, "", 0,
 					   &existing, NULL, 0))
 		die(_("unable to load existing sparse-checkout patterns"));
 	free(sparse_filename);
+
+	/*
+	 * If use_cone_patterns has been disabled, at least one of the existing
+	 * patterns is invalid for cone mode. In that case, the hashmap does not
+	 * correctly reflect patterns, so we must exit early.
+	 */
+	if (existing.use_cone_patterns == 0)
+		die(_("unable to use existing sparse-checkout patterns in cone mode"));
 
 	hashmap_for_each_entry(&existing.recursive_hashmap, &iter, pe, ent) {
 		if (!hashmap_contains_parent(&pl->recursive_hashmap,

--- a/dir.c
+++ b/dir.c
@@ -715,6 +715,11 @@ static void add_pattern_to_hashsets(struct pattern_list *pl, struct path_pattern
 	if (!pl->use_cone_patterns)
 		return;
 
+	if (*given->pattern != '/') {
+		warning(_("unrecognized pattern: '%s'"), given->pattern);
+		goto clear_hashmaps;
+	}
+
 	if (given->flags & PATTERN_FLAG_NEGATIVE &&
 	    given->flags & PATTERN_FLAG_MUSTBEDIR &&
 	    !strcmp(given->pattern, "/*")) {

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -712,4 +712,17 @@ test_expect_success 'cone mode clears ignored subdirectories' '
 	test_cmp expect out
 '
 
+test_expect_success 'init with cone mode verifies existing cone patterns' '
+	rm -f repo/.git/info/sparse-checkout &&
+
+	# Set non-cone mode pattern
+	git -C repo sparse-checkout init &&
+	git -C repo sparse-checkout set deep/deeper*/ &&
+	git -C repo sparse-checkout disable &&
+
+	git -C repo sparse-checkout init --cone 2>err &&
+	test_i18ngrep "disabling cone mode" err &&
+	test_must_fail git -C repo config core.sparsecheckoutcone
+'
+
 test_done

--- a/t/t1091-sparse-checkout-builtin.sh
+++ b/t/t1091-sparse-checkout-builtin.sh
@@ -725,4 +725,18 @@ test_expect_success 'init with cone mode verifies existing cone patterns' '
 	test_must_fail git -C repo config core.sparsecheckoutcone
 '
 
+test_expect_success 'add with cone mode verifies existing cone patterns' '
+	rm -f repo/.git/info/sparse-checkout &&
+
+	git -C repo sparse-checkout init --cone &&
+	cat >repo/.git/info/sparse-checkout <<-\EOF &&
+	/*
+	!/*/
+	/deep/deeper*/
+	EOF
+
+	test_must_fail git -C repo sparse-checkout add folder1 2>err &&
+	test_i18ngrep "unable to use existing sparse-checkout patterns in cone mode" err
+'
+
 test_done


### PR DESCRIPTION
## Background
The goal of these changes was to fix the infinite loop (and subsequent crash) that results from running the following commands in sequence in a repository:

```
$ git sparse-checkout init
$ git sparse-checkout add folder1/
$ git sparse-checkout init --cone
$ git sparse-checkout add folder2/
```

## Changes
- Disable cone mode when `git sparse-checkout init --cone` is called with existing non-cone patterns
- Exit with an error when `git sparse-checkout add` is called in cone mode with existing non-cone patterns
- Require starting '/' in cone mode patterns (otherwise interpreting them as invalid)

These patches, taken together, fix the failure case mentioned earlier (along with other, similar cases covered in the tests added to `t1091`).

## Other Notes
I originally also had a commit that disallowed running `add`, `set`, `list`, and `reapply` when sparse-checkout is not enabled. It directly reversed the earlier decision to enable sparse-checkout when `git sparse-checkout set` is called with sparse-checkout disabled. As far as I can tell, it was added in [V5 of the patch series introducing the command](https://lore.kernel.org/git/pull.316.v5.git.1571666186.gitgitgadget@gmail.com/), but not much context is given as to why. 

Most of the motivation to remove it came from the fact that 1) when sparse-checkout is disabled, the cone mode setting isn't preserved and 2) `git sparse-checkout set` doesn't include an option to set cone mode (or sparse index). Point 1) came up in the internal bug bash and led to some unexpected behavior; point 2) could partially resolve it, but I still find the (uncomfortably silent) auto-init to be unintuitive.

I ultimately didn't include the change here because lots of tests were relying on `set` to initialize the sparse-checkout (which, to me, indicates that users might as well?). I may introduce the change again (in a later pull request), but with some updates:
- `add`, `reapply`, and `list` are still disallowed outside an active sparse-checkout
- `git sparse-checkout disable` preserves the `core.sparsecheckoutcone` setting. It would be overwritten back to the default by `git sparse-checkout init`, but could be used when init-ing with `git sparse-checkout set`
- `set` called in a disabled sparse checkout causes a warning message to be displayed that says 1) it's initializing the sparse checkout and 2) it's doing so with cone mode enabled/disabled, and to use `git sparse-checkout init` to change that setting

Let me know what you think - I definitely think there are improvements that could be made with the UX here (brought to light by the bug bash), but because I'm not really the target audience of `git sparse-checkout`, I'm not sure what the "right" UX is.