### PR TITLE
Fix `osx-gcc` CI build failures

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2910,7 +2910,7 @@ static void do_req(const char *url_base,
 	slot = get_active_slot();
 	slot->results = &results;
 
-	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0); /* not a HEAD request */
+	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0L); /* not a HEAD request */
 	curl_easy_setopt(slot->curl, CURLOPT_URL, rest_url.buf);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, params->headers);
 	if (curl_version_info(CURLVERSION_NOW)->version_num < 0x074b00)
@@ -2928,14 +2928,14 @@ static void do_req(const char *url_base,
 		curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, (long)0);
 
 	if (params->b_is_post) {
-		curl_easy_setopt(slot->curl, CURLOPT_POST, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_POST, 1L);
 		curl_easy_setopt(slot->curl, CURLOPT_ENCODING, NULL);
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS,
 				 params->post_payload->buf);
 		curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE,
 				 (long)params->post_payload->len);
 	} else {
-		curl_easy_setopt(slot->curl, CURLOPT_POST, 0);
+		curl_easy_setopt(slot->curl, CURLOPT_POST, 0L);
 	}
 
 	if (params->b_write_to_file) {
@@ -2961,9 +2961,9 @@ static void do_req(const char *url_base,
 		curl_easy_setopt(slot->curl, CURLOPT_XFERINFOFUNCTION,
 				 gh__curl_progress_cb);
 		curl_easy_setopt(slot->curl, CURLOPT_XFERINFODATA, params);
-		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 0);
+		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 0L);
 	} else {
-		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_NOPROGRESS, 1L);
 	}
 
 	gh__run_one_slot(slot, params, status);

--- a/http-push.c
+++ b/http-push.c
@@ -204,7 +204,7 @@ static void curl_setup_http(CURL *curl, const char *url,
 		const char *custom_req, struct buffer *buffer,
 		curl_write_callback write_fn)
 {
-	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
+	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_INFILE, buffer);
 	curl_easy_setopt(curl, CURLOPT_INFILESIZE, buffer->buf.len);
@@ -212,9 +212,9 @@ static void curl_setup_http(CURL *curl, const char *url,
 	curl_easy_setopt(curl, CURLOPT_SEEKFUNCTION, seek_buffer);
 	curl_easy_setopt(curl, CURLOPT_SEEKDATA, buffer);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_fn);
-	curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
+	curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
 	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, custom_req);
-	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
+	curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 }
 
 static struct curl_slist *get_dav_token_headers(struct remote_lock *lock, enum dav_header_flag options)

--- a/http-push.c
+++ b/http-push.c
@@ -194,7 +194,7 @@ static char *xml_entities(const char *s)
 static void curl_setup_http_get(CURL *curl, const char *url,
 		const char *custom_req)
 {
-	curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+	curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, custom_req);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite_null);

--- a/http.c
+++ b/http.c
@@ -731,7 +731,7 @@ static int has_proxy_cert_password(void)
 
 static void set_curl_keepalive(CURL *c)
 {
-	curl_easy_setopt(c, CURLOPT_TCP_KEEPALIVE, 1);
+	curl_easy_setopt(c, CURLOPT_TCP_KEEPALIVE, 1L);
 }
 
 /* Return 1 if redactions have been made, 0 otherwise. */
@@ -1032,13 +1032,13 @@ static CURL *get_curl_handle(void)
 		die("curl_easy_init failed");
 
 	if (!curl_ssl_verify) {
-		curl_easy_setopt(result, CURLOPT_SSL_VERIFYPEER, 0);
-		curl_easy_setopt(result, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_easy_setopt(result, CURLOPT_SSL_VERIFYPEER, 0L);
+		curl_easy_setopt(result, CURLOPT_SSL_VERIFYHOST, 0L);
 	} else {
 		/* Verify authenticity of the peer's certificate */
-		curl_easy_setopt(result, CURLOPT_SSL_VERIFYPEER, 1);
+		curl_easy_setopt(result, CURLOPT_SSL_VERIFYPEER, 1L);
 		/* The name in the cert must match whom we tried to connect */
-		curl_easy_setopt(result, CURLOPT_SSL_VERIFYHOST, 2);
+		curl_easy_setopt(result, CURLOPT_SSL_VERIFYHOST, 2L);
 	}
 
     if (curl_http_version) {
@@ -1141,7 +1141,7 @@ static CURL *get_curl_handle(void)
 				 curl_low_speed_time);
 	}
 
