### PR TITLE
gvfs-helper: move prefetch/since tracing to helper

### DIFF
--- a/gvfs-helper-client.c
+++ b/gvfs-helper-client.c
@@ -539,10 +539,9 @@ int gh_client__get_immediate(const struct object_id *oid,
  * Ask gvfs-helper to prefetch commits-and-trees packfiles since a
  * given timestamp.
  *
- * If seconds_since_epoch is zero, gvfs-helper will scan the ODB for
- * the last received prefetch and ask for ones newer than that.
+ * We ignore seconds_since_epoch and use the value from the ODB.
  */
-int gh_client__prefetch(timestamp_t seconds_since_epoch,
+int gh_client__prefetch(timestamp_t seconds_since_epoch UNUSED,
 			int *nr_packfiles_received)
 {
 	struct gh_server__process *entry;
@@ -557,14 +556,12 @@ int gh_client__prefetch(timestamp_t seconds_since_epoch,
 		return -1;
 
 	trace2_region_enter("gh-client", "objects/prefetch", the_repository);
-	trace2_data_intmax("gh-client", the_repository, "prefetch/since",
-			   seconds_since_epoch);
 
 	process = &entry->subprocess.process;
 
 	sigchain_push(SIGPIPE, SIG_IGN);
 
-	err = gh_client__send__objects_prefetch(process, seconds_since_epoch);
+	err = gh_client__send__objects_prefetch(process, /* seconds unknown */ 0);
 	if (!err)
 		err = gh_client__objects__receive_response(
 			process, &ghc, &nr_loose, &nr_packfile);

--- a/gvfs-helper-client.h
+++ b/gvfs-helper-client.h
@@ -70,7 +70,7 @@ int gh_client__drain_queue(enum gh_client__created *p_ghc);
  * Ask `gvfs-helper server` to fetch any "prefetch packs"
  * available on the server more recent than the requested time.
  *
- * If seconds_since_epoch is zero, gvfs-helper will scan the ODB for
+ * seconds_since_epoch is ignored. the gvfs-helper will scan the ODB for
  * the last received prefetch and ask for ones newer than that.
  *
  * A long-running background process is used to subsequent requests

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -3542,6 +3542,10 @@ static void do__http_get__gvfs_prefetch(struct gh__response_status *status,
 		strbuf_addf(&component_url, "?lastPackTimestamp=%"PRItime,
 			    seconds_since_epoch);
 
+	trace2_data_intmax(TR2_CAT, the_repository,
+			   "prefetch/since",
+			   seconds_since_epoch);
+
 	params.b_is_post = 0;
 	params.b_write_to_file = 1;
 	params.b_permit_cache_server_if_defined = 1;


### PR DESCRIPTION
The gvfs-helper-client code was logging a prefetch timestamp that was always 0 because nothing on the client side checks the ODB for this value. This tracing is confusing and makes it look like we are always sending a zero timestamp.

Move this tracing to the server so we can actually know the value being sent.

I created this as a `fixup!` commit so it will be squashed in the future. The commit I'm fixing doesn't integrate the method call in `builtin/fetch.c`, so to be safe I didn't modify the method prototype. I documented to be clear that we ignore the value.

* [X] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
