### PR TITLE
Fix build git installers in v2.53.0 rc1

### DIFF
--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -408,6 +408,9 @@ jobs:
           brew link --force gettext
 
           # Make universal gettext library
+          # Note: libintl depends on iconv, but we use the system's libiconv
+          # which is already universal, rather than Homebrew's libiconv which
+          # has different symbol names (_libiconv vs _iconv)
           lipo -create -output libintl.a /usr/local/opt/gettext/lib/libintl.a /opt/homebrew/opt/gettext/lib/libintl.a
 
       - name: Log in to Azure
@@ -487,9 +490,19 @@ jobs:
           # used in 'git version --build-options'.  We'll fix that in code.
           HOST_CPU = universal
           BASIC_CFLAGS += -arch arm64 -arch x86_64
+
+          # CRITICAL FIX: Disable USE_HOMEBREW_LIBICONV
+          # On Darwin 24+ (macOS 15), config.mak.uname sets USE_HOMEBREW_LIBICONV
+          # which causes ICONVDIR to point to Homebrew's libiconv. But Homebrew's
+          # libiconv exports _libiconv/_libiconv_open symbols (with prefix), while
+          # Homebrew's gettext/libintl was built against system iconv which uses
+          # _iconv/_iconv_open symbols (no prefix). We must use the system's
+          # /usr/lib/libiconv.dylib which is universal and has the correct symbols.
+          USE_HOMEBREW_LIBICONV =
+          ICONVDIR =
           EOF
 
-          # Configure the Git build to pick up gettext
+          # Configure the Git build to find our universal libintl.a
           homebrew_prefix="$(brew --prefix)"
           cat >>git/config.mak <<EOF
           CFLAGS = -I$homebrew_prefix/include -I/usr/local/opt/gettext/include

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -491,6 +491,11 @@ jobs:
           HOST_CPU = universal
           BASIC_CFLAGS += -arch arm64 -arch x86_64
 
+          # macOS uses Apple Common Crypto instead of OpenSSL. The main Makefile
+          # sets NO_OPENSSL and adds -DNO_OPENSSL to BASIC_CFLAGS, but contrib
+          # Makefiles that only include config.mak* don't get this logic.
+          BASIC_CFLAGS += -DNO_OPENSSL
+
           # CRITICAL FIX: Disable USE_HOMEBREW_LIBICONV
           # On Darwin 24+ (macOS 15), config.mak.uname sets USE_HOMEBREW_LIBICONV
           # which causes ICONVDIR to point to Homebrew's libiconv. But Homebrew's

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DEF_VER=v2.53.0-rc0
+DEF_VER=v2.53.0-rc1
 
 # Identify microsoft/git via a distinct version suffix
 DEF_VER=$DEF_VER.vfs.0.0

--- a/contrib/credential/osxkeychain/Makefile
+++ b/contrib/credential/osxkeychain/Makefile
@@ -41,8 +41,8 @@ prefix ?= /usr/local
 gitexecdir ?= $(prefix)/libexec/git-core
 
 CC ?= gcc
-CFLAGS ?= -g -O2 -Wall -I../../.. $(BASIC_CFLAGS)
-LDFLAGS ?= $(BASIC_LDFLAGS) $(EXTLIBS)
+override CFLAGS += -g -O2 -Wall -I../../.. $(BASIC_CFLAGS)
+override LDFLAGS += $(BASIC_LDFLAGS) $(EXTLIBS)
 INSTALL ?= install
 RM ?= rm -f
 


### PR DESCRIPTION
This includes the fixes I had to make to get https://github.com/microsoft/git/releases/tag/v2.53.0-rc0.vfs.0.0 to build, plus a fix for an overlooked stale `GIT-VERSION-GEN`,