### PR TITLE
checkout: ignore skip-worktree when virtual

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1,5 +1,6 @@
 #define USE_THE_INDEX_VARIABLE
 #include "builtin.h"
+#include "gvfs.h"
 #include "advice.h"
 #include "branch.h"
 #include "cache-tree.h"
@@ -1758,6 +1759,7 @@ static int checkout_main(int argc, const char **argv, const char *prefix,
 	}
 
 	opts->track = BRANCH_TRACK_UNSPECIFIED;
+	opts->ignore_skipworktree = gvfs_config_is_set(GVFS_USE_VIRTUAL_FILESYSTEM);
 
 	if (!opts->accept_pathspec && !opts->accept_ref)
 		BUG("make up your mind, you need to take _something_");


### PR DESCRIPTION
As documented in microsoft/vfsforgit#1812, attempting to restore a file fails when using either of these commands in a VFS for Git repo:

```
  git restore --source=<commit> <path>
  git checkout <commit> -- <path>
```

To discover the issue, I debugged such a call and found that since `opt->ignore_skipworktree` is not set, that the restore will not update the index when the file is not hydrated.

I verified that this works as expected, including that the file on-disk is projecting the new index version.

----

* [X] This change only applies to the virtualization hook and VFS for Git.
