### PR TITLE
build-git-installers: verify that the `.exe` files are code-signed

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -285,6 +285,12 @@ jobs:
             git signtool artifacts/PortableGit-*.exe
           fi &&
           openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.exe | sed "s/.* //" >artifacts/sha-256.txt
+      - name: Verify that .exe files are code-signed
+        if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        shell: bash
+        run: |
+          PATH=$PATH:"/c/Program Files (x86)/Windows Kits/10/App Certification Kit/" \
+          signtool verify //pa artifacts/${{matrix.artifact.fileprefix}}-*.exe
       - name: Publish ${{matrix.artifact.name}}-x86_64
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
As pointed out in #519, we inadvertently used an expired code-signing certificate when building v2.37.1. Let's catch such problems already in the workflow run that builds the Git installers & friends.