### PR TITLE
vfs-2.50.1: codeql: run static analysis as part of CI builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1' # Every Monday at 03:00 UTC
 
 jobs:
   analyze:


### PR DESCRIPTION
I had forgotten to integrate https://github.com/microsoft/git/pull/772 into the `vfs-2.50.1` branch... sorry!