### PR TITLE
winget: fix asset/release regexes to match correctly

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -11,10 +11,10 @@ jobs:
         run: |
           # Get correct release asset
           $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
-          $asset = $github.release.assets | Where-Object -Property name -match '.exe$'
+          $asset = $github.release.assets | Where-Object -Property name -match '64-bit.exe$'
 
           # Remove 'v' and 'vfs' from the version
-          $assets.tag_name -match '\d.*'
+          $github.release.tag_name -match '\d.*'
           $version = $Matches[0] -replace ".vfs",""
 
           # Download and run wingetcreate


### PR DESCRIPTION
We had a couple issues in our `release-winget` pipeline that were obfuscated by the error we were getting from `wingetcreate` (fixed with [#206](https://github.com/microsoft/winget-create/pull/206)) and some confusion with PowerShell variables:

1. We were matching on `.exe`, meaning we matched on both the Git and PortableGit assets. This caused `wingetcreate` to attempt to update the `Microsoft.Git` manifest with both assets and return the initial error that tipped us off to something being amiss: `Updating a manifest is only supported with the same number of installer URLs.` This has been fixed by instead matching on `64-bit.exe`.

2. We were trying to match on the `$assets` variable, which does not exist in this version of the script. This caused the initial value of `$Matches[0]` to be saved to the `$version` variable, and the version that the Microsoft.Git manifest was updated to was `64-bit.exe`, rather than `2.34.1.0.0`. This was corrected by updating `$assets` to `$github.release`.

Here is a repro of the initial failure described in item 1 above:
https://github.com/ldennington/git/runs/4512447452?check_suite_focus=true

Here is a repro of the version error described in item 2 above:
https://github.com/ldennington/git/runs/4513024477?check_suite_focus=true

Here is a successful run with the fixes in place:
https://github.com/ldennington/git/runs/4513446852?check_suite_focus=true
