### PR TITLE
Fix rev index

### DIFF
--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1740,6 +1740,7 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 	unsigned foreign_nr = 1;	/* zero is a "good" value, assume bad */
 	int report_end_of_input = 0;
 	int hash_algo = 0;
+	int dash_o = 0;
 
 	/*
 	 * index-pack never needs to fetch missing objects except when
@@ -1832,6 +1833,7 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 				if (index_name || (i+1) >= argc)
 					usage(index_pack_usage);
 				index_name = argv[++i];
+				dash_o = 1;
 			} else if (starts_with(arg, "--index-version=")) {
 				char *c;
 				opts.version = strtoul(arg + 16, &c, 10);
@@ -1874,6 +1876,8 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 		index_name = derive_filename(pack_name, "pack", "idx", &index_name_buf);
 
 	opts.flags &= ~(WRITE_REV | WRITE_REV_VERIFY);
+	if (rev_index && dash_o && !ends_with(index_name, ".idx"))
+		rev_index = 0;
 	if (rev_index) {
 		opts.flags |= verify ? WRITE_REV_VERIFY : WRITE_REV;
 		if (index_name)

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -372,11 +372,10 @@ test_expect_success 'complain about index name' '
 	test -f test-complain-0.idx &&
 	test -f test-complain-0.rev &&
 
-	# Non .idx suffix
+	# Non .idx suffix -- implicitly omits the .rev
 	cat test-1-${packname_1}.pack >test-complain-1.pack &&
-	test_must_fail git index-pack -o test-complain-1.idx-suffix --rev-index test-complain-1.pack 2>err &&
-	grep "does not end" err &&
-	! test -f test-complain-1.idx-suffix &&
+	git index-pack -o test-complain-1.idx-suffix --rev-index test-complain-1.pack &&
+	test -f test-complain-1.idx-suffix &&
 	! test -f test-complain-1.rev
 '
 

--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -355,6 +355,31 @@ test_expect_success \
 
      :'
 
+# The `--rev-index` option of `git index-pack` is now the default, so
+# a `foo.rev` REV file will be created when a `foo.idx` IDX file is
+# created.  Normally, these pathnames are based upon the `foo.pack`
+# PACK file pathname.
+#
+# However, the `-o` option lets you set the pathname of the IDX file
+# indepdent of the PACK file.
+#
+# Verify what happens if these suffixes are changed.
+#
+test_expect_success 'complain about index name' '
+	# Normal case { .pack, .idx, .rev }
+	cat test-1-${packname_1}.pack >test-complain-0.pack &&
+	git index-pack -o test-complain-0.idx --rev-index test-complain-0.pack &&
+	test -f test-complain-0.idx &&
+	test -f test-complain-0.rev &&
+
+	# Non .idx suffix
+	cat test-1-${packname_1}.pack >test-complain-1.pack &&
+	test_must_fail git index-pack -o test-complain-1.idx-suffix --rev-index test-complain-1.pack 2>err &&
+	grep "does not end" err &&
+	! test -f test-complain-1.idx-suffix &&
+	! test -f test-complain-1.rev
+'
+
 test_expect_success 'unpacking with --strict' '
 
 	for j in a b c d e f g


### PR DESCRIPTION
`git index-pack` fails when the `-o` argument is used and the requested IDX file does not have the standard `.idx` suffix.  The reverse index code assumes the `.idx` suffix when it generates the `.rev` pathname.

Silently disable the reverse index when the suffix is different.

Added a test to confirm the breakage and then updated it to confirm the fix.

This is being patched into vfs-2.41.0.5 directly, but the fixes should be backported to upstream Git and to vfs-2.42.0.
