### PR TITLE
Lazy-load libcurl, accommodating for the recent change in how Git for Windows builds mingw-w64-curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1624,7 +1624,11 @@ else
 		# The `CURL_STATICLIB` constant must be defined to avoid seeing the functions
 		# declared as DLL imports
 		CURL_CFLAGS = -DCURL_STATICLIB
+ifneq ($(uname_S),MINGW)
+ifneq ($(uname_S),Windows)
 		CURL_LIBCURL = -ldl
+endif
+endif
 	else
 		ifndef CURL_LDFLAGS
 			CURL_LDFLAGS = $(eval CURL_LDFLAGS := $$(shell $$(CURL_CONFIG) --libs))$(CURL_LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -472,6 +472,11 @@ include shared.mak
 #
 #     CURL_LDFLAGS=-lcurl
 #
+# Define LAZYLOAD_LIBCURL to dynamically load the libcurl; This can be useful
+# if Multiple libcurl versions exist (with different file names) that link to
+# various SSL/TLS backends, to support the `http.sslBackend` runtime switch in
+# such a scenario.
+#
 # === Optional library: libpcre2 ===
 #
 # Define USE_LIBPCRE if you have and want to use libpcre. Various
@@ -1613,10 +1618,19 @@ else
 		CURL_LIBCURL =
 	endif
 
-	ifndef CURL_LDFLAGS
-		CURL_LDFLAGS = $(eval CURL_LDFLAGS := $$(shell $$(CURL_CONFIG) --libs))$(CURL_LDFLAGS)
+	ifdef LAZYLOAD_LIBCURL
+		LAZYLOAD_LIBCURL_OBJ = compat/lazyload-curl.o
+		OBJECTS += $(LAZYLOAD_LIBCURL_OBJ)
+		# The `CURL_STATICLIB` constant must be defined to avoid seeing the functions
+		# declared as DLL imports
+		CURL_CFLAGS = -DCURL_STATICLIB
+		CURL_LIBCURL = -ldl
+	else
+		ifndef CURL_LDFLAGS
+			CURL_LDFLAGS = $(eval CURL_LDFLAGS := $$(shell $$(CURL_CONFIG) --libs))$(CURL_LDFLAGS)
+		endif
+		CURL_LIBCURL += $(CURL_LDFLAGS)
 	endif
-	CURL_LIBCURL += $(CURL_LDFLAGS)
 
 	ifndef CURL_CFLAGS
 		CURL_CFLAGS = $(eval CURL_CFLAGS := $$(shell $$(CURL_CONFIG) --cflags))$(CURL_CFLAGS)
@@ -1640,7 +1654,7 @@ else
 	endif
 	ifdef USE_CURL_FOR_IMAP_SEND
 		BASIC_CFLAGS += -DUSE_CURL_FOR_IMAP_SEND
-		IMAP_SEND_BUILDDEPS = http.o
+		IMAP_SEND_BUILDDEPS = http.o $(LAZYLOAD_LIBCURL_OBJ)
 		IMAP_SEND_LDFLAGS += $(CURL_LIBCURL)
 	endif
 	ifndef NO_EXPAT
@@ -2854,10 +2868,10 @@ git-imap-send$X: imap-send.o $(IMAP_SEND_BUILDDEPS) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(IMAP_SEND_LDFLAGS) $(LIBS)
 
-git-http-fetch$X: http.o http-walker.o http-fetch.o GIT-LDFLAGS $(GITLIBS)
+git-http-fetch$X: http.o http-walker.o http-fetch.o $(LAZYLOAD_LIBCURL_OBJ) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(LIBS)
-git-http-push$X: http.o http-push.o GIT-LDFLAGS $(GITLIBS)
+git-http-push$X: http.o http-push.o $(LAZYLOAD_LIBCURL_OBJ) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
 
@@ -2867,7 +2881,7 @@ $(REMOTE_CURL_ALIASES): $(REMOTE_CURL_PRIMARY)
 	ln -s $< $@ 2>/dev/null || \
 	cp $< $@
 
-$(REMOTE_CURL_PRIMARY): remote-curl.o http.o http-walker.o GIT-LDFLAGS $(GITLIBS)
+$(REMOTE_CURL_PRIMARY): remote-curl.o http.o http-walker.o $(LAZYLOAD_LIBCURL_OBJ) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
 
@@ -2875,7 +2889,7 @@ scalar$X: $(SCALAR_OBJS) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
 		$(filter %.o,$^) $(LIBS)
 
-git-gvfs-helper$X: gvfs-helper.o http.o GIT-LDFLAGS $(GITLIBS)
+git-gvfs-helper$X: gvfs-helper.o http.o $(LAZYLOAD_LIBCURL_OBJ) GIT-LDFLAGS $(GITLIBS)
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
 		$(CURL_LIBCURL) $(EXPAT_LIBEXPAT) $(LIBS)
 

--- a/compat/lazyload-curl.c
+++ b/compat/lazyload-curl.c
@@ -1,0 +1,344 @@
+#include "../git-compat-util.h"
+#include "../git-curl-compat.h"
+#include <dlfcn.h>
+
+/*
+ * The ABI version of libcurl is encoded in its shared libraries' file names.
+ * This ABI version has not changed since October 2006 and is unlikely to be
+ * changed in the future. See https://curl.se/libcurl/abi.html for details.
+ */
+#define LIBCURL_ABI_VERSION "4"
+
+typedef void (*func_t)(void);
+
+#ifdef __APPLE__
+#define LIBCURL_FILE_NAME(base) base "." LIBCURL_ABI_VERSION ".dylib"
+#else
+#define LIBCURL_FILE_NAME(base) base ".so." LIBCURL_ABI_VERSION
+#endif
+
+static void *load_library(const char *name)
+{
+	return dlopen(name, RTLD_LAZY);
+}
+
+static func_t load_function(void *handle, const char *name)
+{
+	/*
+	 * Casting the return value of `dlsym()` to a function pointer is
+	 * explicitly allowed in recent POSIX standards, but GCC complains
+	 * about this in pedantic mode nevertheless. For more about this issue,
+	 * see https://stackoverflow.com/q/31526876/1860823 and
+	 * http://stackoverflow.com/a/36385690/1905491.
+	 */
+	func_t f;
+	*(void **)&f = dlsym(handle, name);
+	return f;
+}
+
+typedef char *(*curl_easy_escape_type)(CURL *handle, const char *string, int length);
+static curl_easy_escape_type curl_easy_escape_func;
+
+typedef void (*curl_free_type)(void *p);
+static curl_free_type curl_free_func;
+
+typedef CURLcode (*curl_global_init_type)(long flags);
+static curl_global_init_type curl_global_init_func;
+
+typedef CURLsslset (*curl_global_sslset_type)(curl_sslbackend id, const char *name, const curl_ssl_backend ***avail);
+static curl_global_sslset_type curl_global_sslset_func;
+
+typedef void (*curl_global_cleanup_type)(void);
+static curl_global_cleanup_type curl_global_cleanup_func;
+
+typedef struct curl_slist *(*curl_slist_append_type)(struct curl_slist *list, const char *data);
+static curl_slist_append_type curl_slist_append_func;
+
+typedef void (*curl_slist_free_all_type)(struct curl_slist *list);
+static curl_slist_free_all_type curl_slist_free_all_func;
+
+typedef const char *(*curl_easy_strerror_type)(CURLcode error);
+static curl_easy_strerror_type curl_easy_strerror_func;
+
+typedef CURLM *(*curl_multi_init_type)(void);
+static curl_multi_init_type curl_multi_init_func;
+
+typedef CURLMcode (*curl_multi_add_handle_type)(CURLM *multi_handle, CURL *curl_handle);
+static curl_multi_add_handle_type curl_multi_add_handle_func;
+
+typedef CURLMcode (*curl_multi_remove_handle_type)(CURLM *multi_handle, CURL *curl_handle);
+static curl_multi_remove_handle_type curl_multi_remove_handle_func;
+
+typedef CURLMcode (*curl_multi_fdset_type)(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd);
+static curl_multi_fdset_type curl_multi_fdset_func;
+
+typedef CURLMcode (*curl_multi_perform_type)(CURLM *multi_handle, int *running_handles);
+static curl_multi_perform_type curl_multi_perform_func;
+
+typedef CURLMcode (*curl_multi_cleanup_type)(CURLM *multi_handle);
+static curl_multi_cleanup_type curl_multi_cleanup_func;
+
+typedef CURLMsg *(*curl_multi_info_read_type)(CURLM *multi_handle, int *msgs_in_queue);
+static curl_multi_info_read_type curl_multi_info_read_func;
+
+typedef const char *(*curl_multi_strerror_type)(CURLMcode error);
+static curl_multi_strerror_type curl_multi_strerror_func;
+
+typedef CURLMcode (*curl_multi_timeout_type)(CURLM *multi_handle, long *milliseconds);
+static curl_multi_timeout_type curl_multi_timeout_func;
+
+typedef CURL *(*curl_easy_init_type)(void);
+static curl_easy_init_type curl_easy_init_func;
+
+typedef CURLcode (*curl_easy_perform_type)(CURL *curl);
+static curl_easy_perform_type curl_easy_perform_func;
+
+typedef void (*curl_easy_cleanup_type)(CURL *curl);
+static curl_easy_cleanup_type curl_easy_cleanup_func;
+
+typedef CURL *(*curl_easy_duphandle_type)(CURL *curl);
+static curl_easy_duphandle_type curl_easy_duphandle_func;
+
+typedef CURLcode (*curl_easy_getinfo_long_type)(CURL *curl, CURLINFO info, long *value);
+static curl_easy_getinfo_long_type curl_easy_getinfo_long_func;
+
+typedef CURLcode (*curl_easy_getinfo_pointer_type)(CURL *curl, CURLINFO info, void **value);
+static curl_easy_getinfo_pointer_type curl_easy_getinfo_pointer_func;
+
+typedef CURLcode (*curl_easy_getinfo_off_t_type)(CURL *curl, CURLINFO info, curl_off_t *value);
+static curl_easy_getinfo_off_t_type curl_easy_getinfo_off_t_func;
+
+typedef CURLcode (*curl_easy_setopt_long_type)(CURL *curl, CURLoption opt, long value);
+static curl_easy_setopt_long_type curl_easy_setopt_long_func;
+
+typedef CURLcode (*curl_easy_setopt_pointer_type)(CURL *curl, CURLoption opt, void *value);
+static curl_easy_setopt_pointer_type curl_easy_setopt_pointer_func;
+
+typedef CURLcode (*curl_easy_setopt_off_t_type)(CURL *curl, CURLoption opt, curl_off_t value);
+static curl_easy_setopt_off_t_type curl_easy_setopt_off_t_func;
+
+static void lazy_load_curl(void)
+{
+	static int initialized;
+	void *libcurl;
+	func_t curl_easy_getinfo_func, curl_easy_setopt_func;
+
+	if (initialized)
+		return;
+
+	initialized = 1;
+	libcurl = load_library(LIBCURL_FILE_NAME("libcurl"));
+	if (!libcurl)
+		die("failed to load library '%s'", LIBCURL_FILE_NAME("libcurl"));
+
+	curl_easy_escape_func = (curl_easy_escape_type)load_function(libcurl, "curl_easy_escape");
+	curl_free_func = (curl_free_type)load_function(libcurl, "curl_free");
+	curl_global_init_func = (curl_global_init_type)load_function(libcurl, "curl_global_init");
+	curl_global_sslset_func = (curl_global_sslset_type)load_function(libcurl, "curl_global_sslset");
+	curl_global_cleanup_func = (curl_global_cleanup_type)load_function(libcurl, "curl_global_cleanup");
+	curl_slist_append_func = (curl_slist_append_type)load_function(libcurl, "curl_slist_append");
+	curl_slist_free_all_func = (curl_slist_free_all_type)load_function(libcurl, "curl_slist_free_all");
+	curl_easy_strerror_func = (curl_easy_strerror_type)load_function(libcurl, "curl_easy_strerror");
+	curl_multi_init_func = (curl_multi_init_type)load_function(libcurl, "curl_multi_init");
+	curl_multi_add_handle_func = (curl_multi_add_handle_type)load_function(libcurl, "curl_multi_add_handle");
+	curl_multi_remove_handle_func = (curl_multi_remove_handle_type)load_function(libcurl, "curl_multi_remove_handle");
+	curl_multi_fdset_func = (curl_multi_fdset_type)load_function(libcurl, "curl_multi_fdset");
+	curl_multi_perform_func = (curl_multi_perform_type)load_function(libcurl, "curl_multi_perform");
+	curl_multi_cleanup_func = (curl_multi_cleanup_type)load_function(libcurl, "curl_multi_cleanup");
+	curl_multi_info_read_func = (curl_multi_info_read_type)load_function(libcurl, "curl_multi_info_read");
+	curl_multi_strerror_func = (curl_multi_strerror_type)load_function(libcurl, "curl_multi_strerror");
+	curl_multi_timeout_func = (curl_multi_timeout_type)load_function(libcurl, "curl_multi_timeout");
+	curl_easy_init_func = (curl_easy_init_type)load_function(libcurl, "curl_easy_init");
+	curl_easy_perform_func = (curl_easy_perform_type)load_function(libcurl, "curl_easy_perform");
+	curl_easy_cleanup_func = (curl_easy_cleanup_type)load_function(libcurl, "curl_easy_cleanup");
+	curl_easy_duphandle_func = (curl_easy_duphandle_type)load_function(libcurl, "curl_easy_duphandle");
+
+	curl_easy_getinfo_func = load_function(libcurl, "curl_easy_getinfo");
+	curl_easy_getinfo_long_func = (curl_easy_getinfo_long_type)curl_easy_getinfo_func;
+	curl_easy_getinfo_pointer_func = (curl_easy_getinfo_pointer_type)curl_easy_getinfo_func;
+	curl_easy_getinfo_off_t_func = (curl_easy_getinfo_off_t_type)curl_easy_getinfo_func;
+
+	curl_easy_setopt_func = load_function(libcurl, "curl_easy_setopt");
+	curl_easy_setopt_long_func = (curl_easy_setopt_long_type)curl_easy_setopt_func;
+	curl_easy_setopt_pointer_func = (curl_easy_setopt_pointer_type)curl_easy_setopt_func;
+	curl_easy_setopt_off_t_func = (curl_easy_setopt_off_t_type)curl_easy_setopt_func;
+}
+
+char *curl_easy_escape(CURL *handle, const char *string, int length)
+{
+	lazy_load_curl();
+	return curl_easy_escape_func(handle, string, length);
+}
+
+void curl_free(void *p)
+{
+	lazy_load_curl();
+	curl_free_func(p);
+}
+
+CURLcode curl_global_init(long flags)
+{
+	lazy_load_curl();
+	return curl_global_init_func(flags);
+}
+
+CURLsslset curl_global_sslset(curl_sslbackend id, const char *name, const curl_ssl_backend ***avail)
+{
+	lazy_load_curl();
+	return curl_global_sslset_func(id, name, avail);
+}
+
+void curl_global_cleanup(void)
+{
+	lazy_load_curl();
+	curl_global_cleanup_func();
+}
+
+struct curl_slist *curl_slist_append(struct curl_slist *list, const char *data)
+{
+	lazy_load_curl();
+	return curl_slist_append_func(list, data);
+}
+
+void curl_slist_free_all(struct curl_slist *list)
+{
+	lazy_load_curl();
+	curl_slist_free_all_func(list);
+}
+
+const char *curl_easy_strerror(CURLcode error)
+{
+	lazy_load_curl();
+	return curl_easy_strerror_func(error);
+}
+
+CURLM *curl_multi_init(void)
+{
+	lazy_load_curl();
+	return curl_multi_init_func();
+}
+
+CURLMcode curl_multi_add_handle(CURLM *multi_handle, CURL *curl_handle)
+{
+	lazy_load_curl();
+	return curl_multi_add_handle_func(multi_handle, curl_handle);
+}
+
+CURLMcode curl_multi_remove_handle(CURLM *multi_handle, CURL *curl_handle)
+{
+	lazy_load_curl();
+	return curl_multi_remove_handle_func(multi_handle, curl_handle);
+}
+
+CURLMcode curl_multi_fdset(CURLM *multi_handle, fd_set *read_fd_set, fd_set *write_fd_set, fd_set *exc_fd_set, int *max_fd)
+{
+	lazy_load_curl();
+	return curl_multi_fdset_func(multi_handle, read_fd_set, write_fd_set, exc_fd_set, max_fd);
+}
+
+CURLMcode curl_multi_perform(CURLM *multi_handle, int *running_handles)
+{
+	lazy_load_curl();
+	return curl_multi_perform_func(multi_handle, running_handles);
+}
+
+CURLMcode curl_multi_cleanup(CURLM *multi_handle)
+{
+	lazy_load_curl();
+	return curl_multi_cleanup_func(multi_handle);
+}
+
+CURLMsg *curl_multi_info_read(CURLM *multi_handle, int *msgs_in_queue)
+{
+	lazy_load_curl();
+	return curl_multi_info_read_func(multi_handle, msgs_in_queue);
+}
+
+const char *curl_multi_strerror(CURLMcode error)
+{
+	lazy_load_curl();
+	return curl_multi_strerror_func(error);
+}
+
+CURLMcode curl_multi_timeout(CURLM *multi_handle, long *milliseconds)
+{
+	lazy_load_curl();
+	return curl_multi_timeout_func(multi_handle, milliseconds);
+}
+
+CURL *curl_easy_init(void)
+{
+	lazy_load_curl();
+	return curl_easy_init_func();
+}
+
+CURLcode curl_easy_perform(CURL *curl)
+{
+	lazy_load_curl();
+	return curl_easy_perform_func(curl);
+}
+
+void curl_easy_cleanup(CURL *curl)
+{
+	lazy_load_curl();
+	curl_easy_cleanup_func(curl);
+}
+
+CURL *curl_easy_duphandle(CURL *curl)
+{
+	lazy_load_curl();
+	return curl_easy_duphandle_func(curl);
+}
+
+#ifndef CURL_IGNORE_DEPRECATION
+#define CURL_IGNORE_DEPRECATION(x) x
+#endif
+
+#ifndef CURLOPTTYPE_BLOB
+#define CURLOPTTYPE_BLOB 40000
+#endif
+
+#undef curl_easy_getinfo
+CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...)
+{
+	va_list ap;
+	CURLcode res;
+
+	va_start(ap, info);
+	lazy_load_curl();
+	CURL_IGNORE_DEPRECATION(
+		if (info >= CURLINFO_LONG && info < CURLINFO_DOUBLE)
+			res = curl_easy_getinfo_long_func(curl, info, va_arg(ap, long *));
+		else if ((info >= CURLINFO_STRING && info < CURLINFO_LONG) ||
+			 (info >= CURLINFO_SLIST && info < CURLINFO_SOCKET))
+			res = curl_easy_getinfo_pointer_func(curl, info, va_arg(ap, void **));
+		else if (info >= CURLINFO_OFF_T)
+			res = curl_easy_getinfo_off_t_func(curl, info, va_arg(ap, curl_off_t *));
+		else
+			die("%s:%d: TODO (info: %d)!", __FILE__, __LINE__, info);
+	)
+	va_end(ap);
+	return res;
+}
+
+#undef curl_easy_setopt
+CURLcode curl_easy_setopt(CURL *curl, CURLoption opt, ...)
+{
+	va_list ap;
+	CURLcode res;
+
+	va_start(ap, opt);
+	lazy_load_curl();
+	CURL_IGNORE_DEPRECATION(
+		if (opt >= CURLOPTTYPE_LONG && opt < CURLOPTTYPE_OBJECTPOINT)
+			res = curl_easy_setopt_long_func(curl, opt, va_arg(ap, long));
+		else if (opt >= CURLOPTTYPE_OBJECTPOINT && opt < CURLOPTTYPE_OFF_T)
+			res = curl_easy_setopt_pointer_func(curl, opt, va_arg(ap, void *));
+		else if (opt >= CURLOPTTYPE_OFF_T && opt < CURLOPTTYPE_BLOB)
+			res = curl_easy_setopt_off_t_func(curl, opt, va_arg(ap, curl_off_t));
+		else
+			die("%s:%d: TODO (opt: %d)!", __FILE__, __LINE__, opt);
+	)
+	va_end(ap);
+	return res;
+}