-	curl_easy_setopt(result, CURLOPT_MAXREDIRS, 20);
+	curl_easy_setopt(result, CURLOPT_MAXREDIRS, 20L);
 	curl_easy_setopt(result, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
 
 #ifdef GIT_CURL_HAVE_CURLOPT_PROTOCOLS_STR
@@ -1175,7 +1175,7 @@ static CURL *get_curl_handle(void)
 		user_agent ? user_agent : git_user_agent());
 
 	if (curl_ftp_no_epsv)
-		curl_easy_setopt(result, CURLOPT_FTP_USE_EPSV, 0);
+		curl_easy_setopt(result, CURLOPT_FTP_USE_EPSV, 0L);
 
 	if (curl_ssl_try)
 		curl_easy_setopt(result, CURLOPT_USE_SSL, CURLUSESSL_TRY);

--- a/http.c
+++ b/http.c
@@ -1533,9 +1533,9 @@ struct active_request_slot *get_active_slot(void)
 	curl_easy_setopt(slot->curl, CURLOPT_WRITEFUNCTION, NULL);
 	curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS, NULL);
 	curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE, -1L);
-	curl_easy_setopt(slot->curl, CURLOPT_UPLOAD, 0);
-	curl_easy_setopt(slot->curl, CURLOPT_HTTPGET, 1);
-	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 1);
+	curl_easy_setopt(slot->curl, CURLOPT_UPLOAD, 0L);
+	curl_easy_setopt(slot->curl, CURLOPT_HTTPGET, 1L);
+	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 1L);
 	curl_easy_setopt(slot->curl, CURLOPT_RANGE, NULL);
 
 	/*
@@ -1544,9 +1544,9 @@ struct active_request_slot *get_active_slot(void)
 	 * HTTP_FOLLOW_* cases themselves.
 	 */
 	if (http_follow_config == HTTP_FOLLOW_ALWAYS)
-		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 1L);
 	else
-		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 0);
+		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 0L);
 
 	curl_easy_setopt(slot->curl, CURLOPT_IPRESOLVE, git_curl_ipresolve);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPAUTH, http_auth_methods);
@@ -2113,12 +2113,12 @@ static int http_request(const char *url,
 	int ret;
 
 	slot = get_active_slot();
-	curl_easy_setopt(slot->curl, CURLOPT_HTTPGET, 1);
+	curl_easy_setopt(slot->curl, CURLOPT_HTTPGET, 1L);
 
 	if (!result) {
-		curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 1L);
 	} else {
-		curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0);
+		curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0L);
 		curl_easy_setopt(slot->curl, CURLOPT_WRITEDATA, result);
 
 		if (target == HTTP_REQUEST_FILE) {
@@ -2144,7 +2144,7 @@ static int http_request(const char *url,
 		strbuf_addstr(&buf, " no-cache");
 	if (options && options->initial_request &&
 	    http_follow_config == HTTP_FOLLOW_INITIAL)
-		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 1);
+		curl_easy_setopt(slot->curl, CURLOPT_FOLLOWLOCATION, 1L);
 
 	headers = curl_slist_append(headers, buf.buf);
 
@@ -2163,7 +2163,7 @@ static int http_request(const char *url,
 	curl_easy_setopt(slot->curl, CURLOPT_URL, url);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(slot->curl, CURLOPT_ENCODING, "");
-	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 0);
+	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 0L);
 
 	ret = run_one_slot(slot, &results);
 
@@ -2743,7 +2743,7 @@ struct http_object_request *new_http_object_request(const char *base_url,
 	freq->headers = object_request_headers();
 
 	curl_easy_setopt(freq->slot->curl, CURLOPT_WRITEDATA, freq);
-	curl_easy_setopt(freq->slot->curl, CURLOPT_FAILONERROR, 0);
+	curl_easy_setopt(freq->slot->curl, CURLOPT_FAILONERROR, 0L);
 	curl_easy_setopt(freq->slot->curl, CURLOPT_WRITEFUNCTION, fwrite_sha1_file);
 	curl_easy_setopt(freq->slot->curl, CURLOPT_ERRORBUFFER, freq->errorstr);
 	curl_easy_setopt(freq->slot->curl, CURLOPT_URL, freq->url);

--- a/http.c
+++ b/http.c
@@ -1142,7 +1142,7 @@ static CURL *get_curl_handle(void)
 	}
 
 	curl_easy_setopt(result, CURLOPT_MAXREDIRS, 20L);
