### PR TITLE
release: fix federated auth

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -666,6 +666,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # required for Azure login via OIDC
     needs:
       - validate-installers
       - create-linux-artifacts


### PR DESCRIPTION
One "funny" quirk of GitHub Actions is that some of their YAML constructs that users _assume_ to be cumulative, are not. One example is the `permissions` block: Most readers will assume that the following YAML will combine `contents` and `id-token` permissions:

	permissions:
	  id-token: write

	jobs:
	  my-job:
	    permissions:
	      contents: write

However, that is not the case! The inner `permissions` block completely negates the outer `permissions` block. This can be seen in all its glory [here](https://github.com/microsoft/git/actions/runs/9757936987/job/26936077969#step:7:76). With this commit, [the bug is fixed](https://github.com/microsoft/git/actions/runs/9759511633/job/26937544197#step:7:77).