### PR TITLE
Prevent potential segfault in `scalar reconfigure --all`

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -1099,10 +1099,8 @@ static int cmd_reconfigure(int argc, const char **argv)
 		r.commondir = commondir.buf;
 		r.gitdir = gitdir.buf;
 
-		if (set_recommended_config(1) >= 0)
-			succeeded = 1;
-
-		if (toggle_maintenance(1) >= 0)
+		if (set_recommended_config(1) >= 0 &&
+		    toggle_maintenance(1) >= 0)
 			succeeded = 1;
 
 loop_end:

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -180,6 +180,44 @@ test_expect_success 'scalar reconfigure' '
 	test true = "$(git -C one/src config core.preloadIndex)"
 '
 
+test_expect_success 'scalar reconfigure --all with includeIf.onbranch' '
+	repos="two three four" &&
+	for num in $repos
+	do
+		git init $num/src &&
+		scalar register $num/src &&
+		git -C $num/src config includeif."onbranch:foo".path something &&
+		git -C $num/src config core.preloadIndex false || return 1
+	done &&
+
+	scalar reconfigure --all &&
+
+	for num in $repos
+	do
+		test true = "$(git -C $num/src config core.preloadIndex)" || return 1
+	done
+'
+
+ test_expect_success 'scalar reconfigure --all with detached HEADs' '
+	repos="two three four" &&
+	for num in $repos
+	do
+		rm -rf $num/src &&
+		git init $num/src &&
+		scalar register $num/src &&
+		git -C $num/src config core.preloadIndex false &&
+		test_commit -C $num/src initial &&
+		git -C $num/src switch --detach HEAD || return 1
+	done &&
+
+	scalar reconfigure --all &&
+
+	for num in $repos
+	do
+		test true = "$(git -C $num/src config core.preloadIndex)" || return 1
+	done
+'
+
 test_expect_success '`reconfigure -a` removes stale config entries' '
 	git init stale/src &&
 	scalar register stale &&


### PR DESCRIPTION
See gitgitgadget/git#1724 for the upstream fix. This includes an extra detail around the context of that change that will require some reaction in microsoft/git. Please see the `fixup!` and merge commit messages for details.

This merges in the upstream commit that is going into `master` soon.