### PR TITLE
release-winget/release-homebrew: surface the opened PR's URL more prominently

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -40,7 +40,7 @@ jobs:
         sed s/^/result=/ <token >>$GITHUB_OUTPUT &&
         rm token
     - name: Update scalar Cask
-      uses: mjcheetham/update-homebrew@v1.4
+      uses: mjcheetham/update-homebrew@v1.5
       with:
         token: ${{ steps.token.outputs.result }}
         tap: microsoft/git

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -78,5 +78,6 @@ jobs:
 
           # Submit the manifest to the winget-pkgs repository
           $manifestDirectory = "$PWD\manifests\m\Microsoft\Git\$version"
+          Write-Host -NoNewLine "::notice::Submitting ${env:TAG_NAME} to winget... "
           .\wingetcreate.exe submit -t "$(Get-Content token.txt)" $manifestDirectory
         shell: powershell


### PR DESCRIPTION
By prefixing the line with `::notice::`, the result will not only be printed in the (not very long retained) job logs, but also on the summary page of the workflow run.