### PR TITLE
Add `--ref-format` option to scalar clone (port to `vfs-2.52.0`)

### DIFF
--- a/scalar.c
+++ b/scalar.c
@@ -88,19 +88,9 @@ static void setup_enlistment_directory(int argc, const char **argv,
 
 static int git_retries = 3;
 
-LAST_ARG_MUST_BE_NULL
-static int run_git(const char *arg, ...)
+static int run_git_argv(const struct strvec *argv)
 {
-	va_list args;
-	const char *p;
-	struct strvec argv = STRVEC_INIT;
 	int res = 0, attempts;
-
-	va_start(args, arg);
-	strvec_push(&argv, arg);
-	while ((p = va_arg(args, const char *)))
-		strvec_push(&argv, p);
-	va_end(args);
 
 	for (attempts = 0, res = 1;
 	     res && attempts < git_retries;
@@ -108,9 +98,28 @@ static int run_git(const char *arg, ...)
 		struct child_process cmd = CHILD_PROCESS_INIT;
 
 		cmd.git_cmd = 1;
-		strvec_pushv(&cmd.args, argv.v);
+		strvec_pushv(&cmd.args, argv->v);
 		res = run_command(&cmd);
 	}
+
+	return res;
+}
+
+LAST_ARG_MUST_BE_NULL
+static int run_git(const char *arg, ...)
+{
+	va_list args;
+	const char *p;
+	struct strvec argv = STRVEC_INIT;
+	int res;
+
+	va_start(args, arg);
+	strvec_push(&argv, arg);
+	while ((p = va_arg(args, const char *)))
+		strvec_push(&argv, p);
+	va_end(args);
+
+	res = run_git_argv(&argv);
 
 	strvec_clear(&argv);
 	return res;

--- a/scalar.c
+++ b/scalar.c
@@ -774,6 +774,7 @@ static int cmd_clone(int argc, const char **argv)
 	const char *cache_server_url = NULL, *local_cache_root = NULL;
 	char *default_cache_server_url = NULL, *local_cache_root_abs = NULL;
 	int gvfs_protocol = -1;
+	const char *ref_format = NULL;
 
 	struct option clone_options[] = {
 		OPT_STRING('b', "branch", &branch, N_("<branch>"),
@@ -797,18 +798,22 @@ static int cmd_clone(int argc, const char **argv)
 		OPT_STRING(0, "local-cache-path", &local_cache_root,
 			   N_("<path>"),
 			   N_("override the path for the local Scalar cache")),
+		OPT_STRING(0, "ref-format", &ref_format, N_("format"),
+			   N_("specify the reference format to use")),
 		OPT_HIDDEN_BOOL(0, "no-fetch-commits-and-trees",
 				&dummy, N_("no longer used")),
 		OPT_END(),
 	};
 	const char * const clone_usage[] = {
 		N_("scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]\n"
-		   "\t[--[no-]src] [--[no-]tags] [--[no-]maintenance] <url> [<enlistment>]"),
+		   "\t[--[no-]src] [--[no-]tags] [--[no-]maintenance] [--ref-format <format>]\n"
+		   "\t<url> [<enlistment>]"),
 		NULL
 	};
 	const char *url;
 	char *enlistment = NULL, *dir = NULL;
 	struct strbuf buf = STRBUF_INIT;
+	struct strvec init_argv = STRVEC_INIT;
 	int res;
 
 	argc = parse_options(argc, argv, NULL, clone_options, clone_usage, 0);
@@ -856,16 +861,26 @@ static int cmd_clone(int argc, const char **argv)
 	if (!local_cache_root)
 		die(_("could not determine local cache root"));
 
-	strbuf_reset(&buf);
+	strvec_clear(&init_argv);
+	strvec_pushf(&init_argv, "-c");
 	if (branch)
-		strbuf_addf(&buf, "init.defaultBranch=%s", branch);
+		strvec_pushf(&init_argv, "init.defaultBranch=%s", branch);
 	else {
 		char *b = repo_default_branch_name(the_repository, 1);
-		strbuf_addf(&buf, "init.defaultBranch=%s", b);
+		strvec_pushf(&init_argv, "init.defaultBranch=%s", b);
 		free(b);
 	}
 
-	if ((res = run_git("-c", buf.buf, "init", "--", dir, NULL)))
+	strvec_push(&init_argv, "init");
+
+	if (ref_format) {
+		strvec_push(&init_argv, "--ref-format");
+		strvec_push(&init_argv, ref_format);
+	}
+
+	strvec_push(&init_argv, "--");
+	strvec_push(&init_argv, dir);
+	if ((res = run_git_argv(&init_argv)))
 		goto cleanup;
 
 	if (chdir(dir) < 0) {
@@ -1015,6 +1030,7 @@ cleanup:
 	free(enlistment);
 	free(dir);
 	strbuf_release(&buf);
+	strvec_clear(&init_argv);
 	free(default_cache_server_url);
 	free(local_cache_root_abs);
 	return res;

--- a/t/t9211-scalar-clone.sh
+++ b/t/t9211-scalar-clone.sh
@@ -201,4 +201,34 @@ test_expect_success '`scalar clone --no-src`' '
 	test_cmp with without
 '
 
+test_expect_success '`scalar clone --ref-format`' '
+	scalar clone "file://$(pwd)/to-clone" refs-default &&
+	scalar clone --ref-format files "file://$(pwd)/to-clone" refs-files &&
+	scalar clone --ref-format reftable "file://$(pwd)/to-clone" refs-reftable &&
+
+	test_path_is_dir refs-default/src &&
+	test_path_is_dir refs-files/src &&
+	test_path_is_dir refs-reftable/src &&
+
+	(
+		cd refs-default/src &&
+		case test_detect_ref_format in
+		files)
+			test_must_fail git config --local extensions.refstorage
+			;;
+		reftable)
+			test_cmp_config reftable extensions.refstorage
+			;;
+		esac
+	) &&
+	(
+		cd refs-files/src &&
+		test_must_fail git config --local extensions.refstorage
+	) &&
+	(
+		cd refs-reftable/src &&
+		test_cmp_config reftable extensions.refstorage
+	)
+'
+
 test_done


### PR DESCRIPTION
Cherry picking the commits from https://github.com/microsoft/git/pull/829 to the `vfs-2.52.0` branch.