### PR TITLE
Fix infinite loop in packfile MRU after prefetch packs are added

### DIFF
--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -216,7 +216,7 @@ static void gh_client__update_packed_git(const char *line)
 
 	p = add_packed_git(the_repository, path.buf, path.len, is_local);
 	if (p)
-		packfile_store_add_pack_also_to_mru(the_repository, p);
+		packfile_store_add_pack(the_repository->objects->packfiles, p);
 	strbuf_release(&path);
 }
 

--- a/packfile.c
+++ b/packfile.c
@@ -792,14 +792,6 @@ void packfile_store_add_pack(struct packfile_store *store,
 	hashmap_add(&store->map, &pack->packmap_ent);
 }
 
-void packfile_store_add_pack_also_to_mru(struct repository *r,
-					 struct packed_git *pack)
-{
-	packfile_store_add_pack(r->objects->packfiles, pack);
-	list_add(&pack->mru,
-		 packfile_store_get_packs_mru(r->objects->packfiles));
-}
-
 struct packed_git *packfile_store_load_pack(struct packfile_store *store,
 					    const char *idx_path, int local)
 {

--- a/packfile.h
+++ b/packfile.h
@@ -135,13 +135,6 @@ void packfile_store_reprepare(struct packfile_store *store);
  */
 void packfile_store_add_pack(struct packfile_store *store,
 			     struct packed_git *pack);
-/*
- * Add the pack to the store so that contained objects become accessible via
- * the store, and then mark it as most recently used. This moves ownership into
- * the store.
- */
-void packfile_store_add_pack_also_to_mru(struct repository *r,
-					 struct packed_git *pack);
 
 /*
  * Load and iterate through all packs of the given repository. This helper


### PR DESCRIPTION
This fixup updates b46ad0ac29 (gvfs-helper: create tool to fetch objects using the GVFS Protocol, 2019-08-13) in reaction to f6f236d926 (packfile: refactor `install_packed_git()` to work on packfile store, 2025-09-23) which is included in Git 2.52.0.

This PR is organized to fixup the commit mentioned above and to drop 4e743e6e6c (packfile: add install_packed_git_and_mru(), 2019-09-25) now that the packfile method is no longer used.

The refactored packfile store includes an automatic inclusion of new packifles into the MRU list. This introduces a bug in microsoft/git's use of the GVFS protocol in the following scenario in 'git fetch':

 1. If the prefetch downloads at least one prefetch packfile, then it is added to the MRU list twice, creating an infinite loop.

 2. If the refs that are updated include commits that are not present in the packfile list, then the MRU lookup will iterate through without interruption, hitting the infinite loop.

The fix is to modify this patch to no longer include a custom "add to MRU" method now that the default implementation does this for us.

* [X] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.