### PR TITLE
Add support for Windows on ARM

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -301,12 +301,7 @@ jobs:
 
   # Build and sign Mac OSX installers & upload artifacts
   create-macos-artifacts:
-    strategy:
-      matrix:
-        arch:
-          - name: arm64
-            runner: macos-latest-xl-arm64
-    runs-on: ${{ matrix.arch.runner }}
+    runs-on: macos-latest-xl-arm64
     needs: prereqs
     env:
       VERSION: "${{ needs.prereqs.outputs.tag_version }}"

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -122,11 +122,6 @@ jobs:
           # Make sure that there is a `/usr/bin/git` that can be used by `makepkg-mingw`
           printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git &&
 
-          # Restrict `PATH` to MSYS2 and to Visual Studio (to let `cv2pdb` find the relevant DLLs)
-          PATH="/mingw64/bin:/usr/bin:/C/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64:/C/Windows/system32"
-
-          type -p mspdb140.dll || exit 1
-
           sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-64-bit --build-src-pkg -o artifacts HEAD &&
           if test -n "$GPGKEY"
           then

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -50,11 +50,25 @@ jobs:
           test "${{ steps.tag.outputs.version }}" == "$(sed -n 's/^GIT_VERSION = //p'< GIT-VERSION-FILE)" || die "GIT-VERSION-FILE tag does not match ${{ steps.tag.outputs.name }}"
   # End check prerequisites for the workflow
 
-  # Build Windows installers (x86_64 installer & portable)
+  # Build Windows installers (x86_64 & aarch64; installer & portable)
   windows_pkg:
-    runs-on: windows-2019
     environment: release
     needs: prereqs
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: x86_64
+            artifact: pkg-x86_64
+            toolchain: x86_64
+            mingwprefix: mingw64
+            runner: windows-2019
+          - name: aarch64
+            artifact: pkg-aarch64
+            toolchain: clang-aarch64
+            mingwprefix: clangarm64
+            runner: ['self-hosted', '1ES.Pool=github-arm64-pool']
+    runs-on: ${{ matrix.arch.runner }}
     env:
       GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
       HOME: "${{github.workspace}}\\home"
@@ -72,6 +86,7 @@ jobs:
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
           flavor: build-installers
+          architecture: ${{ matrix.arch.name }}
       - name: Clone build-extra
         shell: bash
         run: |
@@ -112,7 +127,7 @@ jobs:
           git config --global user.email "<${info#*<}"
         env:
           GPGKEY: ${{secrets.GPGKEY}}
-      - name: Build mingw-w64-x86_64-git
+      - name: Build mingw-w64-${{matrix.arch.toolchain}}-git
         env:
           GPGKEY: "${{secrets.GPGKEY}}"
         shell: bash
@@ -120,9 +135,9 @@ jobs:
           set -x
 
           # Make sure that there is a `/usr/bin/git` that can be used by `makepkg-mingw`
-          printf '#!/bin/sh\n\nexec /mingw64/bin/git.exe "$@"\n' >/usr/bin/git &&
+          printf '#!/bin/sh\n\nexec /${{matrix.arch.mingwprefix}}/bin/git.exe "$@"\n' >/usr/bin/git &&
 
