### PR TITLE
Fix `sparse-checkout set` crashes

### DIFF
--- a/sparse-index.c
+++ b/sparse-index.c
@@ -371,7 +371,7 @@ void expand_index(struct index_state *istate, struct pattern_list *pl)
 		if (pl &&
 		    path_matches_pattern_list(ce->name, ce->ce_namelen,
 					      NULL, &dtype,
-					      pl, istate) == NOT_MATCHED) {
+					      pl, full) == NOT_MATCHED) {
 			set_index_entry(full, full->cache_nr++, ce);
 			continue;
 		}
@@ -399,6 +399,7 @@ void expand_index(struct index_state *istate, struct pattern_list *pl)
 	}
 
 	/* Copy back into original index. */
+	istate->name_hash_initialized = full->name_hash_initialized;
 	memcpy(&istate->name_hash, &full->name_hash, sizeof(full->name_hash));
 	memcpy(&istate->dir_hash, &full->dir_hash, sizeof(full->dir_hash));
 	istate->sparse_index = pl ? INDEX_PARTIALLY_SPARSE : INDEX_EXPANDED;

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -242,7 +242,7 @@ static int add_path_to_index(const struct object_id *oid,
 	size_t len = base->len;
 
 	if (S_ISDIR(mode)) {
-		int dtype;
+		int dtype = DT_DIR;
 		size_t baselen = base->len;
 		if (!ctx->pl)
 			return READ_TREE_RECURSIVE;
@@ -360,7 +360,7 @@ void expand_index(struct index_state *istate, struct pattern_list *pl)
 		struct cache_entry *ce = istate->cache[i];
 		struct tree *tree;
 		struct pathspec ps;
-		int dtype;
+		int dtype = DT_UNKNOWN;
 
 		if (!S_ISSPARSEDIR(ce->ce_mode)) {
 			set_index_entry(full, full->cache_nr++, ce);

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -311,6 +311,22 @@ test_expect_success 'root directory cannot be sparse' '
 	test_cmp expect actual
 '
 
+test_expect_success 'sparse-checkout with untracked files and dirs' '
+	init_repos &&
+
+	# Empty directories outside sparse cone are deleted
+	run_on_sparse mkdir -p deep/empty &&
+	test_sparse_match git sparse-checkout set folder1 &&
+	test_must_be_empty sparse-checkout-err &&
+	run_on_sparse test_path_is_missing deep &&
+
+	# Untracked files outside sparse cone are not deleted
+	run_on_sparse touch folder1/another &&
+	test_sparse_match git sparse-checkout set folder2 &&
+	grep "directory ${SQ}folder1/${SQ} contains untracked files" sparse-checkout-err &&
+	run_on_sparse test_path_exists folder1/another
+'
+
 test_expect_success 'status with options' '
 	init_repos &&
 	test_sparse_match ls &&


### PR DESCRIPTION
Thanks for taking the time to contribute to Git!

This fork contains changes specific to monorepo scenarios. If you are an
external contributor, then please detail your reason for submitting to
this fork:

* [x] This is an early version of work already under review upstream.
* [ ] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
* [x] This change only applies to the virtualization hook and VFS for Git.

---

This PR corrects a couple of issues in order to fix #606:

- Commit 1 ensures the `dtype` arg to `path_matches_pattern_list()` is always initialized, since the code added in 2cff5e9e9e0 requires an initialized value.
- Commit 2 fixes copying & modification of the index `name_hash`, `dir_hash`, and `name_hash_initialized` in `expand_index()`. This problem originates upstream (and should eventually be fixed there as well), but it doesn't actually trigger any bugs there; it's the interaction with 2cff5e9e9e0 that causes the segfault in our fork.
- Commit 3 adds a test around the treatment of untracked files & directories when sparse-checkout patterns are updated, moving them from "in cone" to "outside of cone." Again, while this is a good thing to have upstream (I plan to submit it eventually), its real value here is showing that [this segfault](https://github.com/microsoft/git/issues/606#issuecomment-1726709490) no longer occurs.