### PR TITLE
Fix Scalar's Functional Tests failure due to a deprecated Actions version

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Archive Trace2 Logs
         if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows.conclusion == 'success' )
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TRACE2_BASENAME }}.zip
           path: scalar/${{ env.TRACE2_BASENAME }}.zip


### PR DESCRIPTION
The Scalar Functional Tests run at
https://github.com/microsoft/git/actions/runs/13074318147 has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

The error message suggested to learn more at:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

While we may very well soon decide to just stop running the Scalar Functional Tests because basically all of the tests (except for integration testing with the remote `gvfs/ci` repository) have equivalent coverage in `microsoft/git`'s own test suite.