-          sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-64-bit --build-src-pkg -o artifacts HEAD &&
+          sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-${{matrix.arch.name}} --build-src-pkg -o artifacts HEAD &&
           if test -n "$GPGKEY"
           then
             for tar in artifacts/*.tar*
@@ -137,34 +152,46 @@ jobs:
           cp PKGBUILD.$version PKGBUILD &&
           git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
           git bundle create "$b"/MINGW-packages.bundle origin/main..main)
-      - name: Publish mingw-w64-x86_64-git
+      - name: Publish mingw-w64-${{matrix.arch.toolchain}}-git
         uses: actions/upload-artifact@v4
         with:
-          name: pkg-x86_64
+          name: "${{ matrix.arch.artifact }}"
           path: artifacts
   windows_artifacts:
-    runs-on: windows-2019
     environment: release
     needs: [prereqs, windows_pkg]
     env:
       HOME: "${{github.workspace}}\\home"
     strategy:
+      fail-fast: false
       matrix:
-        artifact:
+        arch:
+          - name: x86_64
+            artifact: pkg-x86_64
+            toolchain: x86_64
+            mingwprefix: mingw64
+            runner: windows-2019
+          - name: aarch64
+            artifact: pkg-aarch64
+            toolchain: clang-aarch64
+            mingwprefix: clangarm64
+            runner: ['self-hosted', '1ES.Pool=github-arm64-pool']
+        type:
           - name: installer
             fileprefix: Git
           - name: portable
             fileprefix: PortableGit
-      fail-fast: false
+    runs-on: ${{ matrix.arch.runner }}
     steps:
-      - name: Download pkg-x86_64
+      - name: Download ${{ matrix.arch.artifact }}
         uses: actions/download-artifact@v4
         with:
-          name: pkg-x86_64
-          path: pkg-x86_64
+          name: ${{ matrix.arch.artifact }}
+          path: ${{ matrix.arch.artifact }}
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
           flavor: build-installers
+          architecture: ${{ matrix.arch.name }}
       - name: Clone build-extra
         shell: bash
         run: |
@@ -194,7 +221,7 @@ jobs:
           EOF
 
           sed -i -e '/^#include "file-list.iss"/a\
-          Source: {#SourcePath}\\..\\git-update-git-for-windows.config; DestDir: {app}\\mingw64\\bin; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore' \
+          Source: {#SourcePath}\\..\\git-update-git-for-windows.config; DestDir: {app}\\${{matrix.arch.mingwprefix}}\\bin; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore' \
             -e '/^Type: dirifempty; Name: {app}\\{#MINGW_BITNESS}$/i\
           Type: files; Name: {app}\\{#MINGW_BITNESS}\\bin\\git-update-git-for-windows.config\
           Type: dirifempty; Name: {app}\\{#MINGW_BITNESS}\\bin' \
@@ -204,15 +231,15 @@ jobs:
         run: |
           set -x
 
-          b=/mingw64/bin &&
+          b=/${{matrix.arch.mingwprefix}}/bin &&
 
           sed -i -e '6 a use_recently_seen=no' \
             $b/git-update-git-for-windows
-      - name: Set the installer Publisher to the GitClient team
+      - name: Set the installer Publisher to the Git Client team
         shell: bash
         run: |
           b=/usr/src/build-extra &&
-          sed -i -e 's/^\(AppPublisher=\).*/\1The GitClient Team at Microsoft/' $b/installer/install.iss
+          sed -i -e 's/^\(AppPublisher=\).*/\1The Git Client Team at Microsoft/' $b/installer/install.iss
       - name: Let the installer configure Visual Studio to use the installed Git
         shell: bash
         run: |
@@ -264,7 +291,7 @@ jobs:
                   WizardSelectComponents('scalar');\n\
           #endif\n\
               end;" $b/installer/install.iss
-      - name: Build 64-bit ${{matrix.artifact.name}}
+      - name: Build ${{matrix.type.name}} (${{matrix.arch.name}})
         shell: bash
         run: |
           set -x
@@ -272,30 +299,30 @@ jobs:
           # Copy the PDB archive to the directory where `--include-pdbs` expects it
           b=/usr/src/build-extra &&
           mkdir -p $b/cached-source-packages &&
