### PR TITLE
.github: update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,25 @@
- - [ ] I was not able to find an [open](https://github.com/git-for-windows/git/issues?q=is%3Aopen) or [closed](https://github.com/git-for-windows/git/issues?q=is%3Aclosed) issue matching what I'm seeing
+ - [ ] I was not able to find an [open](https://github.com/microsoft/git/issues?q=is%3Aopen)
+        or [closed](https://github.com/microsoft/git/issues?q=is%3Aclosed) issue matching
+        what I'm seeing, including in [the `git-for-windows/git` tracker](https://github.com/git-for-windows/git/issues).
 
 ### Setup
 
- - Which version of Git for Windows are you using? Is it 32-bit or 64-bit?
+ - Which version of `microsoft/git` are you using? Is it 32-bit or 64-bit?
 
 ```
 $ git --version --build-options
+
+** insert your machine's response here **
+```
+
+Are you using Scalar or VFS for Git?
+
+** insert your answer here **
+
+If VFS for Git, then what version?
+
+```
+$ gvfs version
 
 ** insert your machine's response here **
 ```
@@ -14,19 +28,6 @@ $ git --version --build-options
 
 ```
 $ cmd.exe /c ver
-
-** insert your machine's response here **
-```
-
- - What options did you set as part of the installation? Or did you choose the
-   defaults?
-
-```
-# One of the following:
-> type "C:\Program Files\Git\etc\install-options.txt"
-> type "C:\Program Files (x86)\Git\etc\install-options.txt"
-> type "%USERPROFILE%\AppData\Local\Programs\Git\etc\install-options.txt"
-$ cat /etc/install-options.txt
 
 ** insert your machine's response here **
 ```
@@ -57,7 +58,11 @@ $ cat /etc/install-options.txt
 
 ** insert here **
 
- - If the problem was occurring with a specific repository, can you provide the
-   URL to that repository to help us with testing?
+ - If the problem was occurring with a specific repository, can you specify
+   the repository?
 
-** insert URL here **
+   * [ ] Public repo: **insert URL here**
+   * [ ] Windows monorepo
+   * [ ] Office monorepo
+   * [ ] Other Microsoft-internal repo: **insert name here**
+   * [ ] Other internal repo.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,10 @@
 Thanks for taking the time to contribute to Git!
 
-Those seeking to contribute to the Git for Windows fork should see
-http://gitforwindows.org/#contribute on how to contribute Windows specific
-enhancements.
+This fork contains changes specific to monorepo scenarios. If you are an
+external contributor, then please detail your reason for submitting to
+this fork:
 
-If your contribution is for the core Git functions and documentation
-please be aware that the Git community does not use the github.com issues
-or pull request mechanism for their contributions.
-
-Instead, we use the Git mailing list (git@vger.kernel.org) for code and
-documentation submissions, code reviews, and bug reports. The
-mailing list is plain text only (anything with HTML is sent directly
-to the spam folder).
-
-Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
-to conveniently send your Pull Requests commits to our mailing list.
-
-Please read the "guidelines for contributing" linked above!
+* [ ] This is an early version of work already under review upstream.
+* [ ] This change only applies to interactions with Azure DevOps and the
+      GVFS Protocol.
+* [ ] This change only applies to the virtualization hook and VFS for Git.


### PR DESCRIPTION
This fork inherited the issue and pull request templates from `git-for-windows/git`, but `microsoft/git` could use different templates to help external contributors.