### PR TITLE
_Really_ fix links to the Scalar documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ In addition to the Git command-line interface (CLI), `microsoft/git` includes th
 further enable working with extremely large repositories. Scalar is a tool to apply the latest
 recommendations and use the most advanced Git features. You can read
 [the Scalar CLI documentation](Documentation/scalar.txt) or read our
-[Scalar user guide](Documentation/scalar/docs/index.md) including
-[the philosophy of Scalar](Documentation/scalar/docs/philosophy.md).
+[Scalar user guide](contrib/scalar/docs/index.md) including
+[the philosophy of Scalar](contrib/scalar/docs/philosophy.md).
 
 If you encounter problems with `microsoft/git`, please report them as
 [GitHub issues](https://github.com/microsoft/git/issues).


### PR DESCRIPTION
#528  missed the fact that some of the Scalar documentation is still in `contrib/`, not in `Documentation/`. Sorry about that.