### PR TITLE
ci(scalar): work around bug in `actions/setup-dotnet`

### DIFF
--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '3.1.426'
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
The bug that lets every single Scalar Functional Test run fail in the `macos` matrix job is actually https://github.com/dotnet/install-scripts/issues/610 and it seems that _somehow_ the logic to determine the latest version is broken with cURL v8.14.0.

Hard-coding the latest version seems to fix this.

Note: https://dotnet.microsoft.com/en-us/download/dotnet/3.1 says that v3.1.426 is the latest. This site also says that .NET Core 3.1 is out of support, and therefore it is unlikely that a different "latest" version is going to materialize, like, ever.