### PR TITLE
build-git-installers: integrate fixes that were required for v2.50.0.vfs.0.1

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -720,7 +720,7 @@ jobs:
           - os: ubuntu-latest
             artifact: linux-artifacts
             command: git
-          - os: macos-latest-xl-arm64
+          - os: macos-latest
             artifact: macos-artifacts
             command: git
           - os: macos-latest

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -381,7 +381,7 @@ jobs:
 
   # Build and sign Mac OSX installers & upload artifacts
   create-macos-artifacts:
-    runs-on: macos-latest-xl-arm64
+    runs-on: macos-latest
     needs: prereqs
     env:
       VERSION: "${{ needs.prereqs.outputs.tag_version }}"

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -65,7 +65,7 @@ jobs:
             artifact: pkg-x86_64
             toolchain: x86_64
             mingwprefix: mingw64
-            runner: windows-2019
+            runner: windows-2022
           - name: aarch64
             artifact: pkg-aarch64
             toolchain: clang-aarch64
@@ -192,7 +192,7 @@ jobs:
             artifact: pkg-x86_64
             toolchain: x86_64
             mingwprefix: mingw64
-            runner: windows-2019
+            runner: windows-2022
           - name: aarch64
             artifact: pkg-aarch64
             toolchain: clang-aarch64

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2019, macos-13, ubuntu-22.04]
+        os: [windows-2022, macos-13, ubuntu-22.04]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...


### PR DESCRIPTION
While working on the pre-release, several things failed:

- The macOS pool we used seems to have gone (or at least jobs aren't picked up even waiting 4 hours).
- The `windows-2019` pool was retired.
- The connection to the Ubuntu `apt-get` servers is flaky and sometimes times out or is super slow.

I could not do anything about the third problem (except exercising my patience), but the first two I could fix and this PR integrates the patches into the `vfs-2.50.0` branch.