### PR TITLE
README: adjust the currently-broken GVFS Protocol link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ One major feature that Scalar recommends is [partial clone](https://github.blog/
 which reduces the amount of data transferred in order to work with a Git repository. While several
 services such as GitHub support partial clone, Azure Repos instead has an older version of this
 functionality called
-[the GVFS protocol](https://docs.microsoft.com/en-us/azure/devops/learn/git/gvfs-architecture#gvfs-protocol).
+[the GVFS protocol](https://github.com/microsoft/VFSForGit/blob/HEAD/Protocol.md).
 The integration with the GVFS protocol present in `microsoft/git` is not appropriate to include in
 the core Git client because partial clone is the official version of that functionality.
 


### PR DESCRIPTION
The current link points to a page that has gone away. While there is https://web.archive.org/web/20210302002834/https://docs.microsoft.com/en-us/azure/devops/learn/git/gvfs-architecture#gvfs-protocol that _could_ be used to reinstate the link, it is not actually the best document to which to point the keen reader. We already point interested parties to the VFSforGit repository's documentation elsewhere, so let's also do that in the README.

This fixes https://github.com/microsoft/git/issues/628.

* [x] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.