### PR TITLE
Use Azure Federated login mechanism rather than secrets

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]*vfs*' # matches "v<number><any characters>vfs<any characters>"
 
+permissions:
+  id-token: write # required for Azure login via OIDC
+
 jobs:
   # Check prerequisites for the workflow
   prereqs:
@@ -546,7 +549,9 @@ jobs:
       - name: Log into Azure
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Prepare for GPG signing
         env:
@@ -704,7 +709,9 @@ jobs:
       - name: Log into Azure
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Download GPG public key signature file
         run: |


### PR DESCRIPTION
Use federated authentication with GitHub Actions and Azure Entra ID for the Azure login commands during `build-git-installers.yml` builds.

This will allow us to drop the use of a client secret to authenticate as the signing identity for Trusted Code Signing.

The `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` secrets have already been added to the `release` environment, and a test of the `azure/login` step using this mechanism and a subsequent `az` command has been successfully demonstrated here: https://github.com/microsoft/git/actions/runs/9652892561/job/26624014573