### PR TITLE
Fixes for MacOS release build & build options

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -354,6 +354,9 @@ jobs:
           cp git/git-$VERSION.tar.gz git/git-manpages-$VERSION.tar.gz git_osx_installer/build/ ||
             die "Could not copy .tar.gz files"
 
+          GIT_BUILT_FROM_COMMIT=$(gunzip -c git/git-$VERSION.tar.gz | git get-tar-commit-id) ||
+            die "Could not determine commit for build"
+
           # drop the -isysroot `GIT_SDK` hack
           sed -i .bak -e 's/ -isysroot .(SDK_PATH)//' git_osx_installer/Makefile || die "Could not drop the -isysroot hack"
 
@@ -371,6 +374,7 @@ jobs:
 
           PATH=/usr/local/bin:$PATH \
           make -C git_osx_installer \
+              GIT_BUILT_FROM_COMMIT=$GIT_BUILT_FROM_COMMIT \
               OSX_VERSION=10.15 C_INCLUDE_PATH="$C_INCLUDE_PATH" V=1 image ||
             die "Build failed"
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /fuzz-pack-headers
 /fuzz-pack-idx
 /GIT-BUILD-OPTIONS
+/GIT-BUILT-FROM-COMMIT
 /GIT-CFLAGS
 /GIT-LDFLAGS
 /GIT-PREFIX

--- a/Makefile
+++ b/Makefile
@@ -2262,9 +2262,9 @@ git$X: git.o GIT-LDFLAGS $(BUILTIN_OBJS) $(GITLIBS)
 		$(filter %.o,$^) $(LIBS)
 
 help.sp help.s help.o: command-list.h
-hook.sp hook.s hook.o: hook-list.h
+builtin/bugreport.sp builtin/bugreport.s builtin/bugreport.o: hook-list.h
 
-builtin/help.sp builtin/help.s builtin/help.o: config-list.h hook-list.h GIT-PREFIX
+builtin/help.sp builtin/help.s builtin/help.o: config-list.h GIT-PREFIX
 builtin/help.sp builtin/help.s builtin/help.o: EXTRA_CPPFLAGS = \
 	'-DGIT_HTML_PATH="$(htmldir_relative_SQ)"' \
 	'-DGIT_MAN_PATH="$(mandir_relative_SQ)"' \

--- a/Makefile
+++ b/Makefile
@@ -3274,7 +3274,7 @@ dist: git-archive$(X) configure
 	@$(MAKE) -C git-gui TARDIR=../.dist-tmp-dir/git-gui dist-version
 	./git-archive --format=tar \
 		$(GIT_ARCHIVE_EXTRA_FILES) \
-		--prefix=$(GIT_TARNAME)/ HEAD^{tree} > $(GIT_TARNAME).tar
+		--prefix=$(GIT_TARNAME)/ HEAD > $(GIT_TARNAME).tar
 	@$(RM) -r .dist-tmp-dir
 	gzip -f -9 $(GIT_TARNAME).tar
 

--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,10 @@ all::
 # Define GIT_USER_AGENT if you want to change how git identifies itself during
 # network interactions.  The default is "git/$(GIT_VERSION)".
 #
+# Define GIT_BUILT_FROM_COMMIT if you want to force the commit hash identified
+# in 'git version --build-options' to a specific value. The default is the
+# commit hash of the current HEAD.
+#
 # Define DEFAULT_HELP_FORMAT to "man", "info" or "html"
 # (defaults to "man") if you want to have a different default when
 # "git help" is called without a parameter specifying the format.
@@ -2147,6 +2151,15 @@ GIT-USER-AGENT: FORCE
 		echo '$(GIT_USER_AGENT_SQ)' >GIT-USER-AGENT; \
 	fi
 
+GIT_BUILT_FROM_COMMIT = $(eval GIT_BUILT_FROM_COMMIT := $$(shell \
+	GIT_CEILING_DIRECTORIES="$$(CURDIR)/.." \
+	git rev-parse -q --verify HEAD 2>/dev/null))$(GIT_BUILT_FROM_COMMIT)
+GIT-BUILT-FROM-COMMIT: FORCE
+	@if test x'$(GIT_BUILT_FROM_COMMIT)' != x"`cat GIT-BUILT-FROM-COMMIT 2>/dev/null`" ; then \
+		echo >&2 "    * new built-from commit"; \
+		echo '$(GIT_BUILT_FROM_COMMIT)' >GIT-BUILT-FROM-COMMIT; \
+	fi
+
 ifdef DEFAULT_HELP_FORMAT
 BASIC_CFLAGS += -DDEFAULT_HELP_FORMAT='"$(DEFAULT_HELP_FORMAT)"'
 endif
@@ -2270,13 +2283,11 @@ builtin/help.sp builtin/help.s builtin/help.o: EXTRA_CPPFLAGS = \
 	'-DGIT_MAN_PATH="$(mandir_relative_SQ)"' \
 	'-DGIT_INFO_PATH="$(infodir_relative_SQ)"'
 
-version.sp version.s version.o: GIT-VERSION-FILE GIT-USER-AGENT
+version.sp version.s version.o: GIT-VERSION-FILE GIT-USER-AGENT GIT-BUILT-FROM-COMMIT
 version.sp version.s version.o: EXTRA_CPPFLAGS = \
 	'-DGIT_VERSION="$(GIT_VERSION)"' \
 	'-DGIT_USER_AGENT=$(GIT_USER_AGENT_CQ_SQ)' \
-	'-DGIT_BUILT_FROM_COMMIT="$(shell \
-		GIT_CEILING_DIRECTORIES="$(CURDIR)/.." \
-		git rev-parse -q --verify HEAD 2>/dev/null)"'
+	'-DGIT_BUILT_FROM_COMMIT="$(GIT_BUILT_FROM_COMMIT)"'
 
 $(BUILT_INS): git$X
 	$(QUIET_BUILT_IN)$(RM) $@ && \


### PR DESCRIPTION
Depends on: https://github.com/derrickstolee/git_osx_installer/pull/8

## Changes
- Update `make dist` to archive the `HEAD` commit, rather than the `HEAD` tree (preserves commit hash in tar header)
- Allow manual specification of `GIT_BUILT_FROM_COMMIT` (like e.g. `GIT_USER_AGENT`)
- Use `make dist` archive commit hash as `GIT_BUILT_FROM_COMMIT` in `build-git-installers.yml`
- Fix dependency issue with `hook-list.h`
  - Pulled (early) from upstream
  - Dependency issue only seems to appear consistently on `macos-latest` - for some reason, `macos-10.15` doesn't show the same issue. Regardless, this is a good fix to have in case of a mid-cycle release

## Testing
- Test installer build (including corresponding changes to `git_osx_installer` Makefile): https://github.com/vdye/git_osx_installer/actions/runs/1531273864
- `build-git-installers` execution: https://github.com/vdye/git/actions/runs/1532263438
  - Note: this will NOT include the value in `git version --build-options`, as it relies on the corresponding change in `git_osx_installer` to be merged 