### PR TITLE
fixup! scalar: enable path-walk during push via config

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -193,7 +193,7 @@ static int set_recommended_config(int reconfigure)
 		{ "core.autoCRLF", "false" },
 		{ "core.safeCRLF", "false" },
 		{ "fetch.showForcedUpdates", "false" },
-		{ "push.usePathWalk", "true" },
+		{ "pack.usePathWalk", "true" },
 		{ "core.configWriteLockTimeoutMS", "150" },
 		{ NULL, NULL },
 	};


### PR DESCRIPTION
There was a typo in the configuration Scalar registers, which was missed by author and reviewer 🤦. No big harm done, let's just fix this in time for the next Git for Windows version.

This is a companion to https://github.com/git-for-windows/git/pull/5220.