### PR TITLE
gvfs-helper: simplify progress output during prefetch

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2345,12 +2345,17 @@ static void install_prefetch(struct gh__request_params *params,
 		trace2_data_intmax(TR2_CAT, NULL,
 				   "prefetch/packfile_count", np);
 
+	if (gh__cmd_opts.show_progress)
+		params->progress = start_progress("Installing prefetch packfiles", np);
+
 	for (k = 0; k < np; k++) {
 		extract_packfile_from_multipack(params, status, fd, k);
+		display_progress(params->progress, k + 1);
 		if (status->ec != GH__ERROR_CODE__OK)
 			break;
 		nr_installed++;
 	}
+	stop_progress(&params->progress);
 
 	if (nr_installed)
 		delete_stale_keep_files(params, status);

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1855,13 +1855,8 @@ static void my_run_index_pack(struct gh__request_params *params,
 	strvec_push(&ip.args, "git");
 	strvec_push(&ip.args, "index-pack");
 
-	if (gh__cmd_opts.show_progress) {
-		strvec_push(&ip.args, "-v");
-		ip.err = 0;
-	} else {
-		ip.err = -1;
-		ip.no_stderr = 1;
-	}
+	ip.err = -1;
+	ip.no_stderr = 1;
 
 	/* Skip generating the rev index, we don't need it. */
 	strvec_push(&ip.args, "--no-rev-index");


### PR DESCRIPTION
* [x] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.

A user reported confusion when presented with the progress indicators for several `git index-pack` subprocesses during a prefetch. This happened by surprise, and is related to our issues with GVFS Cache Servers rejecting credentials and thus halting background maintenance until a foreground fetch happens.

In the meantime, we can modify our progress output to be simpler in this case. There are two changes:

1. We unconditionally stifle output from `git index-pack`. It would be preferrable to pass a `-q` parameter, but it is not available. This prevents two progress indicators per prefetch packfile.
2. We add a conditional `Installing prefetch packfiles: ..% (X/Y)` indicator in the loop that installs these packfiles via `git index-pack`. This shows progress feedback frequently enough that users know something is happening without overwhelming their terminal interface.