### PR TITLE
gvfs-helper: create shared object cache if missing

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -1352,13 +1352,16 @@ static int option_parse_shared_cache_directory(const struct option *opt,
 		 */
 		strbuf_addbuf(&gvfs_shared_cache_pathname, &buf_arg);
 
+		/* Attempt to create the directory, in case it doesn't exist. */
+		safe_create_leading_directories(the_repository,
+						gvfs_shared_cache_pathname.buf);
+		mkdir(gvfs_shared_cache_pathname.buf, 0777);
+
 		odb_add_to_alternates_memory(the_repository->objects, buf_arg.buf);
 
 		strbuf_release(&buf_arg);
 		return 0;
-	}
-
-	else {
+	} else {
 		/*
 		 * The requested shared-cache is different from the one
 		 * we inherited.  Replace the inherited value with this
@@ -1370,6 +1373,11 @@ static int option_parse_shared_cache_directory(const struct option *opt,
 
 		strbuf_setlen(&gvfs_shared_cache_pathname, 0);
 		strbuf_addbuf(&gvfs_shared_cache_pathname, &buf_arg);
+
+		/* Attempt to create the directory, in case it doesn't exist. */
+		safe_create_leading_directories(the_repository,
+						gvfs_shared_cache_pathname.buf);
+		mkdir(gvfs_shared_cache_pathname.buf, 0777);
 
 		odb_add_to_alternates_memory(the_repository->objects, buf_arg.buf);
 

--- a/t/t9210-scalar.sh
+++ b/t/t9210-scalar.sh
@@ -455,6 +455,37 @@ test_expect_success '`scalar clone` with GVFS-enabled server' '
 	)
 '
 
+test_expect_success '`scalar clone` with GVFS-enabled server; local cache path' '
+	: the fake cache server requires fake authentication &&
+	git config --global core.askPass true &&
+
+	LOCAL_CACHE_BASE="$(pwd)/local" &&
+
+	# We must set credential.interactive=true to bypass a setting
+	# in "scalar clone" that disables interactive credentials during
+	# an unattended command.
+	scalar \
+		-c credential.interactive=true \
+		clone --gvfs-protocol \
+		--local-cache-path="$LOCAL_CACHE_BASE" \
+		--single-branch -- http://$ORIGIN_HOST_PORT/ with-local &&
+
+	: verify that the shared cache has been configured &&
+	cache_key="url_$(printf "%s" http://$ORIGIN_HOST_PORT/ |
+		tr A-Z a-z |
+		test-tool sha1)" &&
+	LOCAL_CACHE_DIR="$LOCAL_CACHE_BASE/$cache_key" &&
+	echo "$LOCAL_CACHE_DIR" >expect &&
+	git -C with-local/src config gvfs.sharedCache >actual &&
+	test_cmp expect actual &&
+
+	: check the local cache is recreated on fetch &&
+	rm -rf $LOCAL_CACHE_BASE &&
+	git -C with-local fetch &&
+	test_path_is_dir "$LOCAL_CACHE_DIR" &&
+	test_path_is_dir "$LOCAL_CACHE_DIR/pack"
+'
+
 . "$TEST_DIRECTORY"/lib-gvfs-helper.sh
 
 test_expect_success 'scalar clone: all verbs with different servers' '


### PR DESCRIPTION
Users should be allowed to delete their shared cache and have it recreated on 'git fetch'. This change makes that happen by creating any leading directories and then creating the directory itself with `mkdir()`.

Users may have had more instances of this due to #840, which advises deleting the shared cache on a mistaken assumption that it would be recreated on `git fetch`.

* [X] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
