### PR TITLE
Fix `scalar diagnose` failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1351,6 +1351,7 @@ BASIC_CFLAGS += -DSHA1DC_FORCE_ALIGNED_ACCESS
 endif
 ifneq ($(filter leak,$(SANITIZERS)),)
 BASIC_CFLAGS += -DSUPPRESS_ANNOTATED_LEAKS
+BASIC_CFLAGS += -O0
 SANITIZE_LEAK = YesCompiledWithIt
 endif
 ifneq ($(filter address,$(SANITIZERS)),)

--- a/scalar.c
+++ b/scalar.c
@@ -930,6 +930,8 @@ static int cmd_diagnose(int argc, const char **argv)
 	setup_enlistment_directory(argc, argv, usage, options, &diagnostics_root);
 	strbuf_addstr(&diagnostics_root, "/.scalarDiagnostics");
 
+	/* Here, a failure should not repeat itself. */
+	git_retries = 1;
 	res = run_git("diagnose", "--mode=all", "-s", "%Y%m%d_%H%M%S",
 		      "-o", diagnostics_root.buf, NULL);
 


### PR DESCRIPTION
This resolves #541.

The root cause here is that this loop that intended to get all files from the `info` directory of the shared object cache _never worked_, but previously we did not propagate that to a complete failure.

The reason it didn't work is that we tried to read file contents from the directory path.

I also noticed a silly retry issue because we are now using `run_git()` which does three retries due to concurrency issues in the functional tests. We don't want to repeat failures three times in `scalar diagnose`.