### PR TITLE
hooks: skip post-command hook more often

### DIFF
--- a/t/t0401-post-command-hook.sh
+++ b/t/t0401-post-command-hook.sh
@@ -78,12 +78,42 @@ test_expect_success 'with post-index-change config' '
 	test_cmp expect post-index-change.out &&
 	test_path_is_missing post-command.out &&
 
+	# add keeps the worktree the same, so does not run post-command.
+	# and this should work through an alias.
+	git config alias.addalias add &&
+	rm -f post-command.out post-index-change.out &&
+	echo more stuff >>file &&
+	git addalias file &&
+	test_cmp expect post-index-change.out &&
+
+	# TODO: This is the opposite of what we want! We want this to
+	# be missing, but the current state has this happening in this
+	# way.
+	test_path_exists post-command.out &&
+
 	echo stuff >>file &&
 	# reset --hard updates the worktree.
+	# even through an alias
+	git config alias.resetalias "reset --hard" &&
 	rm -f post-command.out post-index-change.out &&
-	git reset --hard &&
+	git resetalias &&
 	test_cmp expect post-index-change.out &&
-	test_cmp expect post-command.out
+	test_cmp expect post-command.out &&
+
+	# TODO: We want to skip the post-command hook here!
+	rm -f post-command.out &&
+	test_must_fail git && # get help text
+	test_path_exists post-command.out &&
+
+	# TODO: We want to skip the post-command hook here!
+	rm -f post-command.out &&
+	git version &&
+	test_path_exists post-command.out &&
+
+	# TODO: We want to skip the post-command hook here!
+	rm -f post-command.out &&
+	test_must_fail git typo &&
+	test_path_exists post-command.out
 '
 
 test_done

--- a/t/t0401-post-command-hook.sh
+++ b/t/t0401-post-command-hook.sh
@@ -85,11 +85,7 @@ test_expect_success 'with post-index-change config' '
 	echo more stuff >>file &&
 	git addalias file &&
 	test_cmp expect post-index-change.out &&
-
-	# TODO: This is the opposite of what we want! We want this to
-	# be missing, but the current state has this happening in this
-	# way.
-	test_path_exists post-command.out &&
+	test_path_is_missing post-command.out &&
 
 	echo stuff >>file &&
 	# reset --hard updates the worktree.
@@ -100,20 +96,17 @@ test_expect_success 'with post-index-change config' '
 	test_cmp expect post-index-change.out &&
 	test_cmp expect post-command.out &&
 
-	# TODO: We want to skip the post-command hook here!
 	rm -f post-command.out &&
 	test_must_fail git && # get help text
-	test_path_exists post-command.out &&
+	test_path_is_missing post-command.out &&
 
-	# TODO: We want to skip the post-command hook here!
 	rm -f post-command.out &&
 	git version &&
-	test_path_exists post-command.out &&
+	test_path_is_missing post-command.out &&
 
-	# TODO: We want to skip the post-command hook here!
 	rm -f post-command.out &&
 	test_must_fail git typo &&
-	test_path_exists post-command.out
+	test_path_is_missing post-command.out
 '
 
 test_done


### PR DESCRIPTION
The postCommand.strategy=worktree-change config option allows for skipping the post-command hook when the Git command doesn't change the worktree. However, sometimes this config isn't loaded before the post-command hook is invoked, causing the hook to run in cases where we'd prefer it to not run.

Examples include: `git version` or `git <typo>`.

The tricky bit is that there are several places where we get here and standard config mechanisms can't load due to not having a `gitdir` in the repository struct. We fix this by:

1. Using the "load early config" mechanism also used by `core.hooksPath`.
2. Skipping the lookup for the sentinel file when there isn't a `gitdir` since we couldn't have written one without it.

The change is given in two commits: the first expands the tests with the existing behavior and the second changes the behavior, showing the impact on those tests.

* [X] This change only applies to microsoft/git specifics (post-command hook)

See #736 and #748 for prior art in this space.
