### PR TITLE
Bump a couple of GitHub Actions versions

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -143,7 +143,7 @@ jobs:
           git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
           git bundle create "$b"/MINGW-packages.bundle origin/main..main)
       - name: Publish mingw-w64-x86_64-git
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pkg-x86_64
           path: artifacts
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Download pkg-x86_64
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pkg-x86_64
           path: pkg-x86_64
@@ -298,7 +298,7 @@ jobs:
           PATH=$PATH:"/c/Program Files (x86)/Windows Kits/10/App Certification Kit/" \
           signtool verify //pa artifacts/${{matrix.artifact.fileprefix}}-*.exe
       - name: Publish ${{matrix.artifact.name}}-x86_64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: win-${{matrix.artifact.name}}-x86_64
           path: artifacts

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -465,7 +465,7 @@ jobs:
           mv git/.github/macos-installer/disk-image/*.pkg git/.github/macos-installer/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-artifacts
           path: |

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -486,7 +486,7 @@ jobs:
           sudo apt-get install -y -q --no-install-recommends gettext libcurl4-gnutls-dev libpcre3-dev asciidoc xmlto
 
       - name: Clone git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: git
 

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -588,7 +588,7 @@ jobs:
           debsigs --sign=origin --verify --check microsoft-git_"$version".deb
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-artifacts
           path: |

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -684,25 +684,25 @@ jobs:
         needs.windows_artifacts.result == 'success')
     steps:
       - name: Download Windows portable installer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: win-portable-x86_64
           path: win-portable-x86_64
 
       - name: Download Windows x86_64 installer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: win-installer-x86_64
           path: win-installer-x86_64
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: macos-artifacts
           path: macos-artifacts
 
       - name: Download Debian package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: linux-artifacts
           path: deb-package

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -617,7 +617,7 @@ jobs:
     needs: [prereqs, windows_artifacts, create-macos-artifacts, create-linux-artifacts]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.component.artifact }}
 

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -318,7 +318,7 @@ jobs:
     environment: release
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'git'
 


### PR DESCRIPTION
I propose this alternative to https://github.com/microsoft/git/pull/684, for several reasons:

- according to https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/, it is incorrect to bump `download-artifact` to v4 _without_ also bumping `upload-artifact` to the same version.
- bumping it to v4.1.7 instead of v4 would require us to follow the versions in too fine-grained a way, better to just follow v4.
- there is also a v4 of `actions/checkout` that we need to use
- to accommodate `microsoft/git`'s release flow, the changes need to be split into appropriate `fixup!` commits so that the next time we rebase to a newer upstream version, the changes are folded into the appropriate patches.