### PR TITLE
worktree remove: use gvfs_config_is_set for skip-clean-check gate

### DIFF
--- a/builtin/worktree.c
+++ b/builtin/worktree.c
@@ -1420,7 +1420,9 @@ static int remove_worktree(int ac, const char **av, const char *prefix,
 	strbuf_release(&errmsg);
 
 	if (file_exists(wt->path)) {
-		if (!force && !(core_virtualfilesystem && should_skip_clean_check(wt)))
+		if (!force &&
+		    !(gvfs_config_is_set(the_repository, GVFS_SUPPORTS_WORKTREES) &&
+		      should_skip_clean_check(wt)))
 			check_clean_worktree(wt, av[0]);
 
 		ret |= delete_git_work_tree(wt);


### PR DESCRIPTION
The skip-clean-check guard in remove_worktree() was gated on core_virtualfilesystem, which is only initialized by repo_config_get_virtualfilesystem() during index loading. Since the worktree remove path never loads the index before this check, the variable was always NULL, causing check_clean_worktree() to run even when VFSForGit had already unmounted the projection and written the skip-clean-check marker file. This made 'git worktree remove' fail with 'fatal: failed to run git status' in GVFS repos.

Replace core_virtualfilesystem with gvfs_config_is_set(GVFS_USE_VIRTUAL_FILESYSTEM), which is already loaded from core.gvfs by cmd_worktree() before dispatch to remove_worktree().