-	curl_easy_setopt(result, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+	curl_easy_setopt(result, CURLOPT_POSTREDIR, (long)CURL_REDIR_POST_ALL);
 
 #ifdef GIT_CURL_HAVE_CURLOPT_PROTOCOLS_STR
 	{
@@ -1217,18 +1217,18 @@ static CURL *get_curl_handle(void)
 
 		if (starts_with(curl_http_proxy, "socks5h"))
 			curl_easy_setopt(result,
-				CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
+				CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS5_HOSTNAME);
 		else if (starts_with(curl_http_proxy, "socks5"))
 			curl_easy_setopt(result,
-				CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+				CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS5);
 		else if (starts_with(curl_http_proxy, "socks4a"))
 			curl_easy_setopt(result,
-				CURLOPT_PROXYTYPE, CURLPROXY_SOCKS4A);
+				CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS4A);
 		else if (starts_with(curl_http_proxy, "socks"))
 			curl_easy_setopt(result,
-				CURLOPT_PROXYTYPE, CURLPROXY_SOCKS4);
+				CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS4);
 		else if (starts_with(curl_http_proxy, "https")) {
-			curl_easy_setopt(result, CURLOPT_PROXYTYPE, CURLPROXY_HTTPS);
+			curl_easy_setopt(result, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTPS);
 
 			if (http_proxy_ssl_cert)
 				curl_easy_setopt(result, CURLOPT_PROXY_SSLCERT, http_proxy_ssl_cert);

--- a/imap-send.c
+++ b/imap-send.c
@@ -1418,7 +1418,7 @@ static CURL *setup_curl(struct imap_server_conf *srvc, struct credential *cred)
 
 	curl_easy_setopt(curl, CURLOPT_URL, path.buf);
 	strbuf_release(&path);
-	curl_easy_setopt(curl, CURLOPT_PORT, srvc->port);
+	curl_easy_setopt(curl, CURLOPT_PORT, (long)srvc->port);
 
 	if (srvc->auth_method) {
 		struct strbuf auth = STRBUF_INIT;
@@ -1431,8 +1431,8 @@ static CURL *setup_curl(struct imap_server_conf *srvc, struct credential *cred)
 	if (!srvc->use_ssl)
 		curl_easy_setopt(curl, CURLOPT_USE_SSL, (long)CURLUSESSL_TRY);
 
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, srvc->ssl_verify);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, srvc->ssl_verify);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (long)srvc->ssl_verify);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, (long)srvc->ssl_verify);
 
 	curl_easy_setopt(curl, CURLOPT_READFUNCTION, fread_buffer);
 

--- a/remote-curl.c
+++ b/remote-curl.c
@@ -971,8 +971,8 @@ retry:
 
 	slot = get_active_slot();
 
-	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0);
-	curl_easy_setopt(slot->curl, CURLOPT_POST, 1);
+	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0L);
+	curl_easy_setopt(slot->curl, CURLOPT_POST, 1L);
 	curl_easy_setopt(slot->curl, CURLOPT_URL, rpc->service_url);
 	curl_easy_setopt(slot->curl, CURLOPT_ENCODING, "");
 
@@ -1059,7 +1059,7 @@ retry:
 	rpc_in_data.check_pktline = stateless_connect;
 	memset(&rpc_in_data.pktline_state, 0, sizeof(rpc_in_data.pktline_state));
 	curl_easy_setopt(slot->curl, CURLOPT_WRITEDATA, &rpc_in_data);
-	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 0);
+	curl_easy_setopt(slot->curl, CURLOPT_FAILONERROR, 0L);
 
 
 	rpc->any_written = 0;

--- a/remote-curl.c
+++ b/remote-curl.c
@@ -878,12 +878,12 @@ static int probe_rpc(struct rpc_state *rpc, struct slot_results *results)
 	headers = curl_slist_append(headers, rpc->hdr_content_type);
 	headers = curl_slist_append(headers, rpc->hdr_accept);
 
-	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0);
-	curl_easy_setopt(slot->curl, CURLOPT_POST, 1);
+	curl_easy_setopt(slot->curl, CURLOPT_NOBODY, 0L);
+	curl_easy_setopt(slot->curl, CURLOPT_POST, 1L);
 	curl_easy_setopt(slot->curl, CURLOPT_URL, rpc->service_url);
 	curl_easy_setopt(slot->curl, CURLOPT_ENCODING, NULL);
 	curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDS, "0000");
-	curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE, 4);
+	curl_easy_setopt(slot->curl, CURLOPT_POSTFIELDSIZE, 4L);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(slot->curl, CURLOPT_WRITEFUNCTION, fwrite_buffer);
 	curl_easy_setopt(slot->curl, CURLOPT_WRITEDATA, &buf);


