### PR TITLE
Run CodeQL workflow every week

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1' # Every Monday at 03:00 UTC
 
 jobs:
   analyze:


### PR DESCRIPTION
Run the CodeQL GitHub workflow every week, on Mondays at 03:00 UTC. It's good practice to run this regularly as queries are updated.