### PR TITLE
ci: use a newer macOS pool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,16 +313,16 @@ jobs:
         vector:
           - jobname: osx-clang
             cc: clang
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-reftable
             cc: clang
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-gcc
             cc: gcc-13
-            pool: macos-13
+            pool: macos-14
           - jobname: osx-meson
             cc: clang
-            pool: macos-13
+            pool: macos-14
     env:
       CC: ${{matrix.vector.cc}}
       CC_PACKAGE: ${{matrix.vector.cc_package}}

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Order by runtime (in descending order)
-        os: [windows-2022, macos-13, ubuntu-22.04]
+        os: [windows-2022, macos-15, ubuntu-22.04]
         # Scalar.NET used to be tested using `features: [false, experimental]`
         # But currently, Scalar/C ignores `feature.scalar` altogether, so let's
         # save some electrons and run only one of them...
@@ -99,7 +99,7 @@ jobs:
             ;;
           macOS)
             SUDO=sudo
-            extra=prefix=/usr/local
+            extra=prefix=/opt/homebrew
             ;;
           esac
 
@@ -123,10 +123,23 @@ jobs:
           repository: ${{ env.SCALAR_REPOSITORY }}
           ref: ${{ env.SCALAR_REF }}
 
-      - name: Setup .NET Core
+      - name: Target .NET 9
+        shell: bash
+        run:
+          csproj=scalar/Scalar.FunctionalTests/Scalar.FunctionalTests.csproj &&
+          sed 's/netcoreapp3\.1/net9.0/g' <$csproj >$csproj.new &&
+          mv $csproj.new $csproj &&
+
+          echo "BUILD_FRAGMENT=bin/Release/net9.0" >>$GITHUB_ENV &&
+
+          props=scalar/Directory.Build.props &&
+          sed 's/\(<RuntimeIdentifiers>\)[^<]*/\1osx-arm64/' <$props >$props.new &&
+          mv $props.new $props
+
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '3.1.426'
+          dotnet-version: '9.0.306'
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
The macos-13 pool is no longer available, as of December 2nd, 2025.

This PR contains backports of the fixes that already made it to the `vfs-2.52.0` branch.