### PR TITLE
Avoid using the `full` flavor of `setup-git-for-windows-sdk`

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -69,7 +69,7 @@ jobs:
           echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
-          flavor: full
+          flavor: build-installers
       - name: Clone build-extra
         shell: bash
         run: |
@@ -166,7 +166,7 @@ jobs:
           path: pkg-x86_64
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
-          flavor: full
+          flavor: build-installers
       - name: Clone build-extra
         shell: bash
         run: |


### PR DESCRIPTION
Now that [the `build-installers` flavor of `setup-git-for-windows-sdk` works again](https://github.com/git-for-windows/setup-git-for-windows-sdk/pull/384), we can use it again (which is _much_ faster than using the `full` flavor).