### PR TITLE
build-git-installers: ensure that the tag name conforms with the pattern required for VFS for Git

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -18,6 +18,13 @@ jobs:
       tag_version: ${{ steps.tag.outputs.version }}     # The version number (without preceding "v"), e.g. 2.32.0.vfs.0.0
       deb_signable: ${{ steps.deb.outputs.signable }}   # Whether the credentials needed to sign the .deb package are available
     steps:
+      - name: Validate tag
+        run: |
+          echo "$GITHUB_REF" |
+          grep '^refs/tags/v2\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)\.vfs\.0\.\(0\|[1-9][0-9]*\)$' || {
+            echo "::error::${GITHUB_REF#refs/tags/} is not of the form v2.<X>.<Y>.vfs.0.<W>" >&2
+            exit 1
+          }
       - name: Determine tag to build
         run: |
           echo "name=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
I almost made the mistake of releasing v2.41.0.vfs.1.0 (where I chose the "1" to indicate that it is based on a newer Git for Windows version than v2.41.0.vfs.0.0, namely based on v2.41.0.windows.2).

This would have broken VFS for Git, though. The code comments at https://github.com/microsoft/VFSForGit/blob/3790eb06e14d/Version.props#L7-L22 and
https://github.com/microsoft/VFSForGit/blob/3790eb06e14d/GVFS/GVFS/CommandLine/GVFSVerb.cs#L901-L908 clearly state:

	Note that we require that the revision (Z) of the Git version
	string (2.X.Y.vfs.Z.W) is an exact match.
	[...]
	<MinimumGitVersion>v2.31.0.vfs.0.1</MinimumGitVersion>

To make sure that I cannot make that mistake anymore, let's validate the tag format to the stringent pattern that is actually required to make VFS for Git work as intended.