### PR TITLE
GitHub CI: macos-13 images are no more

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,16 +313,16 @@ jobs:
         vector:
           - jobname: osx-clang
             cc: clang
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-reftable
             cc: clang
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-gcc
             cc: gcc-13
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-meson
             cc: clang
-            pool: macos-13
+            pool: macos-14
     env:
       CC: ${{matrix.vector.cc}}
       CC_PACKAGE: ${{matrix.vector.cc_package}}


### PR DESCRIPTION
As this image was dropped on Dec 4th, replace these jobs to use a newer macos pool instead.

This backports the fix Junio made in upstream Git.