### PR TITLE
docs: remove versions from Debian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ Or you can run the `git update-microsoft-git` command, which will run those brew
 ## Linux
 ### Ubuntu/Debian distributions
 
-On newer distributions*, you may use the most recent
-[Debian package](https://github.com/microsoft/git/releases). For
-example, you can download a specific version as follows:
+On newer distributions*, you can download the most recent Debian package from
+the [releases page](https://github.com/microsoft/git/releases/latest) (or
+using a tool such as `wget`) then run:
 
 ```shell
-wget -O microsoft-git.deb https://github.com/microsoft/git/releases/download/v2.33.0.vfs.0.0/microsoft-git_2.33.0.vfs.0.0.deb
-sudo dpkg -i microsoft-git.deb
+sudo dpkg -i <path to package>
 ```
 
 Double-check that you have the right version by running these commands,


### PR DESCRIPTION
Although meant to simply be an example, having a concrete version in the Debian package install instructions proved to be problematic from multiple standpoints, including:

1. It made it easy for users to download an outdated version.
2. It was not updated when package naming conventions changed.

This change replaces versions with a link to the latest release/a placeholder for the package path for users to fill in after downloading.
