### PR TITLE
maintenance: disable cron on macOS

### DIFF
--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -2018,14 +2018,10 @@ static int schtasks_update_schedule(int run_maintenance, int fd)
 		return schtasks_remove_tasks();
 }
 
-static int is_crontab_available(void)
+MAYBE_UNUSED
+static int check_crontab_process(const char *cmd)
 {
-	const char *cmd = "crontab";
-	int is_available;
 	struct child_process child = CHILD_PROCESS_INIT;
-
-	if (get_schedule_cmd(&cmd, &is_available))
-		return is_available;
 
 	strvec_split(&child.args, cmd);
 	strvec_push(&child.args, "-l");
@@ -2039,6 +2035,25 @@ static int is_crontab_available(void)
 	/* Ignore exit code, as an empty crontab will return error. */
 	finish_command(&child);
 	return 1;
+}
+
+static int is_crontab_available(void)
+{
+	const char *cmd = "crontab";
+	int is_available;
+
+	if (get_schedule_cmd(&cmd, &is_available))
+		return is_available;
+
+#ifdef __APPLE__
+	/*
+	 * macOS has cron, but it requires special permissions and will
+	 * create a UI alert when attempting to run this command.
+	 */
+	return 0;
+#else
+	return check_crontab_process(cmd);
+#endif
 }
 
 #define BEGIN_LINE "# BEGIN GIT MAINTENANCE SCHEDULE"


### PR DESCRIPTION
In eba1ba9 (maintenance: `git maintenance run` learned
`--scheduler=<scheduler>`, 2021-09-04), we introduced the ability to
specify a scheduler explicitly. This led to some extra checks around
whether an alternative scheduler was available. This added the
functionality of removing background maintenance from schedulers other
than the one selected.

On macOS, cron is technically available, but running 'crontab' triggers
a UI prompt asking for special permissions. This is the major reason why
launchctl is used as the default scheduler. The is_crontab_available()
method triggers this UI prompt, causing user disruption.

Remove this disruption by using an #ifdef to prevent running crontab
this way on macOS. This has the unfortunate downside that if a user
manually selects cron via the '--scheduler' option, then adjusting the
scheduler later will not remove the schedule from cron. The
'--scheduler' option ignores the is_available checks, which is how we
can get into this situation.
