### PR TITLE
gvfs-helper-client: clean up server process

### DIFF
--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -426,6 +426,10 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 	)
 '
 
+test_expect_success 'fetch <non-existent> does not hang in gvfs-helper' '
+	test_must_fail git -C using-gvfs/src fetch origin does-not-exist
+'
+
 test_expect_success '`scalar clone --no-gvfs-protocol` skips gvfs/config' '
 	# the fake cache server requires fake authentication &&
 	git config --global core.askPass true &&


### PR DESCRIPTION
On Linux, the following command would cause the terminal to be stuck waiting:

```
  git fetch origin foobar
```

The issue would be that the fetch would fail with the error

```
  fatal: couldn't find remote ref foobar
```

but the underlying `git-gvfs-helper` process wouldn't die. The `subprocess_exit_handler()` method would close its stdin and stdout, but that wouldn't be enough to cause the process to end.

The current approach creates our own `atexit()` handler by sending a `SIGINT` signal to the child process. This has worked in my end-to-end test.

Perhaps another approach would be to change the way git-gvfs-helper server gets messages over `stdin` to better terminate when the pipe closes. However, I debugged to the point that I could see the `git-gvfs-helper` process waiting on a basic `read()` from the standard library, so it's not mishandling an `EOF` signal or anything.