### PR TITLE
Restore previous errno after post command hook

### DIFF
--- a/git.c
+++ b/git.c
@@ -504,6 +504,7 @@ static int run_post_command_hook(struct repository *r)
 {
 	char *lock;
 	int ret = 0;
+	int saved_errno = errno;
 	struct run_hooks_opt opt = RUN_HOOKS_OPT_INIT;
 
 	/*
@@ -520,6 +521,8 @@ static int run_post_command_hook(struct repository *r)
 	ret = run_hooks_opt(r, "post-command", &opt);
 
 	run_post_hook = 0;
+
+	errno = saved_errno;
 	strvec_clear(&sargv);
 	strvec_clear(&opt.args);
 	setenv("COMMAND_HOOK_LOCK", "false", 1);

--- a/t/t0401-post-command-hook.sh
+++ b/t/t0401-post-command-hook.sh
@@ -4,6 +4,21 @@ test_description='post-command hook'
 
 . ./test-lib.sh
 
+test_expect_success 'hook does not block git help' '
+	git config help.autocorrect immediate &&
+	git commit --allow-empty -m "a single log entry" &&
+	mkdir -p .git/hooks &&
+	write_script .git/hooks/post-command <<-EOF &&
+		echo "\$*" | sed "s/ --git-pid=[0-9]*//" \
+		>\$(git rev-parse --git-dir)/post-command.out
+	EOF
+	# intentional typo "logg" gets autocorrected to "log"
+	git logg --format=%s --first-parent > actual &&
+	test "log --format=%s --first-parent --exit_code=0" = "$(cat .git/post-command.out)" &&
+	echo "a single log entry" >expect &&
+	test_cmp expect actual
+'
+
 test_expect_success 'with no hook' '
 	echo "first" > file &&
 	git add file &&


### PR DESCRIPTION
* [ x ] This change only applies to the virtualization hook and VFS for Git.

Test and fix for #859 
