### PR TITLE
DO NOT MERGE: WIP: mimalloc experiment

### DIFF
--- a/compat/mimalloc/init.c
+++ b/compat/mimalloc/init.c
@@ -457,6 +457,7 @@ static void _mi_thread_done(mi_heap_t* heap) {
 }
 
 void _mi_heap_set_default_direct(mi_heap_t* heap)  {
+  fprintf(stderr, "XXX heap_set_default: [m:%d] [th:0x%llx] [h:%p]\n", _mi_is_main_thread(), _mi_thread_id(), heap);
   mi_assert_internal(heap != NULL);
   #if defined(MI_TLS_SLOT)
   mi_tls_slot_set(MI_TLS_SLOT,heap);

--- a/compat/mimalloc/random.c
+++ b/compat/mimalloc/random.c
@@ -334,9 +334,11 @@ static void mi_random_init_ex(mi_random_ctx_t* ctx, bool use_weak) {
       ((uint32_t*)key)[i] = (uint32_t)x;
     }
     ctx->weak = true;
+    fprintf(stderr,"XXX random_init: [ctx %p][weak %d] [th:%lld]\n", ctx, ctx->weak, _mi_thread_id());
   }
   else {
     ctx->weak = false;
+    fprintf(stderr,"XXX random_init: [ctx %p][weak %d] [th:%lld]\n", ctx, ctx->weak, _mi_thread_id());
   }
   chacha_init(ctx, key, (uintptr_t)ctx /*nonce*/ );
 }

--- a/git.c
+++ b/git.c
@@ -462,9 +462,18 @@ static int run_post_command_hook(void)
 	return ret;
 }
 
-static void post_command_hook_atexit(void)
+#include "thread-utils.h"
+static void *xxx_thread_proc(void *data)
 {
 	run_post_command_hook();
+	return NULL;
+}
+static void post_command_hook_atexit(void)
+{
+//	run_post_command_hook();
+	pthread_t pt;
+	pthread_create(&pt, NULL, xxx_thread_proc, NULL);
+	pthread_join(pt, NULL);
 }
 
 static int run_builtin(struct cmd_struct *p, int argc, const char **argv)
@@ -520,7 +529,7 @@ static int run_builtin(struct cmd_struct *p, int argc, const char **argv)
 	if (status)
 		return status;
 
-	run_post_command_hook();
+	/////run_post_command_hook();
 
 	/* Somebody closed stdout? */
 	if (fstat(fileno(stdout), &st))
@@ -820,7 +829,7 @@ static void execv_dashed_external(const char **argv)
 	else if (errno != ENOENT)
 		exit(128);
 
-	run_post_command_hook();
+	/////run_post_command_hook();
 }
 
 static int run_argv(int *argcp, const char ***argv)
@@ -960,7 +969,7 @@ int cmd_main(int argc, const char **argv)
 		list_common_cmds_help();
 		printf("\n%s\n", _(git_more_info_string));
 		exit_code = 1;
-		run_post_command_hook();
+		/////run_post_command_hook();
 		exit(exit_code);
 	}
 


### PR DESCRIPTION
Trying to isolate a crash when running a post-command hook where `run_post_command_hook()` causes "mimalloc" to initialize (? re-initialize) `BCrypt.dll` and `BCryptPrimitives.dll` when it allocates memory to `getenv("COMMAND_HOOK_LOCK")`.

See https://github.com/microsoft/git/issues/578

Right now I'm just trying to reproduce the crash.

* I've commented out all of the direct calls to run the hook and so force the `atexit()` handler to run it.
* I've added some debug messages to look at the heap variables.
* I've added a contrived pthread to force the code to run on a non-main thread.

We are not sure if the `atexit` handlers
are always run on the main thread or not, but by inserting a pthread here, we do force it off whatever thread is running the atexit chain.  This DOES CAUSE the underlying `calloc()` to initialize a new heap and call `os_random_buf()` in `mi_random_init_ex()`

Note that the heap variable is `__declspec(thread)` and is in per-thread local storage.

Also note that when "mimalloc" is initialized, the first call to initialize a heap has the "use_weak" set because it happens during the GCCCRT static ctor init code -- and that code forces weak until the OS has finished startup.

This implies that our entire use of mimalloc is running with the weak random seed -- it is not until I forced it in the atexit handler that we ever actually call `os_random_buf()` again.

I could not get this to crash however, there maybe a data size or shape issue -- or I may have a different version of the BCrypt libraries (or OS release).

Based upon this I want to change the call to `_mi_random_init()` in "init.c:281" to `_mi_random_init_weak()` and just never use the external library.

The _mi_random_init_weak() change should go in GfW rather than here.
All of the code in this PR is throw-away.
