### PR TITLE
path-walk: improve path-walk speed with many tags

### DIFF
--- a/path-walk.c
+++ b/path-walk.c
@@ -299,26 +299,28 @@ int walk_objects_by_path(struct path_walk_info *info)
 			if (obj->type == OBJ_COMMIT || obj->flags & SEEN)
 				continue;
 
-			obj->flags |= SEEN;
-
 			while (obj->type == OBJ_TAG) {
 				struct tag *tag = lookup_tag(info->revs->repo,
 							     &obj->oid);
-				if (oid_array_lookup(&tags, &obj->oid) < 0)
+				if (!(obj->flags & SEEN)) {
+					obj->flags |= SEEN;
 					oid_array_append(&tags, &obj->oid);
+				}
 				obj = tag->tagged;
 			}
 
+			if ((obj->flags & SEEN))
+				continue;
+			obj->flags |= SEEN;
+
 			switch (obj->type) {
 			case OBJ_TREE:
-				if (info->trees &&
-				    oid_array_lookup(&root_tree_list->oids, &obj->oid) < 0)
+				if (info->trees)
 					oid_array_append(&root_tree_list->oids, &obj->oid);
 				break;
 
 			case OBJ_BLOB:
-				if (info->blobs &&
-				    oid_array_lookup(&tagged_blob_list, &obj->oid) < 0)
+				if (info->blobs)
 					oid_array_append(&tagged_blob_list, &obj->oid);
 				break;
 


### PR DESCRIPTION
In the presence of many tags, the use of oid_array_lookup() can become extremely slow. We should rely upon the SEEN bit instead.

This affects the tag-peeling walk as well as the switch statement for adding the peeled object to the correct oid_array.

----

I found this while testing the 2.47.0.vfs.0.0 pre-release against a repo with many annotated tags.