### PR TITLE
reset: fix mixed reset when using virtual filesystem (again)

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -182,7 +182,9 @@ static void update_index_from_diff(struct diff_queue_struct *q,
 		 */
 		if (core_virtualfilesystem && !file_exists(two->path))
 		{
+			respect_skip_worktree = 0;
 			pos = index_name_pos(&the_index, two->path, strlen(two->path));
+
 			if ((pos >= 0 && ce_skip_worktree(the_index.cache[pos])) &&
 			    (is_missing || !was_missing))
 			{
@@ -197,7 +199,6 @@ static void update_index_from_diff(struct diff_queue_struct *q,
 						two->path);
 
 				checkout_entry(ceBefore, &state, NULL, NULL);
-				respect_skip_worktree = 0;
 			}
 		}
 


### PR DESCRIPTION
This should fix #646, at least in the case that I've been able to verify.

The issue is that reset was setting the skip-worktree bit more frequently than it should have. The previous fix in #494 was focused on the case where a file is added or removed across the diff. However, when the file exists on both sides but still needs to be staged in a mixed reset then we should avoid the skip-worktree bit.

---

This fork contains changes specific to monorepo scenarios. If you are an
external contributor, then please detail your reason for submitting to
this fork:

* [X] This change only applies to the virtualization hook and VFS for Git.
