### PR TITLE
Revert "wt-status: add VFS hydration percentage to normal `git status…

### DIFF
--- a/t/t1093-virtualfilesystem.sh
+++ b/t/t1093-virtualfilesystem.sh
@@ -69,8 +69,6 @@ test_expect_success 'verify status is clean' '
 	git status > actual &&
 	cat > expected <<-\EOF &&
 		On branch main
-		You are in a partially-hydrated checkout with 75% of tracked files present.
-
 		nothing to commit, working tree clean
 	EOF
 	test_cmp expected actual

--- a/wt-status.c
+++ b/wt-status.c
@@ -1625,15 +1625,10 @@ static void show_sparse_checkout_in_use(struct wt_status *s,
 {
 	if (s->state.sparse_checkout_percentage == SPARSE_CHECKOUT_DISABLED)
 		return;
-	if (core_virtualfilesystem) {
-		if (s->state.sparse_checkout_percentage == SPARSE_CHECKOUT_SPARSE_INDEX)
-			status_printf_ln(s, color,
-					 _("You are in a partially-hydrated checkout with a sparse index."));
-		else
-			status_printf_ln(s, color,
-					 _("You are in a partially-hydrated checkout with %d%% of tracked files present."),
-					 s->state.sparse_checkout_percentage);
-	} else if (s->state.sparse_checkout_percentage == SPARSE_CHECKOUT_SPARSE_INDEX)
+	if (core_virtualfilesystem)
+		return;
+
+	if (s->state.sparse_checkout_percentage == SPARSE_CHECKOUT_SPARSE_INDEX)
 		status_printf_ln(s, color, _("You are in a sparse checkout."));
 	else
 		status_printf_ln(s, color,


### PR DESCRIPTION
…` output"

This reverts commit 77a05c8b68704d2e111c819eba4ce22384b40497.

The core.virtualfilesystem hook only reports the _modified_ files, not the hydrated files, so this message is inaccurate and misleading.

* [x ] This change only applies to the virtualization hook and VFS for Git.
