### PR TITLE
build-git-installers: sign .deb files with a stronger algorithm

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -690,6 +690,15 @@ jobs:
           # Install debsigs
           sudo apt-get install -y debsigs
 
+          # Stop using SHA-1 for the signature. For details, see
+          # https://gitlab.com/debsigs/debsigs/-/commit/75c6c8f96e6cdc33bca9c5f32195b68ff35bc32f
+          # which seems to have made it to have made it into debsigs v0.2.1, but Ubuntu 24.04 is
+          # stuck with v1.19.
+          mkdir -p patched-debsigs &&
+          sed 's/, "--openpgp"//' </usr/bin/debsigs >patched-debsigs/debsigs &&
+          chmod a+x patched-debsigs/debsigs &&
+          echo "$PWD/patched-debsigs" >>$GITHUB_PATH
+
           # Import GPG key
           echo -n '${{ steps.gpg-secrets.outputs.private-key }}' | gpg --import --no-tty --batch --yes
 


### PR DESCRIPTION
It has been reported in https://github.com/microsoft/git/issues/706 that the `.deb` files of Microsoft Git's releases cannot be validated with `debsig-verify`. A deeper investigation brought to light that the reason is a weak digest algorithm: `debsigs` calls `gpg --opengpg` which uses SHA-1, but `debsig-verify` rejects such weak signatures.

This was actually already fixed in `debsigs`, but current Ubuntu versions will not get those fixes, being stuck with older `debsigs` versions.

It's easy enough to work around, though, by manually retracing the `debsigs` patch, so let's do that.