### PR TITLE
Set updated_skipworktree on restore --staged

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -370,7 +370,13 @@ static void mark_ce_for_checkout_no_overlay(struct cache_entry *ce,
 					    const struct checkout_opts *opts)
 {
 	ce->ce_flags &= ~CE_MATCHED;
-	if (!opts->ignore_skipworktree && ce_skip_worktree(ce))
+	if (!opts->ignore_skipworktree && 
+		/* `restore --staged` after `cherry-pick -n` or `reset --soft` 
+		 * may have new files added to the index but with skip_worktree
+		 * set if using virtual file system
+		 */ 
+		!(core_virtualfilesystem && opts->checkout_index) 
+		&& ce_skip_worktree(ce))
 		return;
 	if (ce_path_match(the_repository->index, ce, &opts->pathspec, ps_matched)) {
 		ce->ce_flags |= CE_MATCHED;
@@ -641,10 +647,19 @@ static int checkout_paths(const struct checkout_opts *opts,
 		checkout_index = opts->checkout_index;
 
 	if (checkout_index) {
-		/* Some scenarios may update skipworktree bits, such as 
-		 * `restore --staged` after `cherry-pick -n` or `reset --soft`
-		 */
-		the_repository->index->updated_skipworktree = 1;
+		if (opts->checkout_index && core_virtualfilesystem) {
+			/* Some `restore --staged` scenarios may update
+			* skipworktree bits, such as after `cherry-pick -n` or
+			* `reset --soft`
+			*/
+			the_repository->index->updated_skipworktree = 1;
+			/* In same scenarios, if there were files added during
+			 * the previous operation they may not have been added
+			 * to the projection when added to the worktree, but
+			 * they need to be added now.
+			 */ 
+			the_repository->index->updated_workdir = 1;
+		}
 		if (write_locked_index(the_repository->index, &lock_file, COMMIT_LOCK))
 			die(_("unable to write new index file"));
 	} else {

--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -641,6 +641,10 @@ static int checkout_paths(const struct checkout_opts *opts,
 		checkout_index = opts->checkout_index;
 
 	if (checkout_index) {
+		/* Some scenarios may update skipworktree bits, such as 
+		 * `restore --staged` after `cherry-pick -n` or `reset --soft`
+		 */
+		the_repository->index->updated_skipworktree = 1;
 		if (write_locked_index(the_repository->index, &lock_file, COMMIT_LOCK))
 			die(_("unable to write new index file"));
 	} else {


### PR DESCRIPTION
This is a fix for https://github.com/microsoft/VFSForGit/issues/1855

When `git restore --staged` is run in certain situations, such as after `git cherry-pick -n` or `git reset --soft`, git may change the SKIP_WORKTREE bits for some entries from TRUE to FALSE. `index->updated_skipworktree` needs to be set in this scenario so that when VFSForGit is notified about the index update it can invalidate its cache.