### PR TITLE
Really mention the winget and homebrew PR URLs in the respective workflow runs' summary

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -40,7 +40,7 @@ jobs:
         sed s/^/result=/ <token >>$GITHUB_OUTPUT &&
         rm token
     - name: Update scalar Cask
-      uses: mjcheetham/update-homebrew@v1.5
+      uses: mjcheetham/update-homebrew@v1.5.1
       with:
         token: ${{ steps.token.outputs.result }}
         tap: microsoft/git

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -78,6 +78,8 @@ jobs:
 
           # Submit the manifest to the winget-pkgs repository
           $manifestDirectory = "$PWD\manifests\m\Microsoft\Git\$version"
-          Write-Host -NoNewLine "::notice::Submitting ${env:TAG_NAME} to winget... "
-          .\wingetcreate.exe submit -t "$(Get-Content token.txt)" $manifestDirectory
+          $output = & .\wingetcreate.exe submit -t "$(Get-Content token.txt)" $manifestDirectory
+          Write-Host $output
+          $url = ($output | Select-String -Pattern 'https://\S+' | ForEach-Object { $_.Matches.Value })[0]
+          Write-Host "::notice::Submitted ${env:TAG_NAME} to winget as $url"
         shell: powershell


### PR DESCRIPTION
I had already tried to achieve the same in #807, but neither winget nor homebrew patch worked as intended. This here PR hopefully fixes that (we will see in the v2.52.0 release...).