### PR TITLE
Fix a typo in `release-winget`

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -78,5 +78,5 @@ jobs:
 
           # Submit the manifest to the winget-pkgs repository
           $manifestDirectory = "$PWD\manifests\m\Microsoft\Git\$version"
-          .\wingetcreate.exe submit -t "$(Get-Content token.txt)" $manfiestDirectory
+          .\wingetcreate.exe submit -t "$(Get-Content token.txt)" $manifestDirectory
         shell: powershell


### PR DESCRIPTION
This typo prevented [the automatically-triggered `release-winget` workflow run](https://github.com/microsoft/git/actions/runs/14968035556) from succeeding ([the manually-triggered workflow using this here PR branch](https://github.com/microsoft/git/actions/runs/14968651802) succeeded).