--- a/compat/lazyload-curl.c
+++ b/compat/lazyload-curl.c
@@ -153,17 +153,26 @@ static curl_easy_setopt_pointer_type curl_easy_setopt_pointer_func;
 typedef CURLcode (*curl_easy_setopt_off_t_type)(CURL *curl, CURLoption opt, curl_off_t value);
 static curl_easy_setopt_off_t_type curl_easy_setopt_off_t_func;
 
+static char ssl_backend[64];
+
 static void lazy_load_curl(void)
 {
 	static int initialized;
-	void *libcurl;
+	void *libcurl = NULL;
 	func_t curl_easy_getinfo_func, curl_easy_setopt_func;
 
 	if (initialized)
 		return;
 
 	initialized = 1;
-	libcurl = load_library(LIBCURL_FILE_NAME("libcurl"));
+	if (ssl_backend[0]) {
+		char dll_name[64 + 16];
+		snprintf(dll_name, sizeof(dll_name) - 1,
+			 LIBCURL_FILE_NAME("libcurl-%s"), ssl_backend);
+		libcurl = load_library(dll_name);
+	}
+	if (!libcurl)
+		libcurl = load_library(LIBCURL_FILE_NAME("libcurl"));
 	if (!libcurl)
 		die("failed to load library '%s'", LIBCURL_FILE_NAME("libcurl"));
 
@@ -220,6 +229,9 @@ CURLcode curl_global_init(long flags)
 
 CURLsslset curl_global_sslset(curl_sslbackend id, const char *name, const curl_ssl_backend ***avail)
 {
+	if (name && strlen(name) < sizeof(ssl_backend))
+		strlcpy(ssl_backend, name, sizeof(ssl_backend));
+
 	lazy_load_curl();
 	return curl_global_sslset_func(id, name, avail);
 }

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -671,6 +671,7 @@ ifeq ($(uname_S),MINGW)
 	HAVE_PLATFORM_PROCINFO = YesPlease
 	CSPRNG_METHOD = rtlgenrandom
 	BASIC_LDFLAGS += -municode -Wl,--tsaware
+	LAZYLOAD_LIBCURL = YesDoThatPlease
 	COMPAT_CFLAGS += -DNOGDI -Icompat -Icompat/win32
 	COMPAT_CFLAGS += -DSTRIP_EXTENSION=\".exe\"
 	COMPAT_OBJS += compat/mingw.o compat/winansi.o \


### PR DESCRIPTION
Git for Windows recently started adjusting the way its `mingw-w64-curl` packages are built, to align better with the upstream MSYS2 project. This change required patches in the Git source code (see git-for-windows/git#4410), and they were already incorporated into Git for Windows v2.41.0-rc0. Without these patches, Git would still work, except when fetching or pushing with `http.sslBackend=openssl`.

However, those patches were _not_ incorporated into the `vfs-2.40.1` branch, under the assumption that the `microsoft/git` fork would receive those patches via the imminent v2.41.0, anyway.

When v2.40.1.vfs.0.1 was released in the hopes to address #578, I totally forgot that this would break `http.sslBackend=openssl` support.

Let's backport the changes from git-for-windows/git#4410 into the `vfs-2.40.1` branch so that we can release a v2.40.1.vfs.0.2 that fixes this regression _as well_ as the regression reported in #578.