### PR TITLE
fixup! sha1-file: create shared-cache directory if it doesn't exist

### DIFF
--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -324,7 +324,7 @@ static void gh_client__choose_odb(void)
 		return;
 
 	for (odb = the_repository->objects->odb->next; odb; odb = odb->next) {
-		if (!strcmp(odb->path, gvfs_shared_cache_pathname.buf)) {
+		if (!fspathcmp(odb->path, gvfs_shared_cache_pathname.buf)) {
 			gh_client__chosen_odb = odb;
 			return;
 		}


### PR DESCRIPTION
Resolves #645.

When on Windows, these paths may differ only by case in the config but also correspond to the same paths on disk. Use fspathcmp() instead.

---

* [X] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
