### PR TITLE
scalar: set core.fsync=all for stability

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -185,6 +185,7 @@ static int set_recommended_config(int reconfigure)
 		{ "core.safeCRLF", "false" },
 		{ "fetch.showForcedUpdates", "false" },
 		{ "core.configWriteLockTimeoutMS", "150" },
+		{ "core.fsync", "all" },
 		{ NULL, NULL },
 	};
 	int i;


### PR DESCRIPTION
The core.fsync config option was introduced in b9f5d0358d2 (core.fsync: documentation and user-friendly aggregate options, 2022-03-15), and first shipped in Git 2.36.0. This config option allows customizing which layers of Git data require fsync().

One issue is that 020406eaa52 (core.fsync: introduce granular fsync control infrastructure, 2022-03-10) changed the default behavior of fsync()ing index files (among others) such that users are starting to see issues where their .idx files are empty, halting their interactions with their repositories.

Setting core.fsync=all will use fsync() in all possible places, avoiding this issue in any data written by Git. Here, we are preferring stability over performance. This is left as an optional setting so users can override with their preferred setting, if needed. At that point, they accept the risk of not fsync()ing.

* [X] This is an early version of work ~~already under review~~ to consider for upstream contribution.

---

This is something that is affecting users right now, specifically when using the GVFS protocol. The precomputed prefetch packs are getting empty `.idx` files pretty frequently. This is very likely an `fsync()` issue, but the frequency is still alarming.