### PR TITLE
workflow: add release-vfsforgit to automate VFS for Git updates

### DIFF
--- a/.github/workflows/release-vfsforgit.yml
+++ b/.github/workflows/release-vfsforgit.yml
@@ -1,0 +1,97 @@
+name: Update VFS for Git
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  id-token: write # required for Azure login via OIDC
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Compute tag name
+        id: tag
+        run: echo "name=${{ github.event.release.tag_name }}" >>$GITHUB_OUTPUT
+
+      - name: Log into Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Checkout (for akv-secret action)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+
+      - name: Retrieve token
+        id: token
+        uses: ./.github/actions/akv-secret
+        with:
+          vault: ${{ secrets.AZURE_VAULT }}
+          secrets: |
+            ${{ secrets.VFSFORGIT_TOKEN_SECRET_NAME }} > $output:result
+
+      # Create a PR to bump the default GIT_VERSION
+      - name: Create VFS for Git version bump PR
+        env:
+          # GH_TOKEN overrides the GITHUB_TOKEN provided by the actions runner,
+          # so that `gh` commands use the VFS for Git repo token from Key Vault.
+          GH_TOKEN: ${{ steps.token.outputs.result }}
+        run: |
+          # Configure gh as the git credential helper and force HTTPS protocol
+          # so that git clone/push authenticate using GH_TOKEN.
+          gh auth setup-git
+          gh config set git_protocol https
+
+          TAG="${{ steps.tag.outputs.name }}"
+          REPO="microsoft/VFSForGit"
+          BRANCH="automation/gitrelease-$TAG"
+          FILE=".github/workflows/build.yaml"
+
+          # Clone VFS for Git repo (sparse partial clone for efficiency)
+          gh repo clone "$REPO" vfsforgit -- --filter=blob:none --no-checkout --depth=1
+          cd vfsforgit
+          git sparse-checkout set "$FILE"
+          git checkout
+
+          # Create new branch
+          git checkout -b "$BRANCH"
+
+          # Update the GIT_VERSION default in build.yaml
+          sed -i "/GIT_VERSION/s/|| '[^']*' }}/|| '$TAG' }}/" "$FILE"
+
+          # Verify the change was made
+          if ! git diff --quiet "$FILE"; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git add "$FILE"
+            git commit -m "Update default Microsoft Git version to $TAG"
+
+            # Push the new branch
+            git push origin "$BRANCH"
+
+            # Create the PR
+            WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            RELEASE_URL="https://github.com/microsoft/git/releases/tag/$TAG"
+            PR_TITLE="Update default Microsoft Git version to $TAG"
+            PR_BODY=$(cat <<EOF
+            This PR was automatically created by the [microsoft/git release workflow]($WORKFLOW_URL)
+            to update the default Microsoft Git version to [\`$TAG\`]($RELEASE_URL).
+            EOF
+            )
+
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --head "$BRANCH" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY")
+            echo "::notice::Created VFS for Git PR: $PR_URL"
+          else
+            echo "::warning::No changes detected in $FILE; GIT_VERSION may already be set to $TAG"
+          fi


### PR DESCRIPTION
When a new `microsoft/git` release is published, VFS for Git needs to pick up the new Git version. Today this is a manual process. This workflow automates it by reacting to GitHub release events.
    
On a full releases: creates a PR in `microsoft/VFSForGit` to bump the default `GIT_VERSION` in the build workflow, so future CI runs and manual dispatches use the latest stable Git version.
    
Authentication uses the existing Azure Key Vault + OIDC pattern (matching `release-homebrew` and `release-winget`) to retrieve a token with write access to the VFS for Git repository.
    
In a separate effort we'll add another workflow that triggers on push to `vfs-*` branches to trigger a run of VFS for Git Functional Tests (from the `master` branch).