### PR TITLE
winget-release: fix workflow version parsing

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -71,12 +71,6 @@ jobs:
                  "$($asset_arm64_url)|arm64|machine" `
                  "$($asset_arm64_url)|arm64|user"
 
-          # Manually substitute the name of the default branch in the License
-          # and Copyright URLs since the tooling cannot do that for us.
-          $shortenedVersion = $version -replace ".{4}$"
-          $manifestPath = dir -Path ./manifests -Filter Microsoft.Git.locale.en-US.yaml -Recurse | %{$_.FullName}
-          sed -i "s/vfs-[.0-9]*/vfs-$shortenedVersion/g" "$manifestPath"
-
           # Download the token from Azure Key Vault and mask it in the logs
           az keyvault secret download --name ${{ secrets.WINGET_TOKEN_SECRET_NAME }} --vault-name ${{ secrets.AZURE_VAULT }} --file token.txt
           Write-Host -NoNewLine "::add-mask::$(Get-Content token.txt)"

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -35,10 +35,11 @@ jobs:
           $PSNativeCommandErrorActionPreference = "Stop"
 
           if ($env:TAG_NAME -eq "") {
-            $env:TAG_NAME =  $github.release.tag_name
-
             # Get latest release
             $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
+
+            # Set the tag name environment variable
+            $env:TAG_NAME =  $github.release.tag_name
 
             # Get download URLs
             $asset_x64 = $github.release.assets | Where-Object -Property name -match '64-bit.exe$'


### PR DESCRIPTION
When running this workflow from the `release` event the parsing of the tag name from the event object must happen _after_ the object has been loaded, not before! This error eventually results in a bogus value for the `$version` argument that gets passed to `wingetcreate`. Example: https://github.com/microsoft/winget-pkgs/commit/c05e69696bfbd20a57c3f7e7d90908d3218be388#diff-297f752772b92e600a2cba463f006d085a70a0919a5fad6b62fd8f88b135c9ee

Ensure we only access the `$github` variable _after_ we've defined it.

Whilst we're in here, also drop some no longer needed parts of the script. We now use the licence URLs pointing at `HEAD` rather than a specific branch version. This change was made during the 2.47.0.vfs.0.3 release by this PR: https://github.com/microsoft/winget-pkgs/pull/185867

