### PR TITLE
Do re-download corrupt objects with GVFS

### DIFF
--- a/commit.c
+++ b/commit.c
@@ -566,9 +566,14 @@ int repo_parse_commit_internal(struct repository *r,
 	int flags = OBJECT_INFO_LOOKUP_REPLACE | OBJECT_INFO_SKIP_FETCH_OBJECT |
 		    OBJECT_INFO_DIE_IF_CORRUPT;
 
-	/* But the GVFS Protocol _does_ support missing commits! */
+	/*
+	 * But the GVFS Protocol _does_ support missing commits!
+	 * And the idea with VFS for Git is to re-download corrupted objects,
+	 * not to fail!
+	 */
 	if (gvfs_config_is_set(GVFS_MISSING_OK))
-		flags ^= OBJECT_INFO_SKIP_FETCH_OBJECT;
+		flags &= ~(OBJECT_INFO_SKIP_FETCH_OBJECT |
+			   OBJECT_INFO_DIE_IF_CORRUPT);
 
 	if (!item)
 		return -1;

--- a/object-store.c
+++ b/object-store.c
@@ -7,6 +7,7 @@
 #include "dir.h"
 #include "environment.h"
 #include "gettext.h"
+#include "gvfs.h"
 #include "gvfs-helper-client.h"
 #include "hex.h"
 #include "hook.h"
@@ -1106,6 +1107,9 @@ void *repo_read_object_file(struct repository *r,
 	struct object_info oi = OBJECT_INFO_INIT;
 	unsigned flags = OBJECT_INFO_DIE_IF_CORRUPT | OBJECT_INFO_LOOKUP_REPLACE;
 	void *data;
+
+	if (gvfs_config_is_set(GVFS_MISSING_OK))
+		flags &= ~OBJECT_INFO_DIE_IF_CORRUPT;
 
 	oi.typep = type;
 	oi.sizep = size;

--- a/object-store.c
+++ b/object-store.c
@@ -707,6 +707,9 @@ int read_object_process(const struct object_id *oid)
 	const char *cmd = find_hook(the_repository, "read-object");
 	uint64_t start;
 
+	if (!cmd)
+		die(_("could not find the `read-object` hook"));
+
 	start = getnanotime();
 
 	trace2_region_enter("subprocess", "read_object", the_repository);


### PR DESCRIPTION
As of 9e59b38c88c, Git will loudly complain about corrupt objects.

That is fine, as long as the idea isn't to re-download locally-corrupted objects. But that's exactly what we want to do in VFS for Git. This is even tested for in the functional tests of VFS for Git, which has been identified as a regression in https://github.com/microsoft/VFSForGit/pull/1853.
