### PR TITLE
Fix regression from batch object downloads

### DIFF
--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -192,35 +192,6 @@ static void gh_client__update_loose_cache(const char *line)
 }
 
 /*
- * Update the packed-git list to include the newly created packfile.
- */
-static void gh_client__update_packed_git(const char *line)
-{
-	struct strbuf path = STRBUF_INIT;
-	const char *v1_filename;
-	struct packed_git *p;
-	int is_local;
-
-	if (!skip_prefix(line, "packfile ", &v1_filename))
-		BUG("update_packed_git: invalid line '%s'", line);
-
-	/*
-	 * ODB[0] is the local .git/objects.  All others are alternates.
-	 */
-	is_local = (gh_client__chosen_odb == the_repository->objects->sources);
-
-	strbuf_addf(&path, "%s/pack/%s",
-		    gh_client__chosen_odb->path, v1_filename);
-	strbuf_strip_suffix(&path, ".pack");
-	strbuf_addstr(&path, ".idx");
-
-	p = add_packed_git(the_repository, path.buf, path.len, is_local);
-	if (p)
-		packfile_store_add_pack(the_repository->objects->packfiles, p);
-	strbuf_release(&path);
-}
-
-/*
  * CAP_OBJECTS verbs return the same format response:
  *
  *    <odb>

--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -250,7 +250,6 @@ static int gh_client__objects__receive_response(
 		}
 
 		else if (starts_with(line, "packfile")) {
-			gh_client__update_packed_git(line);
 			ghc |= GHC__CREATED__PACKFILE;
 			nr_packfile++;
 		}
@@ -270,6 +269,9 @@ static int gh_client__objects__receive_response(
 			err = -1;
 		}
 	}
+
+	if (ghc & GHC__CREATED__PACKFILE)
+		packfile_store_reprepare(the_repository->objects->packfiles);
 
 	*p_ghc = ghc;
 	*p_nr_loose = nr_loose;


### PR DESCRIPTION
This is a fix for a performance regression introduced by #822. That change updated the packfile installation process to call a different packfile installation method after some upstream changes to the packfile data structures.

However, while I thought I read the new packfile methods as including a modification of the MRU cache, it apparently does not fully install the packfile in the list.

This manifests in something like `git checkout` where the missing blobs are queued for download, downloaded in blob packfiles, and then the checkout process continues. During the process of writing the data to the worktree, the "updating files" progress indicator slows to a crawl because it was "missing" the blobs and then downloaded them on-demand.

This fixes the issue by being less fancy about packfiles and using `packfile_store_reprepare()` to just reset the full packfile list. This is more future-proof and isn't very expensive compared to the packfile download.

I augmented a test to include tracing that shows a necessary blob is queued for packfile download and is not later downloaded via an immediate request. Without the code change, that test would fail.

* [X] This change only applies to interactions with Azure DevOps and the GVFS Protocol.
