### PR TITLE
ci: add ARM64 (aarch64) Linux release builds

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -558,9 +558,24 @@ jobs:
 
   # Build and sign Debian package
   create-linux-unsigned-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch.runner }}
+    strategy:
+      matrix:
+        arch:
+          - name: amd64
+            runner: ubuntu-latest
+            # EOL 04/2025: https://endoflife.date/ubuntu
+            container_image: ubuntu:20.04
+            # Use unofficial Node.js builds with glibc-217 for older Ubuntu
+            node_url: https://unofficial-builds.nodejs.org/download/release/v20.18.1/node-v20.18.1-linux-x64-glibc-217.tar.gz
+          - name: arm64
+            runner: ubuntu-24.04-arm
+            # EOL 04/2027: https://endoflife.date/ubuntu
+            container_image: ubuntu:22.04
+            # Use official Node.js builds for ARM64 (requires glibc 2.28+, Ubuntu 22.04 has 2.35)
+            node_url: https://nodejs.org/dist/v20.18.1/node-v20.18.1-linux-arm64.tar.gz
     container:
-      image: ubuntu:20.04 # security support until 04/02/2025, according to https://endoflife.date/ubuntu
+      image: ${{ matrix.arch.container_image }}
       volumes:
         # override /__e/node20 because GitHub Actions uses a version that requires too-recent glibc, see "Install dependencies" below
         - /tmp:/__e/node20
@@ -581,10 +596,8 @@ jobs:
             libcurl4-gnutls-dev libpcre2-dev zlib1g-dev libexpat-dev \
             curl ca-certificates
 
-          # Install a Node.js version that works in older Ubuntu containers (read: does not require very recent glibc)
-          NODE_VERSION=v20.18.1 &&
-          NODE_URL=https://unofficial-builds.nodejs.org/download/release/$NODE_VERSION/node-$NODE_VERSION-linux-x64-glibc-217.tar.gz &&
-          curl -Lo /tmp/node.tar.gz $NODE_URL &&
+          # Install Node.js for GitHub Actions compatibility
+          curl -Lo /tmp/node.tar.gz "${{ matrix.arch.node_url }}" &&
           tar -C /__e/node20 -x --strip-components=1 -f /tmp/node.tar.gz
 
       - name: Clone git
@@ -613,7 +626,7 @@ jobs:
             die "Could not determine host architecture!"
           fi
 
-          PKGNAME="microsoft-git_$VERSION"
+          PKGNAME="microsoft-git_${VERSION}_${ARCH}"
           PKGDIR="$(dirname $(pwd))/$PKGNAME"
 
           rm -rf "$PKGDIR"
@@ -654,13 +667,16 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-unsigned-artifacts
+          name: linux-unsigned-${{ matrix.arch.name }}
           path: |
             *.deb
 
   create-linux-artifacts:
     runs-on: ubuntu-latest
     needs: [prereqs, create-linux-unsigned-artifacts]
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     environment: release
     steps:
       - name: Log into Azure
@@ -710,18 +726,18 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: linux-unsigned-artifacts
+          name: linux-unsigned-${{ matrix.arch }}
 
       - name: Sign Debian package
         run: |
           # Sign Debian package
           version="${{ needs.prereqs.outputs.tag_version }}"
-          debsigs --sign=origin --verify --check microsoft-git_"$version".deb
+          debsigs --sign=origin --verify --check microsoft-git_"$version"_${{ matrix.arch }}.deb
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-artifacts
+          name: linux-${{ matrix.arch }}
           path: |
             *.deb
   # End build and sign Debian package
@@ -733,7 +749,10 @@ jobs:
       matrix:
         component:
           - os: ubuntu-latest
-            artifact: linux-artifacts
+            artifact: linux-amd64
+            command: git
+          - os: ubuntu-24.04-arm
+            artifact: linux-arm64
             command: git
           - os: macos-latest
             artifact: macos-artifacts
@@ -844,10 +863,16 @@ jobs:
           name: macos-artifacts
           path: macos-artifacts
 
-      - name: Download Debian package
+      - name: Download Debian package (amd64)
         uses: actions/download-artifact@v4
         with:
-          name: linux-artifacts
+          name: linux-amd64
+          path: deb-package
+
+      - name: Download Debian package (arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-arm64
           path: deb-package
 
       - name: Log into Azure


### PR DESCRIPTION
## Summary
- Add ARM64 (aarch64) Linux builds to the release workflow using `ubuntu-24.04-arm` runners
- Update package naming to include architecture (e.g., `microsoft-git_VERSION_arm64.deb`)
- Add ARM64 Linux validation step

## Details
ARM64 uses Ubuntu 22.04 container (not 20.04) because official Node.js ARM64 builds require glibc 2.28+.