### PR TITLE
Upgrade deprecated GitHub Actions in `build-git-installers`

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -138,7 +138,7 @@ jobs:
           git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
           git bundle create "$b"/MINGW-packages.bundle origin/main..main)
       - name: Publish mingw-w64-x86_64-git
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pkg-x86_64
           path: artifacts
@@ -292,7 +292,7 @@ jobs:
           PATH=$PATH:"/c/Program Files (x86)/Windows Kits/10/App Certification Kit/" \
           signtool verify //pa artifacts/${{matrix.artifact.fileprefix}}-*.exe
       - name: Publish ${{matrix.artifact.name}}-x86_64
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: win-${{matrix.artifact.name}}-x86_64
           path: artifacts

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -663,7 +663,7 @@ jobs:
         with:
           path: 'git'
       - name: Download unsigned packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: deb-package-unsigned
           path: unsigned

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -157,7 +157,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Download pkg-x86_64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pkg-x86_64
           path: pkg-x86_64

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -577,7 +577,7 @@ jobs:
 
   # Build & sign Ubuntu package
   ubuntu_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: prereqs
     steps:
       - name: Install git dependencies

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -753,34 +753,34 @@ jobs:
         needs.windows_artifacts.result == 'success')
     steps:
       - name: Download Windows portable installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: win-portable-x86_64
           path: win-portable-x86_64
       - name: Download Windows x86_64 installer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: win-installer-x86_64
           path: win-installer-x86_64
       - name: Download Mac dmg
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: osx-dmg
           path: osx-dmg
       - name: Download Mac pkg
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: osx-signed-pkg
           path: osx-pkg
       - name: Download Ubuntu package (signed)
         if: needs.prereqs.outputs.deb_signable == 'true'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: deb-package-signed
           path: deb-package
       - name: Download Ubuntu package (unsigned)
         if: needs.prereqs.outputs.deb_signable != 'true'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: deb-package-unsigned
           path: deb-package

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -647,7 +647,7 @@ jobs:
           mkdir $GITHUB_WORKSPACE/artifacts
           mv "$PKGNAME.deb" $GITHUB_WORKSPACE/artifacts/
       - name: Publish unsigned .deb package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: deb-package-unsigned
           path: artifacts/

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -687,7 +687,7 @@ jobs:
         run: |
           python git\.github\scripts\run-esrp-signing.py unsigned $env:LINUX_KEY_CODE $env:LINUX_OP_CODE
       - name: Upload signed artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: deb-package-signed
           path: signed

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -712,7 +712,7 @@ jobs:
     needs: [prereqs, windows_artifacts, osx_publish_dmg, ubuntu_sign-artifacts]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.component.artifact }}
 

--- a/.github/workflows/release-apt-get.yml
+++ b/.github/workflows/release-apt-get.yml
@@ -33,7 +33,7 @@ jobs:
           rm repoclient.deb
 
       - name: "Configure Repo Client"
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         env:
           AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
           AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
@@ -59,11 +59,11 @@ jobs:
         id: get-asset
         env:
           RELEASE: ${{ github.event.inputs.release }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { data } = await github.repos.getRelease({
+            const { data } = await github.rest.repos.getRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: process.env.RELEASE || 'latest'
@@ -73,7 +73,7 @@ jobs:
               throw new Error(`Unexpected number of .deb assets: ${assets.length}`)
             }
             const fs = require('fs')
-            const buffer = await github.repos.getReleaseAsset({
+            const buffer = await github.rest.repos.getReleaseAsset({
                 headers: {
                   accept: 'application/octet-stream'
                 },


### PR DESCRIPTION
This is a companion to #566.

I pushed a tag to trigger [a build](https://github.com/microsoft/git/actions/runs/4447499276) that demonstrates that all the deprecation warnings are gone (for now).

EDIT: pointed the link to the build that addresses the `download-artifact` warnings.