### PR TITLE
build-installers: Update to actions/checkout v4

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -27,7 +27,7 @@ jobs:
           echo "version=${GITHUB_REF#refs/tags/v}" >>$GITHUB_OUTPUT
         id: tag
       - name: Clone git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate the tag identified with trigger
         run: |
           die () {


### PR DESCRIPTION
When running the build-installers workflow recently, I saw the following warning:

>  Node.js 16 actions are deprecated. Please update the following actions
>  to use Node.js 20: actions/checkout@v3. For more information see:
>  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Update the actions/checkout task to v4 to avoid this node deprecation.