### PR TITLE
release: update Azure storage resource names

### DIFF
--- a/.github/scripts/set-up-esrp.ps1
+++ b/.github/scripts/set-up-esrp.ps1
@@ -1,5 +1,5 @@
 # Install ESRP client
-az storage blob download --file esrp.zip --account-key "$env:AZURE_STORAGE_KEY" --account-name msftgitesrp --container microsoft-esrp-client --name microsoft.esrpclient.1.2.76.nupkg
+az storage blob download --file esrp.zip --account-key "$env:AZURE_STORAGE_KEY" --account-name esrpsigningstorage --container signing-resources --name microsoft.esrpclient.1.2.76.nupkg
 Expand-Archive -Path esrp.zip -DestinationPath .\esrp
 
 # Install certificates

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
         run: |
-          az storage blob download --subscription  "$AZ_SUB" --account-name msftgitesrp -c microsoft-repoclient -n azure-repoapi-client_2.0.1_amd64.deb -f repoclient.deb --auth-mode login
+          az storage blob download --subscription  "$AZ_SUB" --account-name esrpsigningstorage -c signing-resources -n azure-repoapi-client_2.0.1_amd64.deb -f repoclient.deb --auth-mode login
 
       - name: "Install Repo Client"
         run: |


### PR DESCRIPTION
The previous Azure resource architecture separated GCM and Microsoft Git
resources into different Resource Groups. This led to redundancy - we were
storing all our secrets, certificates, etc. in two places. These updates
reflect the consolidation of these resources into a new [esrp Resource
Group](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/ac604cc8-0d98-4033-8766-b4a1407dfe2f/resourceGroups/esrp/overview).

These changes were validated with [this successful `build-git-installers` workflow](https://github.com/microsoft/git/actions/runs/2805671182) and [this successful `release-apt-get` workflow](https://github.com/ldennington/git/actions/runs/2805745811).


