### PR TITLE
diff: avoid segfault with freed entries

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -7046,6 +7046,7 @@ static void diffcore_skip_stat_unmatch(struct diff_options *diffopt)
 			if (!diffopt->flags.no_index)
 				diffopt->skip_stat_unmatch++;
 			diff_free_filepair(p);
+			q->queue[i] = NULL;
 		}
 	}
 	free(q->queue);
@@ -7089,6 +7090,10 @@ void diff_queued_diff_prefetch(void *repository)
 
 	for (i = 0; i < q->nr; i++) {
 		struct diff_filepair *p = q->queue[i];
+
+		if (!p)
+			continue;
+
 		diff_add_if_missing(repo, &to_fetch, p->one);
 		diff_add_if_missing(repo, &to_fetch, p->two);
 	}


### PR DESCRIPTION
This is also going upstream as part of gitgitgadget/git#2027.

However, I found out about this segfault due to a reproducible error happening in the 1JS monorepo's PR build pipelines. After trying to uncover a repro by adding tracing to my own fork and using that version within the pipeline, I was finally able to get a reproducer in a 1JS Codespace. Debugging with a locally-build version of Git helped me find the situation to fix this.

1JS has a workaround for this issue by running `git status` before the necessary build step that runs the `git diff` command. That refresh of the index prevents the freed diff queue items, preventing the issue. This reduces the urgency somewhat, but I also don't know where else this could be impacting users.

* [X] This is an early version of work already under review upstream.

I'm recommending this version on top of the `vfs-2.52.0` branch so we can get this fixed more quickly for an upcoming release of microsoft/git.