### PR TITLE
trace2: prefetch value of GIT_TRACE2_DST_DEBUG at startup

### DIFF
--- a/trace2.c
+++ b/trace2.c
@@ -225,6 +225,16 @@ void trace2_initialize_fl(const char *file, int line)
 	if (!tr2_tgt_want_builtins())
 		return;
 	trace2_enabled = 1;
+
+	/*
+	 * getenv() on Windows stomps on `errno` and the code in
+	 * tr2_dst.c verifies that warnings are enabled before
+	 * formatting the warning message (and calling strerror()).
+	 * So prefetch the value from the environment before we need
+	 * it.
+	 */
+	tr2_dst_want_warning();
+
 	if (!git_env_bool("GIT_TRACE2_REDACT", 1))
 		trace2_redact = 0;
 

--- a/trace2/tr2_dst.c
+++ b/trace2/tr2_dst.c
@@ -24,7 +24,7 @@
  */
 static int tr2env_max_files = 0;
 
-static int tr2_dst_want_warning(void)
+int tr2_dst_want_warning(void)
 {
 	static int tr2env_dst_debug = -1;
 

--- a/trace2/tr2_dst.h
+++ b/trace2/tr2_dst.h
@@ -35,4 +35,16 @@ int tr2_dst_trace_want(struct tr2_dst *dst);
  */
 void tr2_dst_write_line(struct tr2_dst *dst, struct strbuf *buf_line);
 
+/*
+ * Return true if we want warning messages when trying to open a
+ * destination.
+ *
+ * (Trace2 always silently fails if a target cannot be opened so that
+ * we don't affect the execution of the Git command, but it is helpful
+ * for debugging telemetry configuration if we log warning messages
+ * when trying to open a target. This is controlled by another config
+ * value.)
+ */
+int tr2_dst_want_warning(void);
+
 #endif /* TR2_DST_H */


### PR DESCRIPTION
Prefetch the value of GIT_TRACE2_DST_DEBUG during startup and before we try to open any Trace2 destination pathnames.

Normally, Trace2 always silently fails if a destination target cannot be opened so that it doesn't affect the execution of a Git command.  The command should run normally, but just not generate any trace data.  This can make it difficult to debug a telemetry setup, since the user doesn't know why telemetry isn't being generated.  If the environment variable GIT_TRACE2_DST_DEBUG is true, the Trace2 startup will print a warning message with the `errno` to make debugging easier.

However, on Windows, looking up the env variable resets `errno` so the warning message always ends with `...tracing: No error` which is not very helpful.

Prefetch the env variable at startup.  This avoids the need to update each call-site to capture `errno` in the usual `saved-errno` variable.
