### PR TITLE
Fix very long `t5799-gvfs-helper.sh` runtimes in our CI runs

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2913,6 +2913,19 @@ static void do_req(const char *url_base,
 	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0); /* not a HEAD request */
 	curl_easy_setopt(slot->curl, CURLOPT_URL, rest_url.buf);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, params->headers);
+	if (curl_version_info(CURLVERSION_NOW)->version_num < 0x074b00)
+		/*
+		 * cURL 7.75.0 allows headers to be parsed even when
+		 * `CURLOPT_FAILONERROR` is enabled and the HTTP result code
+		 * indicates an error. This is the behavior expected by
+		 * `gvfs-helper`.
+		 *
+		 * On older cURL versions, `gvfs-helper` still needs to parse
+		 * the HTTP headers and therefore needs to _not_ fail upon
+		 * HTTP result codes indicating errors; For newer cURL
+		 * versions, we still prefer to enable `FAILONERROR`.
+		 */
+		curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, (long)0);
 
 	if (params->b_is_post) {
 		curl_easy_setopt(slot->curl, CURLOPT_POST, 1);

--- a/t/t5799-gvfs-helper.sh
+++ b/t/t5799-gvfs-helper.sh
@@ -1122,6 +1122,13 @@ test_expect_success 'http-error: 503 Service Unavailable (with retry and no-fall
 #
 #################################################################
 
+test_lazy_prereq CURL_7_75_OR_NEWER '
+	case "$(curl version | sed -n "1s/^curl \([^ ]*\).*/\1/p")" in
+	""|[0-6].*|7.[0-9]*.*|7.[1-6][0-9].*|7.7[0-4]*.*) return 1;;
+	*) return 0;;
+	esac
+'
+
 test_expect_success 'HTTP GET Auth on Origin Server' '
 	test_when_finished "per_test_cleanup" &&
 	start_gvfs_protocol_server_with_mayhem http_401 &&
@@ -1148,7 +1155,10 @@ test_expect_success 'HTTP GET Auth on Origin Server' '
 	test_cmp "$OID_ONE_BLOB_FILE" OUT.actual &&
 
 	verify_objects_in_shared_cache "$OID_ONE_BLOB_FILE" &&
-	verify_connection_count 2
+	if test_have_prereq CURL_7_75_OR_NEWER
+	then
+		verify_connection_count 2
+	fi
 '
 
 test_expect_success 'HTTP POST Auth on Origin Server' '


### PR DESCRIPTION
I have noticed for over a year now that some jobs in `microsoft/git`'s CI take quite a long time: well over an hour.

Finally I have a fix for that. All those build minutes were quite wastefully spent on... _sleeping_.

The whole story is written down in the commit message, if anyone is interested.