### PR TITLE
fixup! homebrew: add GitHub workflow to release Cask

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -27,4 +27,4 @@ jobs:
         type: cask
         version: ${{ steps.version.outputs.result }}
         sha256: ${{ steps.hash.outputs.result }}
-        alwaysUsePullRequest: true
+        alwaysUsePullRequest: false


### PR DESCRIPTION
We initially used pull requests for the Homebrew releases as a manual
step to ensure that the automation didn't do anything too problematic.
However, we are now manually approving something that has never failed.
Let's just push directly to the branch, if possible, reducing the manual
steps involved in the release process.