### PR TITLE
revert change to `ignore_skip_worktree` in `git checkout` and `git restore`

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1,6 +1,5 @@
 #define USE_THE_INDEX_VARIABLE
 #include "builtin.h"
-#include "gvfs.h"
 #include "advice.h"
 #include "branch.h"
 #include "cache-tree.h"
@@ -1759,7 +1758,6 @@ static int checkout_main(int argc, const char **argv, const char *prefix,
 	}
 
 	opts->track = BRANCH_TRACK_UNSPECIFIED;
-	opts->ignore_skipworktree = gvfs_config_is_set(GVFS_USE_VIRTUAL_FILESYSTEM);
 
 	if (!opts->accept_pathspec && !opts->accept_ref)
 		BUG("make up your mind, you need to take _something_");


### PR DESCRIPTION
This reverts #658 and essentially reopens microsoft/vfsforgit#1812. Resolves #673.

The issue is that by overriding the `ignore_skip_wortree` value (normally set by `--ignore-skip-worktree`) we then force Git to hydrate the entire working directory in a `git restore .`. This leads to some interesting trade-offs:

1. Users on v2.45.2.vfs.0.2 (where `git restore .` overhydrates), they can use `git reset --hard` as a better representation of this behavior.
2. Users on any Git version can use `git restore --ignore-skip-worktree -- <pathspec>` when using a smaller-scale pathspec that corresponds to files they care about and probably have hydrated.

I will include these workarounds in the VFS for Git issue.

To get to a real solution here, we would somehow need to turn the `ignore_skip_worktree` bit into two bits:

a. A bit to say "update index entries that have `SKIP_WORKTREE` set".
b. A bit to say "update the working directory even if `SKIP_WORKTREE` is set".

And perhaps this "working directory" version is what was intended when adding the `--ignore-skip-worktree` option, but it's more involved and has upstream implications to make changes here.