### PR TITLE
gitk: check main window visibility before waiting for it to show

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -12832,7 +12832,7 @@ if {$::tcl_platform(platform) eq {windows} && [file exists $gitk_prefix/etc/git.
     }
 }
 # wait for the window to become visible
-tkwait visibility .
+if {![winfo viewable .]} {tkwait visibility .}
 set_window_title
 update
 readrefs


### PR DESCRIPTION
If the main window is already visible when gitk waits for it to become visible, gitk hangs forever.
This commit adds a check whether the window is already visible. See https://wiki.tcl-lang.org/page/tkwait+visibility

This ports https://github.com/git/git/pull/944 to `microsoft/git`. for Git.

Fixed issue #704.