### PR TITLE
Update releases to work with new SSL certificate

### DIFF
--- a/.github/scripts/run-esrp-signing.py
+++ b/.github/scripts/run-esrp-signing.py
@@ -18,10 +18,6 @@ args = parser.parse_args()
 esrp_tool = os.path.join("esrp", "tools", "EsrpClient.exe")
 
 aad_id = os.environ['AZURE_AAD_ID'].strip()
-# We temporarily need two AAD IDs, as we're using an SSL certificate associated
-# with an older App Registration until we have the required hardware to approve
-# the new certificate in SSL Admin.
-aad_id_ssl = os.environ['AZURE_AAD_ID_SSL'].strip()
 workspace = os.environ['GITHUB_WORKSPACE'].strip()
 
 source_location = args.path
@@ -36,9 +32,10 @@ auth_json = {
     "TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "ClientId": f"{aad_id}",
     "AuthCert": {
-            "SubjectName": f"CN={aad_id_ssl}.microsoft.com",
+            "SubjectName": f"CN={aad_id}.microsoft.com",
             "StoreLocation": "LocalMachine",
-            "StoreName": "My"
+            "StoreName": "My",
+            "SendX5c" :  "true"
     },
     "RequestSigningCert": {
             "SubjectName": f"CN={aad_id}",

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -402,10 +402,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_SIGNING_OP_CODE: ${{ secrets.APPLE_SIGNING_OPERATION_CODE }}
       run: |
@@ -514,10 +510,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_SIGNING_OP_CODE: ${{ secrets.APPLE_SIGNING_OPERATION_CODE }}
       run: |
@@ -534,10 +526,6 @@ jobs:
       shell: pwsh
       env:
         AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-        # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-        # with an older App Registration until we have the required hardware to approve
-        # the new certificate in SSL Admin.
-        AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
         APPLE_KEY_CODE: ${{ secrets.APPLE_KEY_CODE }}
         APPLE_NOTARIZATION_OP_CODE: ${{ secrets.APPLE_NOTARIZATION_OPERATION_CODE }}
       run: |
@@ -691,10 +679,6 @@ jobs:
         shell: pwsh
         env:
           AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
-          # We temporarily need two AAD IDs, as we're using an SSL certificate associated
-          # with an older App Registration until we have the required hardware to approve
-          # the new certificate in SSL Admin.
-          AZURE_AAD_ID_SSL: ${{ secrets.AZURE_AAD_ID_SSL }}
           LINUX_KEY_CODE: ${{ secrets.LINUX_KEY_CODE }}
           LINUX_OP_CODE: ${{ secrets.LINUX_OPERATION_CODE }}
         run: |


### PR DESCRIPTION
This PR contains the required changes to use our [new auto-rotating SSL certificate](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/Certificate/https://msft-git-esrp.vault.azure.net/certificates/esrp-ssl-autorotation). There are two main parts:

1. Adding the "SendX5c" :  "true" key value pair to the contents of our ESRP Auth Json file. This allows us to use the new auto-rotating certificate without having to upload/manage it from our [App Registration](https://ms.portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/6db94d07-8532-429f-9080-5e889a85873c/isMSAApp~/false).
2. Removing the`AZURE_AAD_ID_SSL` secret/environment variable. The new certificate was generated with our main `AZURE_AAD_ID` app registration, so this extra ID is no longer needed.

Here is [a successful test run of the macOS workflow](https://github.com/ldennington/git/runs/7435523886?check_suite_focus=true) with these changes.