### PR TITLE
diff: add renameThreshold configuration option

### DIFF
--- a/Documentation/config/diff.adoc
+++ b/Documentation/config/diff.adoc
@@ -161,9 +161,9 @@ endif::git-diff[]
 	(e.g. `0.5`).  If not set, the default is 50%.  This setting
 	has no effect if rename detection is turned off.
 +
-	This config setting is also respected by linkgit:git-blame[1];
-	to limit blame to only consider exact renames, for example, set
-	`diff.renameThreshold = 100%`.
+This config setting is also respected by linkgit:git-blame[1];
+to limit blame to only consider exact renames, for example, set
+`diff.renameThreshold = 100%`.
 
 `diff.renames`::
 	Whether and how Git detects renames.  If set to `false`,

--- a/Documentation/config/diff.adoc
+++ b/Documentation/config/diff.adoc
@@ -154,6 +154,17 @@ endif::git-diff[]
 	`-l`.  If not set, the default value is currently 1000.  This
 	setting has no effect if rename detection is turned off.
 
+`diff.renameThreshold`::
+	The minimum similarity threshold for rename detection;
+	equivalent to the `git diff` option `-M`.  The value is a
+	percentage (e.g. `50%`), or a fraction between 0 and 1
+	(e.g. `0.5`).  If not set, the default is 50%.  This setting
+	has no effect if rename detection is turned off.
++
+	This config setting is also respected by linkgit:git-blame[1];
+	to limit blame to only consider exact renames, for example, set
+	`diff.renameThreshold = 100%`.
+
 `diff.renames`::
 	Whether and how Git detects renames.  If set to `false`,
 	rename detection is disabled. If set to `true`, basic rename

--- a/Documentation/config/merge.adoc
+++ b/Documentation/config/merge.adoc
@@ -47,6 +47,13 @@ include::fmt-merge-msg.adoc[]
 	currently defaults to 7000.  This setting has no effect if
 	rename detection is turned off.
 
+`merge.renameThreshold`::
+	The minimum similarity threshold for rename detection during
+	a merge.  If not specified, defaults to the value of
+	`diff.renameThreshold`.  See `diff.renameThreshold` for the
+	accepted value format.  This setting has no effect if rename
+	detection is turned off.
+
 `merge.renames`::
 	Whether Git detects renames.  If set to `false`, rename detection
 	is disabled. If set to `true`, basic rename detection is enabled.

--- a/Documentation/config/status.adoc
+++ b/Documentation/config/status.adoc
@@ -29,6 +29,12 @@ status.renameLimit::
 	in linkgit:git-status[1] and linkgit:git-commit[1]. Defaults to
 	the value of diff.renameLimit.
 
+status.renameThreshold::
+	The minimum similarity threshold for rename detection in
+	linkgit:git-status[1] and linkgit:git-commit[1].  Defaults to
+	the value of diff.renameThreshold.  See `diff.renameThreshold`
+	for the accepted value format.
+
 status.renames::
 	Whether and how Git detects renames in linkgit:git-status[1] and
 	linkgit:git-commit[1] .  If set to "false", rename detection is

--- a/Documentation/git-blame.adoc
+++ b/Documentation/git-blame.adoc
@@ -25,9 +25,10 @@ lines.
 
 The origin of lines is automatically followed across whole-file
 renames (currently there is no option to turn the rename-following
-off). To follow lines moved from one file to another, or to follow
-lines that were copied and pasted from another file, etc., see the
-`-C` and `-M` options.
+off, but the minimum similarity threshold can be adjusted with
+`diff.renameThreshold`; see linkgit:git-diff[1]).  To follow lines
+moved from one file to another, or to follow lines that were copied
+and pasted from another file, etc., see the `-C` and `-M` options.
 
 The report does not tell you anything about lines which have been deleted or
 replaced; you need to use a tool such as `git diff` or the "pickaxe"

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1672,6 +1672,26 @@ static int git_status_config(const char *k, const char *v,
 		s->detect_rename = git_config_rename(k, v);
 		return 0;
 	}
+	if (!strcmp(k, "diff.renamethreshold")) {
+		if (s->rename_score == -1) {
+			const char *arg = v;
+			if (!v)
+				return config_error_nonbool(k);
+			s->rename_score = parse_rename_score(&arg);
+			if (*arg)
+				return error(_("invalid value for '%s': '%s'"), k, v);
+		}
+		return 0;
+	}
+	if (!strcmp(k, "status.renamethreshold")) {
+		const char *arg = v;
+		if (!v)
+			return config_error_nonbool(k);
+		s->rename_score = parse_rename_score(&arg);
+		if (*arg)
+			return error(_("invalid value for '%s': '%s'"), k, v);
+		return 0;
+	}
 	return git_diff_ui_config(k, v, ctx, NULL);
 }
 

