### PR TITLE
codeql: upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -45,7 +45,7 @@ jobs:
           make -j$(nproc)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           upload: False
           output: sarif-results
@@ -61,6 +61,6 @@ jobs:
           path: sarif-results
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
          sarif_file: sarif-results/${{ matrix.language }}.sarif


### PR DESCRIPTION
Upgrade CodeQL Action from v3 to v4 per the deprecation notice at
https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

v3 will be deprecated in December 2026 alongside GHES 3.19; v4 moves
to the Node.js 24 runtime.