### PR TITLE
Align better with upstreamed fixes for `clar`

### DIFF
--- a/t/unit-tests/clar/clar.c
+++ b/t/unit-tests/clar/clar.c
@@ -79,6 +79,8 @@
 #	else
 #		define p_snprintf snprintf
 #	endif
+
+#	define localtime_r(timer, buf) (localtime_s(buf, timer) == 0 ? buf : NULL)
 #else
 #	include <sys/wait.h> /* waitpid(2) */
 #	include <unistd.h>

--- a/t/unit-tests/clar/clar/summary.h
+++ b/t/unit-tests/clar/clar/summary.h
@@ -19,15 +19,6 @@ static int clar_summary_testsuites(struct clar_summary *summary)
 	return fprintf(summary->fp, "<testsuites>\n");
 }
 
-#ifdef _WIN32
-static struct tm *localtime_r(const time_t *timep, struct tm *result)
-{
-	if (localtime_s(result, timep) == 0)
-		return result;
-	return NULL;
-}
-#endif
-
 static int clar_summary_testsuite(struct clar_summary *summary,
     int idn, const char *name, time_t timestamp,
     int test_count, int fail_count, int error_count)


### PR DESCRIPTION
When upstreaming this patch to clar, the missing `localtime_r` symbol was addressed in a different way. For details, see https://github.com/clar-test/clar/pull/115/commits/ca0b519a. Let's use that version instead.