### PR TITLE
jeffhostetler/native-curl

### DIFF
--- a/.github/macos-installer/Makefile
+++ b/.github/macos-installer/Makefile
@@ -45,6 +45,20 @@ $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain:
 $(BUILD_DIR)/git-$(VERSION)/osx-built:
 	[ -d $(DESTDIR)$(GIT_PREFIX) ] && $(SUDO) rm -rf $(DESTDIR) || echo ok
 	cd $(BUILD_DIR)/git-$(VERSION); $(SUBMAKE) -j $(CORES) all strip
+	echo "================"
+	echo "Dumping Linkage"
+	cd $(BUILD_DIR)/git-$(VERSION); ./git version
+	echo "===="
+	cd $(BUILD_DIR)/git-$(VERSION); /usr/bin/otool -L ./git
+	echo "===="
+	cd $(BUILD_DIR)/git-$(VERSION); /usr/bin/otool -L ./git-http-fetch
+	echo "===="
+	cd $(BUILD_DIR)/git-$(VERSION); /usr/bin/otool -L ./git-http-push
+	echo "===="
+	cd $(BUILD_DIR)/git-$(VERSION); /usr/bin/otool -L ./git-remote-http
+	echo "===="
+	cd $(BUILD_DIR)/git-$(VERSION); /usr/bin/otool -L ./git-gvfs-helper
+	echo "================"
 	touch $@
 
 $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin: $(BUILD_DIR)/git-$(VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -325,15 +325,14 @@ jobs:
 
           # Install x86_64 packages
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 /usr/local/bin/brew install gettext curl
+          arch -x86_64 /usr/local/bin/brew install gettext
 
           # Install arm64 packages
           brew install automake asciidoc xmlto docbook
           brew link --force gettext
 
-          # Make universal gettext and curl library
+          # Make universal gettext library
           lipo -create -output libintl.a /usr/local/opt/gettext/lib/libintl.a /opt/homebrew/opt/gettext/lib/libintl.a
-          lipo -create -output libcurl.dylib /opt/homebrew/opt/curl/lib/libcurl.4.dylib /usr/local/opt/curl/lib/libcurl.4.dylib
 
       - name: Set up signing/notarization infrastructure
         env:
@@ -412,9 +411,9 @@ jobs:
           LDFLAGS = -L"$(pwd)"
           EOF
 
-          # Configure the Git build to pick up the universal `libcurl.dylib`
+          # Configure the Git to use the OS supplied libcurl.
           cat >>git/config.mak <<EOF
-          CURL_LDFLAGS := -L"$(pwd)" -lcurl
+          CURL_LDFLAGS := -lcurl
           CURL_CONFIG := /usr/bin/true
           EOF
 


### PR DESCRIPTION
Use the OS provided version of `libcurl` when building release packages.
This is in contrast to using Homebrew on ARM64 in our universal binaries.

Also add diagnostics during the release build process to display the DYLIBs
that are referenced by the key executables.
