### PR TITLE
ci: fix `windows-build` with GCC v12.x

### DIFF
--- a/compat/nedmalloc/nedmalloc.c
+++ b/compat/nedmalloc/nedmalloc.c
@@ -323,7 +323,6 @@ static NOINLINE void RemoveCacheEntries(nedpool *p, threadcache *tc, unsigned in
 }
 static void DestroyCaches(nedpool *p) THROWSPEC
 {
-	if(p->caches)
 	{
 		threadcache *tc;
 		int n;

--- a/compat/win32/syslog.c
+++ b/compat/win32/syslog.c
@@ -43,6 +43,7 @@ void syslog(int priority, const char *fmt, ...)
 	va_end(ap);
 
 	while ((pos = strstr(str, "%1")) != NULL) {
+		size_t offset = pos - str;
 		char *oldstr = str;
 		str = realloc(str, st_add(++str_len, 1));
 		if (!str) {
@@ -50,6 +51,7 @@ void syslog(int priority, const char *fmt, ...)
 			warning_errno("realloc failed");
 			return;
 		}
+		pos = str + offset;
 		memmove(pos + 2, pos + 1, strlen(pos));
 		pos[1] = ' ';
 	}

--- a/dir.c
+++ b/dir.c
@@ -3077,6 +3077,15 @@ char *git_url_basename(const char *repo, int is_bundle, int is_bare)
 	}
 
 	/*
+	 * It should not be possible to overflow `ptrdiff_t` by passing in an
+	 * insanely long URL, but GCC does not know that and will complain
+	 * without this check.
+	 */
+	if (end - start < 0)
+		die(_("No directory name could be guessed.\n"
+		      "Please specify a directory on the command line"));
+
+	/*
 	 * Strip trailing port number if we've got only a
 	 * hostname (that is, there is no dir separator but a
 	 * colon). This check is required such that we do not

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2909,7 +2909,7 @@ static void do_req(const char *url_base,
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS,
 				 params->post_payload->buf);
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE,
-				 params->post_payload->len);
+				 (long)params->post_payload->len);
 	} else {
 		curl_easy_setopt(slot->curl, CURLOPT_POST, 0);
 	}

--- a/http.c
+++ b/http.c
@@ -1367,6 +1367,32 @@ void run_active_slot(struct active_request_slot *slot)
 			select(max_fd+1, &readfds, &writefds, &excfds, &select_timeout);
 		}
 	}
+
+	/*
+	 * The value of slot->finished we set before the loop was used
+	 * to set our "finished" variable when our request completed.
+	 *
+	 * 1. The slot may not have been reused for another requst
+	 *    yet, in which case it still has &finished.
+	 *
+	 * 2. The slot may already be in-use to serve another request,
+	 *    which can further be divided into two cases:
+	 *
+	 * (a) If call run_active_slot() hasn't been called for that
+	 *     other request, slot->finished would have been cleared
+	 *     by get_active_slot() and has NULL.
+	 *
+	 * (b) If the request did call run_active_slot(), then the
+	 *     call would have updated slot->finished at the beginning
+	 *     of this function, and with the clearing of the member
+	 *     below, we would find that slot->finished is now NULL.
+	 *
+	 * In all cases, slot->finished has no useful information to
+	 * anybody at this point.  Some compilers warn us for
+	 * attempting to smuggle a pointer that is about to become
+	 * invalid, i.e. &finished.  We clear it here to assure them.
+	 */
+	slot->finished = NULL;
 }
 
 static void release_active_slot(struct active_request_slot *slot)


### PR DESCRIPTION
I noticed in https://github.com/microsoft/git/pull/508 that a recent update of GCC in Git for Windows' SDK (a subset of which is used in Git's CI/PR builds) broke the build. Let's fix it.

This is a companion of https://github.com/gitgitgadget/git/pull/1238 and https://github.com/git-for-windows/git/pull/3864.