### PR TITLE
build-git-installers: decouple the VS registry settings from the autoupdater

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -272,11 +272,16 @@ jobs:
 
           b=/usr/src/build-extra &&
 
-          sed -i -e '/^ *InstallAutoUpdater();$/a\
-              CustomPostInstall();' \
-            -e '/^ *UninstallAutoUpdater();$/a\
-              CustomPostUninstall();' \
-            $b/installer/install.iss &&
+          sed -i "# First, find the autoupdater parts in the install/uninstall steps
+            /if IsComponentInstalled('autoupdate')/{
+              # slurp in the next two lines, where the call to InstallAutoUpdater()/UninstallAutoUpdater() happens
+              N
+              N
+              # insert the corresponding CustomPostInstall()/CustomPostUninstall() call before that block
+              s/^\\([ \t]*\\)\(.*\\)\\(Install\\|Uninstall\\)\\(AutoUpdater\\)/\\1CustomPost\\3();\\n\\1\\2\\3\\4/
+            }" $b/installer/install.iss &&
+          grep CustomPostInstall $b/installer/install.iss &&
+          grep CustomPostUninstall $b/installer/install.iss &&
 
           cat >>$b/installer/helpers.inc.iss <<\EOF
 


### PR DESCRIPTION
As pointed out in https://github.com/microsoft/git/issues/739, the VS registry settings are added only if the autoupdater feature is enabled. This was unintentional; Just like the corresponding part in the uninstaller, these two things should be apart.

So let's decouple the VS registry settings from the autoupdater.

Let's do that by ensuring that we put the function calls _outside_ of the autoupdater blocks.

For good measure, we add checks to verify that both calls _were_ added, i.e. that the expected patterns were found.

This fixes https://github.com/microsoft/git/issues/739