### PR TITLE
build-git-installers: integrate fix from v2.52.0.vfs.0.2

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -350,9 +350,9 @@ jobs:
           eval $b/please.sh make_installers_from_mingw_w64_git --include-pdbs \
               --version=${{ needs.prereqs.outputs.tag_version }} \
               -o artifacts --${{matrix.type.name}} \
-              --pkg=${{matrix.arch.artifact}}/mingw-w64-${{matrix.arch.toolchain}}-git-[0-9]*.tar.xz \
-              --pkg=${{matrix.arch.artifact}}/mingw-w64-${{matrix.arch.toolchain}}-git-doc-html-[0-9]*.tar.xz &&
-
+              $(ls ${{matrix.arch.artifact}}/mingw-w64-${{matrix.arch.toolchain}}-*.tar.* |
+                sed '/\.sig$/d;/archimport/d;/cvs/d;/p4/d;/gitweb/d;/doc-man/d;s/^/--pkg=/' |
+                tr '\n' ' ') &&
           if test portable = '${{matrix.type.name}}' && test -n "$(git config alias.signtool)"
           then
             git signtool artifacts/PortableGit-*.exe


### PR DESCRIPTION
This was required to build v2.52.0.vfs.0.2

In https://github.com/git-for-windows/MINGW-packages/pull/172, the `mingw-w64-git` package was split into multiple packages, with the new primary package as Git for Windows is concerned being the `mingw-w64-git-for-windows-addons` one.

Accommodate for that change by simply adding (almost) all of the packages that were built to the command-line via `--pkg` options, instead of hardcoding the `mingw-w64-git` and `mingw-w64-git-doc-html` one.