### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/actions/akv-secret/action.yml
+++ b/.github/actions/akv-secret/action.yml
@@ -50,5 +50,5 @@ inputs:
         encoded-secret base64> $env:ENV_SECRET
 
 runs:
-  using: node20
+  using: node24
   main: index.js

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -894,7 +894,7 @@ jobs:
           path: deb-package
 
       - name: Log into Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -109,7 +109,7 @@ jobs:
           git fetch "https://github.com/${{github.repository}}" refs/tags/${tag_name}:refs/tags/${tag_name} &&
           git reset --hard ${tag_name}
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -222,7 +222,7 @@ jobs:
         run: |
           git clone --filter=blob:none --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         if: env.DO_WIN_CODESIGN == 'true'
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -683,7 +683,7 @@ jobs:
           mv "$PKGNAME.deb" "$GITHUB_WORKSPACE"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-unsigned-${{ matrix.arch.name }}
           path: |

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -178,7 +178,7 @@ jobs:
           git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
           git bundle create "$b"/MINGW-packages.bundle origin/main..main)
       - name: Publish mingw-w64-${{matrix.arch.toolchain}}-git
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "${{ matrix.arch.artifact }}"
           path: artifacts
@@ -376,7 +376,7 @@ jobs:
           }
           exit $ret
       - name: Publish ${{matrix.type.name}}-${{matrix.arch.name}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: win-${{matrix.type.name}}-${{matrix.arch.name}}
           path: artifacts

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -414,7 +414,7 @@ jobs:
           lipo -create -output libintl.a /usr/local/opt/gettext/lib/libintl.a /opt/homebrew/opt/gettext/lib/libintl.a
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -566,7 +566,7 @@ jobs:
           mv git/.github/macos-installer/disk-image/*.pkg git/.github/macos-installer/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macos-artifacts
           path: |

--- a/.github/workflows/build-git-installers.yml
+++ b/.github/workflows/build-git-installers.yml
@@ -698,7 +698,7 @@ jobs:
     environment: release
     steps:
       - name: Log into Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -753,7 +753,7 @@ jobs:
           debsigs --sign=origin --verify --check microsoft-git_"$version"_${{ matrix.arch }}.deb
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-${{ matrix.arch }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
         run: ls -la sarif-results
 
       - name: publish sarif for debugging
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sarif-results-${{ matrix.language }}
           path: sarif-results

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -23,7 +23,7 @@ jobs:
         hash: sha256
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Log into Azure
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release-vfsforgit.yml
+++ b/.github/workflows/release-vfsforgit.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "name=${{ github.event.release.tag_name }}" >>$GITHUB_OUTPUT
 
       - name: Log into Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -21,7 +21,7 @@ jobs:
     environment: release
     steps:
       - name: Log into Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/scalar-functional-tests.yml
+++ b/.github/workflows/scalar-functional-tests.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Archive Trace2 Logs
         if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows.conclusion == 'success' )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.TRACE2_BASENAME }}.zip
           path: scalar/${{ env.TRACE2_BASENAME }}.zip

--- a/.github/workflows/vfs-functional-tests.yml
+++ b/.github/workflows/vfs-functional-tests.yml
@@ -68,7 +68,7 @@ jobs:
           make -j5 DESTDIR="$GITHUB_WORKSPACE/MicrosoftGit/payload/${{ matrix.architecture }}" install
 
       - name: Upload Git artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: MicrosoftGit-${{ matrix.architecture }}
           path: MicrosoftGit
@@ -112,7 +112,7 @@ jobs:
           BATCH
 
       - name: Upload Git artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: MicrosoftGit
           path: MicrosoftGit


### PR DESCRIPTION
This updates the GitHub Actions to avoid warnings about the Node.JS 20 deprecation, all properly marked as `fixup!` commits to allow for auto-squashing during the next rebase.

**Note**: This _only_ touches the GitHub workflows added in the Microsoft Git fork, and leaves those alone that are already present in Git for Windows.