### PR TITLE
winget: switch to using an Azure KeyVault

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -10,11 +10,21 @@ on:
         required: true
         default: 'latest'
 
+permissions:
+  id-token: write # required for Azure login via OIDC
+
 jobs:
   release:
     runs-on: windows-latest
     environment: release
     steps:
+      - name: Log into Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Publish manifest with winget-create
         run: |
           # Get correct release asset
@@ -37,5 +47,5 @@ jobs:
 
           # Submit manifests
           $manifestDirectory = Split-Path "$manifestPath"
-          .\wingetcreate.exe submit -t "${{ secrets.WINGET_TOKEN }}" $manifestDirectory
+          .\wingetcreate.exe submit -t "(az keyvault secret show --name ${{ secrets.WINGET_TOKEN_SECRET_NAME }} --vault-name ${{ secrets.AZURE_VAULT }} --query "value")" $manifestDirectory
         shell: powershell


### PR DESCRIPTION
Instead of storing the Personal Access Token in an environment secret, store it in Azure KeyVault instead. This allows for much better auditing when (and where) the secret is used.

Ideally, we would even switch away from using a Personal Access Token in the first place. But there is no alternative, such as a Managed Identity on GitHub, where one could define in a fine-grained way which usage scenario can be performed using that identity, and recent reorgs at GitHub suggest that adding such an alternative may not be on the list of priorities at all.

So let's just stay with a Personal Access Token, but do safeguard it better by putting it into a KeyVault that can only be accessed by a narrowly-scoped GitHub Actions environment.