### PR TITLE
Remove deprecated parts of Actions workflows

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -587,7 +587,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q --no-install-recommends gettext libcurl4-gnutls-dev libpcre3-dev asciidoc xmlto
       - name: Clone git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: git
       - name: Build and package .deb

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -23,7 +23,7 @@ jobs:
           echo "version=${GITHUB_REF#refs/tags/v}" >>$GITHUB_OUTPUT
         id: tag
       - name: Determine whether signing certificates are present
-        run: echo "::set-output name=signable::$([[ $AZ_SUB != '' && $AZ_CREDS != '' ]] && echo 'true' || echo 'false')"
+        run: echo "signable=$([[ $AZ_SUB != '' && $AZ_CREDS != '' ]] && echo 'true' || echo 'false')" >>$GITHUB_OUTPUT
         id: deb
       - name: Clone git
         uses: actions/checkout@v2

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -659,7 +659,7 @@ jobs:
       ARTIFACTS_DIR: artifacts
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'git'
       - name: Download unsigned packages

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Determine tag to build
         run: |
-          echo "::set-output name=name::${GITHUB_REF#refs/tags/}"
-          echo "::set-output name=version::${GITHUB_REF#refs/tags/v}"
+          echo "name=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/v}" >>$GITHUB_OUTPUT
         id: tag
       - name: Determine whether signing certificates are present
         run: echo "::set-output name=signable::$([[ $AZ_SUB != '' && $AZ_CREDS != '' ]] && echo 'true' || echo 'false')"

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "signable=$([[ $AZ_SUB != '' && $AZ_CREDS != '' ]] && echo 'true' || echo 'false')" >>$GITHUB_OUTPUT
         id: deb
       - name: Clone git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate the tag identified with trigger
         run: |
           die () {

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -784,7 +784,7 @@ jobs:
         with:
           name: deb-package-unsigned
           path: deb-package
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
@@ -797,7 +797,7 @@ jobs:
 
             // Create the release
             var tagName = "${{ needs.prereqs.outputs.tag_name }}";
-            var createdRelease = await github.repos.createRelease({
+            var createdRelease = await github.rest.repos.createRelease({
               ...releaseMetadata,
               draft: true,
               tag_name: tagName,
@@ -814,7 +814,7 @@ jobs:
                   })
                   .map(async (file) => {
                     var filePath = path.join(directory, file);
-                    github.repos.uploadReleaseAsset({
+                    github.rest.repos.uploadReleaseAsset({
                       ...releaseMetadata,
                       name: file,
                       headers: {

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: azure/login@v1
         with:

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -13,13 +13,13 @@ jobs:
         echo "result=$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")" >>$GITHUB_OUTPUT
     - id: hash
       name: Compute release asset hash
-      uses: mjcheetham/asset-hash@v1
+      uses: mjcheetham/asset-hash@v1.1
       with:
         asset: /git-(.*)\.pkg/
         hash: sha256
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Update scalar Cask
-      uses: mjcheetham/update-homebrew@v1.1
+      uses: mjcheetham/update-homebrew@v1.3
       with:
         token: ${{ secrets.HOMEBREW_TOKEN }}
         tap: microsoft/git

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -10,7 +10,7 @@ jobs:
     - id: version
       name: Compute version number
       run: |
-        echo "::set-output name=result::$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")"
+        echo "result=$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")" >>$GITHUB_OUTPUT
     - id: hash
       name: Compute release asset hash
       uses: mjcheetham/asset-hash@v1

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Archive Trace2 Logs
         if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows.conclusion == 'success' )
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.TRACE2_BASENAME }}.zip
           path: scalar/${{ env.TRACE2_BASENAME }}.zip

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out Git's source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup build tools on Windows
         if: runner.os == 'Windows'
@@ -118,7 +118,7 @@ jobs:
           case "$(scalar version 2>&1)" in *.vfs.*) echo Good;; *) exit 1;; esac
 
       - name: Check out Scalar's source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
           path: scalar

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ env.SCALAR_REF }}
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.1.302
 

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2019, macos-10.15, ubuntu-18.04, ubuntu-20.04]
+        os: [windows-2019, macos-11, ubuntu-20.04, ubuntu-22.04]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...
         features: [ignored]
         exclude:
           # The built-in FSMonitor is not (yet) supported on Linux
-          - os: ubuntu-18.04
-            features: experimental
           - os: ubuntu-20.04
+            features: experimental
+          - os: ubuntu-22.04
             features: experimental
     runs-on: ${{ matrix.os }}
 
@@ -128,7 +128,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 3.1.302
+          dotnet-version: '3.1.x'
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
These fixups should fix all of the deprecation warnings found across this repository's workflows with the exception of `check-whitespace` (fixed upstream) and `git-artifacts` (removed upstream).

- Patches 1-3 fix `set-output` syntax
- Patches 4-8 upgrade the version of `actions/checkout`
- Patch 9 upgrades `actions/github-script` and updates usage of the `github` instance
- Patch 10 upgrades `actions/setup-dotnet` to v3
- Patch 11 upgrades `actions/upload-artifact` to v3
- Patch 12 upgrades the `mjcheetham/*` actions (see the pull requests updating [`asset-hash`](https://github.com/mjcheetham/asset-hash/pull/342) and [`update-homebrew`](https://github.com/mjcheetham/update-homebrew/pull/17) for more details).
- Patch 13 upgrades the OS versions used in the Scalar Functional tests to Actions-supported versions. This patch can be dropped if we still want to test the older OS versions.