### PR TITLE
gvfs: clear DIE_IF_CORRUPT in streaming incore fallback

### DIFF
--- a/odb/streaming.c
+++ b/odb/streaming.c
@@ -7,6 +7,7 @@
 #include "environment.h"
 #include "repository.h"
 #include "object-file.h"
+#include "gvfs.h"
 #include "odb.h"
 #include "odb/streaming.h"
 #include "replace-object.h"
@@ -158,13 +159,14 @@ static int open_istream_incore(struct odb_read_stream **out,
 		.base.read = read_istream_incore,
 	};
 	struct odb_incore_read_stream *st;
+	unsigned flags = gvfs_config_is_set(odb->repo, GVFS_MISSING_OK) ?
+		0 : OBJECT_INFO_DIE_IF_CORRUPT;
 	int ret;
 
 	oi.typep = &stream.base.type;
 	oi.sizep = &stream.base.size;
 	oi.contentp = (void **)&stream.buf;
-	ret = odb_read_object_info_extended(odb, oid, &oi,
-					    OBJECT_INFO_DIE_IF_CORRUPT);
+	ret = odb_read_object_info_extended(odb, oid, &oi, flags);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
The upstream refactoring in 4c89d31494b (streaming: rely on object sources to create object stream, 2025-11-23) changed how istream_source() discovers objects. Previously, it called odb_read_object_info_extended() with flags=0 to locate the object, then tried the source-specific opener (e.g. open_istream_loose). If that failed (e.g. corrupt loose object), it fell back to open_istream_incore which re-read the object — by which time the read-object hook had already re-fetched a clean copy.

After the refactoring, istream_source() iterates over sources directly. When a corrupt loose object is found, odb_source_loose_read_object_stream fails and the loop continues to the next source. When no source has the object, it falls through to open_istream_incore, which calls odb_read_object_info_extended with OBJECT_INFO_DIE_IF_CORRUPT. This encounters the same corrupt loose file still on disk and dies before the read-object hook gets a chance to re-download a clean replacement.

Fix this by clearing OBJECT_INFO_DIE_IF_CORRUPT in open_istream_incore when GVFS_MISSING_OK is set, matching the existing pattern in odb_read_object.

This fixes the GitCorruptObjectTests functional test failures (GitRequestsReplacementForAllNullObject,
GitRequestsReplacementForObjectCorruptedWithBadData, GitRequestsReplacementForTruncatedObject) that appeared when upgrading from v2.50.1.vfs.0.1 to v2.53.0.vfs.0.0.
