### PR TITLE
codeql: do call `apt-get update`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         if: matrix.language == 'cpp'
         env:
           jobname: codeql
+          CI_JOB_IMAGE: ubuntu-latest
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
As of b133d3071ae6 (github: simplify computation of the job's distro, 2025-01-10), the `apt-get update` call that is guarded by `$distro` in the `ci/install-dependencies.sh` script requires the `CI_JOB_IMAGE` variable to set correctly (which is used to initialize `distro` in the GitHub Actions-specific part at the top of `ci/lib.sh`).

Let's do the same in the CodeQL workflow.

/cc @derrickstolee @tyrielv @mjcheetham 