### PR DESCRIPTION
The `osx-gcc` job fails with compiler errors due to the now-stricter type checks in the `curl_easy_setopt()` calls. There is an upstream contribution already to fix this in Git's own main branch, but those patches to not apply cleanly on top of `vfs-2.49.0`, therefore I backported them.

<details><summary>Range-diff</summary>



* 1:  6f11c42e8edc ! 1:  3b1e099f145f curl: fix integer constant typechecks with curl_easy_setopt()

   ``````diff
   @@ Commit message
    
        We can fix it by just marking the constants with a long "L".
    
   +    Backported-from: 6f11c42e8edc (curl: fix integer constant typechecks with curl_easy_setopt(), 2025-06-04)
        Signed-off-by: Jeff King <peff@peff.net>
        Signed-off-by: Junio C Hamano <gitster@pobox.com>
   +    Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    
     ## http-push.c ##
    @@ http-push.c: static char *xml_entities(const char *s)
   @@ http-push.c: static char *xml_entities(const char *s)
     	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite_null);
    
     ## http.c ##
   +@@ http.c: static int has_proxy_cert_password(void)
   + 
   + static void set_curl_keepalive(CURL *c)
   + {
   +-	curl_easy_setopt(c, CURLOPT_TCP_KEEPALIVE, 1);
   ++	curl_easy_setopt(c, CURLOPT_TCP_KEEPALIVE, 1L);
   + }
   + 
   + /* Return 1 if redactions have been made, 0 otherwise. */
    @@ http.c: static CURL *get_curl_handle(void)
     		die("curl_easy_init failed");
     
   @@ http.c: static CURL *get_curl_handle(void)
     
     	if (curl_ssl_try)
     		curl_easy_setopt(result, CURLOPT_USE_SSL, CURLUSESSL_TRY);
   -@@ http.c: static CURL *get_curl_handle(void)
   - 	}
   - 	init_curl_proxy_auth(result);
   - 
   --	curl_easy_setopt(result, CURLOPT_TCP_KEEPALIVE, 1);
   -+	curl_easy_setopt(result, CURLOPT_TCP_KEEPALIVE, 1L);
   - 
   - 	if (curl_tcp_keepidle > -1)
   - 		curl_easy_setopt(result, CURLOPT_TCP_KEEPIDLE,
    
     ## remote-curl.c ##
    @@ remote-curl.c: static int probe_rpc(struct rpc_state *rpc, struct slot_results *results)
   ``````

* 2:  30325e23ba0d ! 2:  ecd7e78829ed curl: fix integer variable typechecks with curl_easy_setopt()

   ``````diff
   @@ Commit message
        going on obvious. There aren't that many spots to modify (and as you can
        see from the context, we already have some similar casts).
    
   +    Backported-from: 30325e23ba0d (curl: fix integer variable typechecks with curl_easy_setopt(), 2025-06-04)
        Signed-off-by: Jeff King <peff@peff.net>
        Signed-off-by: Junio C Hamano <gitster@pobox.com>
   +    Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    
     ## imap-send.c ##
    @@ imap-send.c: static CURL *setup_curl(struct imap_server_conf *srvc, struct credential *cred)
   ``````

* 3:  4558c8f84b2f ! 3:  a53e8f6437b6 curl: fix symbolic constant typechecks with curl_easy_setopt()

   ``````diff
   @@ Commit message
        dig, as it doesn't really matter: we have to follow what existing curl
        versions ask for anyway.
    
   +    Backported-from: 4558c8f84b2f (curl: fix symbolic constant typechecks with curl_easy_setopt(), 2025-06-04)
        Signed-off-by: Jeff King <peff@peff.net>
        Signed-off-by: Junio C Hamano <gitster@pobox.com>
   +    Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
    
     ## http.c ##
    @@ http.c: static CURL *get_curl_handle(void)
   - 
   - 	if (http_ssl_backend && !strcmp("schannel", http_ssl_backend) &&
   - 	    !http_schannel_check_revoke) {
   --		curl_easy_setopt(result, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
   -+		curl_easy_setopt(result, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NO_REVOKE);
   - 	}
   - 
   - 	if (http_proactive_auth != PROACTIVE_AUTH_NONE)
   -@@ http.c: static CURL *get_curl_handle(void)
     	}
     
     	curl_easy_setopt(result, CURLOPT_MAXREDIRS, 20L);
   ``````

* 4:  80de7491d24f = 4:  560fdc11aca2 curl: pass `long` values where expected
* -:  ------------ > 5:  718faf73d5e3 gvfs-helper: pass `long` values where expected

</details>

Obviously, we also needed to address some calls in `gvfs-helper`, which means that the tip commit of this PR branch is _not_ a backport.