-          cp pkg-x86_64/*-pdb* $b/cached-source-packages/ &&
+          cp ${{matrix.arch.artifact}}/*-pdb* $b/cached-source-packages/ &&
 
           # Build the installer, embedding PDBs
           eval $b/please.sh make_installers_from_mingw_w64_git --include-pdbs \
               --version=${{ needs.prereqs.outputs.tag_version }} \
-              -o artifacts --${{matrix.artifact.name}} \
-              --pkg=pkg-x86_64/mingw-w64-x86_64-git-[0-9]*.tar.xz \
-              --pkg=pkg-x86_64/mingw-w64-x86_64-git-doc-html-[0-9]*.tar.xz &&
+              -o artifacts --${{matrix.type.name}} \
+              --pkg=${{matrix.arch.artifact}}/mingw-w64-${{matrix.arch.toolchain}}-git-[0-9]*.tar.xz \
+              --pkg=${{matrix.arch.artifact}}/mingw-w64-${{matrix.arch.toolchain}}-git-doc-html-[0-9]*.tar.xz &&
 
-          if test portable = '${{matrix.artifact.name}}' && test -n "$(git config alias.signtool)"
+          if test portable = '${{matrix.type.name}}' && test -n "$(git config alias.signtool)"
           then
             git signtool artifacts/PortableGit-*.exe
           fi &&
-          openssl dgst -sha256 artifacts/${{matrix.artifact.fileprefix}}-*.exe | sed "s/.* //" >artifacts/sha-256.txt
+          openssl dgst -sha256 artifacts/${{matrix.type.fileprefix}}-*.exe | sed "s/.* //" >artifacts/sha-256.txt
       - name: Verify that .exe files are code-signed
         if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
         shell: bash
         run: |
           PATH=$PATH:"/c/Program Files (x86)/Windows Kits/10/App Certification Kit/" \
-          signtool verify //pa artifacts/${{matrix.artifact.fileprefix}}-*.exe
-      - name: Publish ${{matrix.artifact.name}}-x86_64
+          signtool verify //pa artifacts/${{matrix.type.fileprefix}}-*.exe
+      - name: Publish ${{matrix.type.name}}-${{matrix.arch.name}}
         uses: actions/upload-artifact@v4
         with:
-          name: win-${{matrix.artifact.name}}-x86_64
+          name: win-${{matrix.type.name}}-${{matrix.arch.name}}
           path: artifacts
   # End build Windows installers
 
@@ -603,6 +630,9 @@ jobs:
           - os: windows-latest
             artifact: win-installer-x86_64
             command: $PROGRAMFILES\Git\cmd\git.exe
+          - os: ['self-hosted', '1ES.Pool=github-arm64-pool']
+            artifact: win-installer-aarch64
+            command: $PROGRAMFILES\Git\cmd\git.exe
     runs-on: ${{ matrix.component.os }}
     needs: [prereqs, windows_artifacts, create-macos-artifacts, create-linux-artifacts]
     steps:
@@ -612,20 +642,20 @@ jobs:
           name: ${{ matrix.component.artifact }}
 
       - name: Install Windows
-        if: contains(matrix.component.os, 'windows')
+        if: contains(matrix.component.artifact, 'win-installer')
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path ./*.exe | %{$_.FullName}
           Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1"
 
       - name: Install Linux
-        if: contains(matrix.component.os, 'ubuntu')
+        if: contains(matrix.component.artifact, 'linux')
         run: |
           debpath=$(find ./*.deb)
           sudo apt install $debpath
 
       - name: Install macOS
-        if: contains(matrix.component.os, 'macos')
+        if: contains(matrix.component.artifact, 'macos')
         run: |
           # avoid letting Homebrew's `git` in `/opt/homebrew/bin` override `/usr/local/bin/git`
           arch="$(uname -m)"
@@ -673,17 +703,29 @@ jobs:
         needs.create-macos-artifacts.result == 'success' &&
         needs.windows_artifacts.result == 'success')
     steps:
-      - name: Download Windows portable installer
+      - name: Download Windows portable (x86_64)
         uses: actions/download-artifact@v4
         with:
           name: win-portable-x86_64
           path: win-portable-x86_64
 
-      - name: Download Windows x86_64 installer
+      - name: Download Windows portable (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: win-portable-aarch64
+          path: win-portable-aarch64
+
+      - name: Download Windows installer (x86_64)
         uses: actions/download-artifact@v4
         with:
           name: win-installer-x86_64
           path: win-installer-x86_64
+
+      - name: Download Windows installer (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: win-installer-aarch64
+          path: win-installer-aarch64
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
@@ -754,9 +796,13 @@ jobs:
             }
 
             await Promise.all([
-              // Upload Windows artifacts
+              // Upload Windows x86_64 artifacts
               uploadDirectoryToRelease('win-installer-x86_64', ['.exe']),
               uploadDirectoryToRelease('win-portable-x86_64', ['.exe']),
+
+              // Upload Windows aarch64 artifacts
+              uploadDirectoryToRelease('win-installer-aarch64', ['.exe']),
+              uploadDirectoryToRelease('win-portable-aarch64', ['.exe']),
 
               // Upload Mac artifacts
               uploadDirectoryToRelease('macos-artifacts'),

--- a/.github/workflows/clangarm64-build.yml
+++ b/.github/workflows/clangarm64-build.yml
@@ -9,7 +9,7 @@ defaults:
 
 jobs:
   clang-build:
-    runs-on: [Windows, ARM64]
+    runs-on: ['self-hosted', '1ES.Pool=github-arm64-pool']
     env:
       NO_PERL: 1
     steps:


### PR DESCRIPTION
Bring support for Windows on ARM64 to this fork of Git. We make use of a custom 1ES hosted pool (hosted in Azure) that runs Windows 11 ARM64 on a `B4pls v2` sized VM SKU. The image has the latest Git for Windows ARM64 installed, the GitHub Actions runner, along with PowerShell Core (required for the GitHub Actions runner).

Requests with the `['self-hosted', '1ES.Pool=github-arm64-pool']` labels will be directed to the 1ES hosted pool.

A few changes were made to the `build-git-installers.yml` workflow, mainly to parameterise the architecture to allow for x86_64 and aarch64 builds, via a matrix strategy.

Find the end-to-end successful build of `build-git-installers.yml` [here](https://github.com/microsoft/git/actions/runs/12358457268).