### PR TITLE
homebrew: avoid creating PR on pkg release

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -27,4 +27,3 @@ jobs:
         type: cask
         version: ${{ steps.version.outputs.result }}
         sha256: ${{ steps.hash.outputs.result }}
-        alwaysUsePullRequest: true


### PR DESCRIPTION
Update the GitHub workflow for Homebrew releases to avoid always creating a PR when a new release is made.

Q: is this the correct target branch? or vfs-next? @derrickstolee 