### PR TITLE
Fix WinGet release workflow to account for new installation matrix

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -29,7 +29,8 @@ jobs:
         run: |
           # Get correct release asset
           $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
-          $asset = $github.release.assets | Where-Object -Property name -match '64-bit.exe$'
+          $asset_x64 = $github.release.assets | Where-Object -Property name -match '64-bit.exe$'
+          $asset_arm64 = $github.release.assets | Where-Object -Property name -match 'arm64.exe$'
 
           # Remove 'v' and 'vfs' from the version
           $github.release.tag_name -match '\d.*'
@@ -37,7 +38,13 @@ jobs:
 
           # Download wingetcreate and create manifests
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Microsoft.Git -u $asset.browser_download_url -v $version -o manifests
+          .\wingetcreate.exe update Microsoft.Git `
+              -v $version `
+              -o manifests `
+              -u "$($asset_x64.browser_download_url)|x64|machine" `
+                 "$($asset_x64.browser_download_url)|x64|user" `
+                 "$($asset_arm64.browser_download_url)|arm64|machine" `
+                 "$($asset_arm64.browser_download_url)|arm64|user"
 
           # Manually substitute the name of the default branch in the License
           # and Copyright URLs since the tooling cannot do that for us.


### PR DESCRIPTION
Update the WinGet release workflow to match the updating manifest in `microsoft/winget-pkgs`, where there are now four installation options:

- x86_64 / x64 with machine scope
- x86_64 / x64 with user scope
- aarch64 / arm64 with machine scope
- aarch64 / arm64 with user scope