### PR TITLE
Permit `repack` command in Scalar clones

### DIFF
--- a/builtin/repack.c
+++ b/builtin/repack.c
@@ -24,6 +24,7 @@
 #include "pack-bitmap.h"
 #include "refs.h"
 #include "list-objects-filter-options.h"
+#include "gvfs.h"
 
 #define ALL_INTO_ONE 1
 #define LOOSEN_UNREACHABLE 2
@@ -1177,6 +1178,7 @@ int cmd_repack(int argc,
 	struct tempfile *refs_snapshot = NULL;
 	int i, ext, ret;
 	int show_progress;
+	const char *tmp_obj_dir = NULL;
 
 	/* variables to be filled by option parsing */
 	int delete_redundant = 0;
@@ -1300,6 +1302,10 @@ int cmd_repack(int argc,
 		warning(_("disabling bitmap writing, as some objects are not being packed"));
 		write_bitmaps = 0;
 	}
+
+	if (gvfs_config_is_set(GVFS_ANY_MASK) &&
+	    !git_config_get_value("gvfs.sharedcache", &tmp_obj_dir))
+		warning(_("shared object cache is configured but will not be repacked"));
 
 	if (write_midx && write_bitmaps) {
 		struct strbuf path = STRBUF_INIT;

--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -1451,13 +1451,6 @@ int cmd_worktree(int ac,
 
 	git_config(git_worktree_config, NULL);
 
-	/*
-	 * git-worktree is special-cased to work in Scalar repositories
-	 * even when they use the GVFS Protocol.
-	 */
-	if (core_gvfs & GVFS_USE_VIRTUAL_FILESYSTEM)
-		die("'git %s' is not supported on a GVFS repo", "worktree");
-
 	if (!prefix)
 		prefix = "";
 

--- a/git.c
+++ b/git.c
@@ -32,6 +32,7 @@
 #define DELAY_PAGER_CONFIG	(1<<4)
 #define NO_PARSEOPT		(1<<5) /* parse-options is not used */
 #define BLOCK_ON_GVFS_REPO	(1<<6) /* command not allowed in GVFS repos */
+#define BLOCK_ON_VFS_ENABLED	(1<<7) /* command not allowed when virtual file system is used */
 
 struct cmd_struct {
 	const char *cmd;
@@ -541,6 +542,9 @@ static int run_builtin(struct cmd_struct *p, int argc, const char **argv, struct
 
 	if (!help && p->option & BLOCK_ON_GVFS_REPO && gvfs_config_is_set(GVFS_BLOCK_COMMANDS))
 		die("'git %s' is not supported on a GVFS repo", p->cmd);
+
+	if (!help && p->option & BLOCK_ON_VFS_ENABLED && gvfs_config_is_set(GVFS_USE_VIRTUAL_FILESYSTEM))
+		die("'git %s' is not supported when using the virtual file system", p->cmd);
 
 	if (run_pre_command_hook(the_repository, argv))
 		die("pre-command hook aborted command");

--- a/git.c
+++ b/git.c
@@ -685,7 +685,7 @@ static struct cmd_struct commands[] = {
 	{ "remote", cmd_remote, RUN_SETUP },
 	{ "remote-ext", cmd_remote_ext, NO_PARSEOPT },
 	{ "remote-fd", cmd_remote_fd, NO_PARSEOPT },
-	{ "repack", cmd_repack, RUN_SETUP | BLOCK_ON_GVFS_REPO },
+	{ "repack", cmd_repack, RUN_SETUP | BLOCK_ON_VFS_ENABLED },
 	{ "replace", cmd_replace, RUN_SETUP },
 	{ "replay", cmd_replay, RUN_SETUP },
 	{ "rerere", cmd_rerere, RUN_SETUP },

--- a/git.c
+++ b/git.c
@@ -726,7 +726,7 @@ static struct cmd_struct commands[] = {
 	{ "verify-tag", cmd_verify_tag, RUN_SETUP },
 	{ "version", cmd_version },
 	{ "whatchanged", cmd_whatchanged, RUN_SETUP },
-	{ "worktree", cmd_worktree, RUN_SETUP },
+	{ "worktree", cmd_worktree, RUN_SETUP | BLOCK_ON_VFS_ENABLED },
 	{ "write-tree", cmd_write_tree, RUN_SETUP },
 };
 

--- a/git.c
+++ b/git.c
@@ -629,7 +629,7 @@ static struct cmd_struct commands[] = {
 	{ "for-each-ref", cmd_for_each_ref, RUN_SETUP },
 	{ "for-each-repo", cmd_for_each_repo, RUN_SETUP_GENTLY },
 	{ "format-patch", cmd_format_patch, RUN_SETUP },
-	{ "fsck", cmd_fsck, RUN_SETUP | BLOCK_ON_GVFS_REPO},
+	{ "fsck", cmd_fsck, RUN_SETUP | BLOCK_ON_VFS_ENABLED },
 	{ "fsck-objects", cmd_fsck, RUN_SETUP },
 	{ "fsmonitor--daemon", cmd_fsmonitor__daemon, RUN_SETUP },
 	{ "gc", cmd_gc, RUN_SETUP },

--- a/git.c
+++ b/git.c
@@ -672,7 +672,7 @@ static struct cmd_struct commands[] = {
 	{ "pack-refs", cmd_pack_refs, RUN_SETUP },
 	{ "patch-id", cmd_patch_id, RUN_SETUP_GENTLY | NO_PARSEOPT },
 	{ "pickaxe", cmd_blame, RUN_SETUP },
-	{ "prune", cmd_prune, RUN_SETUP | BLOCK_ON_GVFS_REPO},
+	{ "prune", cmd_prune, RUN_SETUP | BLOCK_ON_VFS_ENABLED },
 	{ "prune-packed", cmd_prune_packed, RUN_SETUP },
 	{ "pull", cmd_pull, RUN_SETUP | NEED_WORK_TREE },
 	{ "push", cmd_push, RUN_SETUP },

--- a/gvfs.h
+++ b/gvfs.h
@@ -30,6 +30,8 @@
 #define GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS      (1 << 6)
 #define GVFS_PREFETCH_DURING_FETCH		    (1 << 7)
 
+#define GVFS_ANY_MASK                               0xFFFFFFFF
+
 void gvfs_load_config_value(const char *value);
 int gvfs_config_is_set(int mask);
 

--- a/t/t0402-block-command-on-gvfs.sh
+++ b/t/t0402-block-command-on-gvfs.sh
@@ -22,7 +22,6 @@ not_with_gvfs fsck
 not_with_gvfs gc
 not_with_gvfs gc --auto
 not_with_gvfs prune
-not_with_gvfs repack
 not_with_gvfs submodule status
 not_with_gvfs update-index --index-version 2
 not_with_gvfs update-index --skip-worktree
@@ -34,6 +33,16 @@ test_expect_success 'test gc --auto succeeds when disabled via config' '
 	test_config core.gvfs true &&
 	test_config gc.auto 0 &&
 	git gc --auto
+'
+
+test_expect_success 'test repack fails with VFS bit enabled' '
+	test_config core.gvfs true &&
+	test_must_fail git repack
+'
+
+test_expect_success 'test repack succeeds with VFS bit disabled' '
+	test_config core.gvfs 150 &&
+	git repack
 '
 
 test_done


### PR DESCRIPTION
Currently when the `core.gvfs` setting is set, several commands are outright blocked from running. Some of these commands, namely `repack` are actually OK to run in a Scalar clone, even if it uses the GVFS protocol (for Azure DevOps).

Introduce a different blocking mechanism to only block commands when the virtual filesystem is being used, rather than as a broad block on any `core.gvfs` setting.