--- a/diff.c
+++ b/diff.c
@@ -56,6 +56,7 @@
 static int diff_detect_rename_default;
 static int diff_indent_heuristic = 1;
 static int diff_rename_limit_default = 1000;
+static int diff_rename_score_default;
 static int diff_suppress_blank_empty;
 static enum git_colorbool diff_use_color_default = GIT_COLOR_UNKNOWN;
 static int diff_color_moved_default;
@@ -396,6 +397,15 @@ int git_diff_ui_config(const char *var, const char *value,
 	}
 	if (!strcmp(var, "diff.renames")) {
 		diff_detect_rename_default = git_config_rename(var, value);
+		return 0;
+	}
+	if (!strcmp(var, "diff.renamethreshold")) {
+		const char *arg = value;
+		if (!value)
+			return config_error_nonbool(var);
+		diff_rename_score_default = parse_rename_score(&arg);
+		if (*arg)
+			return error(_("invalid value for '%s': '%s'"), var, value);
 		return 0;
 	}
 	if (!strcmp(var, "diff.autorefreshindex")) {
@@ -4856,6 +4866,7 @@ void repo_diff_setup(struct repository *r, struct diff_options *options)
 	options->add_remove = diff_addremove;
 	options->use_color = diff_use_color_default;
 	options->detect_rename = diff_detect_rename_default;
+	options->rename_score = diff_rename_score_default;
 	options->xdl_opts |= diff_algorithm;
 	if (diff_indent_heuristic)
 		DIFF_XDL_SET(options, INDENT_HEURISTIC);

--- a/merge-ort.c
+++ b/merge-ort.c
@@ -5444,6 +5444,22 @@ static void merge_recursive_config(struct merge_options *opt, int ui)
 	repo_config_get_int(the_repository, "merge.verbosity", &opt->verbosity);
 	repo_config_get_int(the_repository, "diff.renamelimit", &opt->rename_limit);
 	repo_config_get_int(the_repository, "merge.renamelimit", &opt->rename_limit);
+	if (!repo_config_get_string(the_repository, "diff.renamethreshold", &value)) {
+		const char *arg = value;
+		opt->rename_score = parse_rename_score(&arg);
+		if (*arg)
+			die(_("invalid value for '%s': '%s'"),
+			    "diff.renameThreshold", value);
+		free(value);
+	}
+	if (!repo_config_get_string(the_repository, "merge.renamethreshold", &value)) {
+		const char *arg = value;
+		opt->rename_score = parse_rename_score(&arg);
+		if (*arg)
+			die(_("invalid value for '%s': '%s'"),
+			    "merge.renameThreshold", value);
+		free(value);
+	}
 	repo_config_get_bool(the_repository, "merge.renormalize", &renormalize);
 	opt->renormalize = renormalize;
 	if (!repo_config_get_string(the_repository, "diff.renames", &value)) {

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -126,6 +126,21 @@ test_expect_success 'test diff.renames unset' '
 	compare_diff_patch current expected
 '
 
+test_expect_success 'diff.renameThreshold=100% suppresses inexact rename in diff' '
+	git -c diff.renameThreshold=100% diff --cached $tree >current &&
+	compare_diff_patch current no-rename
+'
+
+test_expect_success 'diff.renameThreshold=1% detects rename in diff' '
+	git -c diff.renameThreshold=1% diff --cached $tree >current &&
+	compare_diff_patch current expected
+'
+
+test_expect_success '-M overrides diff.renameThreshold' '
+	git -c diff.renameThreshold=100% diff -M --cached $tree >current &&
+	compare_diff_patch current expected
+'
+
 test_expect_success 'favour same basenames over different ones' '
 	cp path1 another-path &&
 	git add another-path &&
@@ -153,6 +168,16 @@ test_expect_success 'favour same basenames even with minor differences' '
 	git show HEAD:path1 | sed "s/15/16/" > subdir/path1 &&
 	git status >out &&
 	test_grep "renamed: .*path1 -> subdir/path1" out
+'
+
+test_expect_success 'diff.renameThreshold with modified rename in status' '
+	git show HEAD:path1 | sed -e "s/Line 1/Changed 1/" \
+		-e "s/Line 2/Changed 2/" -e "s/Line 3/Changed 3/" >subdir/path1 &&
+	git add subdir/path1 &&
+	git -c diff.renameThreshold=100% status >out &&
+	test_grep ! "renamed:" out &&
+	git -c diff.renameThreshold=1% status >out &&
+	test_grep "renamed:" out
 '
 
 test_expect_success 'two files with same basename and same content' '

--- a/t/t6434-merge-recursive-rename-options.sh
+++ b/t/t6434-merge-recursive-rename-options.sh
@@ -332,4 +332,36 @@ test_expect_success 'merge.renames overrides diff.renames' '
 	$check_50
 '
 
+test_expect_success 'diff.renameThreshold sets merge threshold' '
+	git read-tree --reset -u HEAD &&
+	test_must_fail git -c diff.renameThreshold=$th0 merge-recursive $tail &&
+	check_threshold_0
+'
+
+test_expect_success 'diff.renameThreshold=100% limits to exact renames in merge' '
+	git read-tree --reset -u HEAD &&
+	test_must_fail git -c diff.renameThreshold=100% merge-recursive $tail &&
+	check_exact_renames
+'
+
+test_expect_success 'merge.renameThreshold overrides diff.renameThreshold' '
+	git read-tree --reset -u HEAD &&
+	test_must_fail git -c diff.renameThreshold=100% \
+		-c merge.renameThreshold=$th0 merge-recursive $tail &&
+	check_threshold_0
+'
+
+test_expect_success 'merge.renameThreshold defaults to diff.renameThreshold' '
+	git read-tree --reset -u HEAD &&
+	test_must_fail git -c diff.renameThreshold=$th2 merge-recursive $tail &&
+	check_threshold_2
+'
+
+test_expect_success '--find-renames overrides merge.renameThreshold' '
+	git read-tree --reset -u HEAD &&
+	test_must_fail git -c merge.renameThreshold=100% \
+		merge-recursive --find-renames=$th0 $tail &&
+	check_threshold_0
+'
+
 test_done

--- a/t/t7525-status-rename.sh
+++ b/t/t7525-status-rename.sh
@@ -97,6 +97,38 @@ test_expect_success 'status score=01%' '
 	test_grep "renamed:" actual
 '
 
+test_expect_success 'diff.renameThreshold sets default threshold' '
+	git -c diff.renameThreshold=100% status >actual &&
+	test_grep "deleted:" actual &&
+	test_grep "new file:" actual
+'
+
+test_expect_success 'status.renameThreshold overrides diff.renameThreshold' '
+	git -c diff.renameThreshold=100% -c status.renameThreshold=01% status >actual &&
+	test_grep "renamed:" actual
+'
+
+test_expect_success 'diff.renameThreshold=01% detects rename in status' '
+	git -c diff.renameThreshold=01% status >actual &&
+	test_grep "renamed:" actual
+'
+
+test_expect_success 'commit honors diff.renameThreshold' '
+	git -c diff.renameThreshold=100% commit --dry-run >actual &&
+	test_grep "deleted:" actual &&
+	test_grep "new file:" actual
+'
+
+test_expect_success 'commit honors status.renameThreshold' '
+	git -c status.renameThreshold=01% commit --dry-run >actual &&
+	test_grep "renamed:" actual
+'
+
+test_expect_success '-M overrides status.renameThreshold' '
+	git -c status.renameThreshold=100% status -M=01% >actual &&
+	test_grep "renamed:" actual
+'
+
 test_expect_success 'copies not overridden by find-renames' '
 	cp renamed copy &&
 	git add copy &&


### PR DESCRIPTION
Add diff.renameThreshold, merge.renameThreshold, and status.renameThreshold configuration options to control the minimum similarity threshold for rename detection without requiring command-line flags.

The cascade follows the existing pattern for renameLimit and renames:
  - merge.renameThreshold overrides diff.renameThreshold for merges
  - status.renameThreshold overrides diff.renameThreshold for status
  - CLI flags (-M, --find-renames) override all config values

The value accepts the same format as -M: a percentage (e.g. 50%) or a fraction (e.g. 0.5). If unset, the default remains 50%.

This also gives git-blame users control over the rename threshold for the first time, since blame has no -M threshold flag but inherits diff.renameThreshold via repo_diff_setup().

Assisted-by: Claude Opus 4.6

__________________

Thanks for taking the time to contribute to Git!

This fork contains changes specific to monorepo scenarios. If you are an
external contributor, then please detail your reason for submitting to
this fork:

* [x] This is an early version of work already under review upstream.
* [ ] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
* [ ] This change only applies to the virtualization hook and VFS for Git.
