### PR TITLE
Set `http.version=HTTP/1.1` in `supports_gvfs_protocol()`

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -467,7 +467,8 @@ static int supports_gvfs_protocol(const char *url, char **cache_server_url)
 		return 0;
 
 	cp.git_cmd = 1;
-	strvec_pushl(&cp.args, "gvfs-helper", "--remote", url, "config", NULL);
+	strvec_pushl(&cp.args, "-c", "http.version=HTTP/1.1",
+		     "gvfs-helper", "--remote", url, "config", NULL);
 	if (!pipe_command(&cp, NULL, 0, &out, 512, NULL, 0)) {
 		long l = 0;
 		struct json_iterator it =


### PR DESCRIPTION
The way the `gvfs-helper` command operates is apparently incompatible with HTTP/2, that's why https://github.com/microsoft/git/pull/754 tried to enforce HTTP/1.1 in Scalar clones accessing Azure Repos.

However, this fix was incomplete for the `scalar clone` part because it made the HTTP/1.1 enforcement contingent on the test whether the remote repository supports the GVFS protocol or not, and that test did _not_ enforce HTTP/1.1.

Let's fix that Catch-22 by enforcing HTTP/1.1 usage during that GVFS Protocol capability test.