### PR TITLE
azure-pipelines: add stub release pipeline for Azure

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -1,0 +1,259 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+trigger: none
+pr: none
+
+resources:
+  repositories:
+    - repository: 1ESPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+parameters:
+  - name: 'github'
+    type: boolean
+    default: false # TODO: change default to true after testing
+    displayName: 'Enable GitHub release publishing'
+
+#
+# 1ES Pipeline Templates do not allow using a matrix strategy so we create
+# a YAML object parameter with and foreach to create jobs for each entry.
+# Each OS has its own matrix object since their build steps differ.
+#
+  - name: windows_matrix
+    type: object
+    default:
+      - id: windows_x64
+        jobName: 'Windows (x64)'
+        pool: GitClientPME-1ESHostedPool-intel-pc
+        image: win-x86_64-ado1es
+        os: windows
+        toolchain: x86_64
+        mingwprefix: mingw64
+
+      - id: windows_arm64
+        jobName: 'Windows (ARM64)'
+        pool: GitClientPME-1ESHostedPool-arm64-pc
+        image: win-arm64-ado1es
+        os: windows
+        toolchain: clang-aarch64
+        mingwprefix: clangarm64
+
+  # No matrix for macOS as we build both x64 and ARM64 in the same job
+  # and produce a universal binary.
+
+  - name: linux_matrix
+    type: object
+    default:
+      - id: linux_x64
+        jobName: 'Linux (x64)'
+        pool: GitClientPME-1ESHostedPool-intel-pc
+        image: ubuntu-x86_64-ado1es
+        os: linux
+        cc_arch: x86_64
+        deb_arch: amd64
+
+      - id: linux_arm64
+        jobName: 'Linux (ARM64)'
+        pool: GitClientPME-1ESHostedPool-arm64-pc
+        image: ubuntu-arm64-ado1es
+        os: linux
+        cc_arch: aarch64
+        deb_arch: arm64
+
+variables:
+  - name: 'githubConnectionName'
+    value: 'GitHub-MicrosoftGit'
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelines
+  parameters:
+    sdl:
+      # SDL source analysis tasks only run on Windows images
+      sourceAnalysisPool:
+        name: GitClientPME-1ESHostedPool-intel-pc
+        image: win-x86_64-ado1es
+        os: windows
+    stages:
+      - stage: prereqs
+        displayName: 'Prerequisites'
+        jobs:
+          - job: prebuild
+            displayName: 'Pre-build validation'
+            pool:
+              name: GitClientPME-1ESHostedPool-intel-pc
+              image: ubuntu-x86_64-ado1es
+              os: linux
+            steps:
+              - task: Bash@3
+                displayName: 'Resolve version and tag information'
+                name: info
+                inputs:
+                  targetType: inline
+                  script: |
+                    # TODO: determine git_version, tag_name, and tag_sha
+                    # TODO: error if the current commit is not an annotated tag
+                    git_version=TODO_GITVER
+                    tag_name=TODO_TAGNAME
+                    tag_sha=TODO_TAGSHA
+                    echo "##vso[task.setvariable variable=git_version;isOutput=true;isReadOnly=true]$git_version"
+                    echo "##vso[task.setvariable variable=tag_name;isOutput=true;isReadOnly=true]$tag_name"
+                    echo "##vso[task.setvariable variable=tag_sha;isOutput=true;isReadOnly=true]$tag_sha"
+
+      - stage: build
+        displayName: 'Build'
+        dependsOn: [prereqs]
+        jobs:
+          #
+          # Windows build jobs
+          #
+          - ${{ each dim in parameters.windows_matrix }}:
+            - job: ${{ dim.id }}
+              displayName: ${{ dim.jobName }}
+              pool:
+                name: ${{ dim.pool }}
+                image: ${{ dim.image }}
+                os: ${{ dim.os }}
+              variables:
+                tag_name: $[stageDependencies.prereqs.prebuild.outputs['info.tag_name']]
+                tag_sha: $[stageDependencies.prereqs.prebuild.outputs['info.tag_sha']]
+                git_version: $[stageDependencies.prereqs.prebuild.outputs['info.git_version']]
+                toolchain: ${{ dim.toolchain }}
+                mingwprefix: ${{ dim.mingwprefix }}
+              templateContext:
+                outputs:
+                  - output: pipelineArtifact
+                    targetPath: '$(Build.ArtifactStagingDirectory)/_final'
+                    artifactName: '${{ dim.id }}'
+              steps:
+                - checkout: self
+                # TODO: add tasks to set up Git for Windows SDK
+                # TODO: add tasks to build Git and installers
+                - script: |
+                    echo $(mingwprefix)
+                    echo $(toolchain)
+                  displayName: 'Dummy build'
+                # TODO: put final artifacts under $(Build.ArtifactStagingDirectory)/_final
+                - script: |
+                    echo "TODO" > $(Build.ArtifactStagingDirectory)/_final/placeholder.txt
+
+          #
+          # macOS build job (universal)
+          #
+          - job: macos_universal
+            displayName: 'macOS (x64 + ARM64)'
+            pool:
+              name: 'Azure Pipelines'
+              image: macOS-latest
+              os: macos
+            variables:
+              tag_name: $[stageDependencies.prereqs.prebuild.outputs['info.tag_name']]
+              tag_sha: $[stageDependencies.prereqs.prebuild.outputs['info.tag_sha']]
+              git_version: $[stageDependencies.prereqs.prebuild.outputs['info.git_version']]
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: '$(Build.ArtifactStagingDirectory)/_final'
+                  artifactName: 'macos_universal'
+            steps:
+              - checkout: self
+              # TODO: add tasks to set up build environment
+              # TODO: add tasks to build Git and installers
+              - script: |
+                  echo "Hello, Mac!"
+                displayName: 'Dummy build'
+              # TODO: put final artifacts under $(Build.ArtifactStagingDirectory)/_final
+              - script: |
+                  echo "TODO" > $(Build.ArtifactStagingDirectory)/_final/placeholder.txt
+
+          #
+          # Linux build jobs
+          #
+          - ${{ each dim in parameters.linux_matrix }}:
+            - job: ${{ dim.id }}
+              displayName: ${{ dim.jobName }}
+              pool:
+                name: ${{ dim.pool }}
+                image: ${{ dim.image }}
+                os: ${{ dim.os }}
+              variables:
+                tag_name: $[stageDependencies.prereqs.prebuild.outputs['info.tag_name']]
+                tag_sha: $[stageDependencies.prereqs.prebuild.outputs['info.tag_sha']]
+                git_version: $[stageDependencies.prereqs.prebuild.outputs['info.git_version']]
+                cc_arch: ${{ dim.cc_arch }}
+                deb_arch: ${{ dim.deb_arch }}
+              templateContext:
+                outputs:
+                  - output: pipelineArtifact
+                    targetPath: '$(Build.ArtifactStagingDirectory)/_final'
+                    artifactName: '${{ dim.id }}'
+              steps:
+                - checkout: self
+                # TODO: add tasks to set up build environment
+                # TODO: add tasks to build Git and installers
+                - script: |
+                    echo $(cc_arch)
+                    echo $(deb_arch)
+                  displayName: 'Dummy build'
+                # TODO: put final artifacts under $(Build.ArtifactStagingDirectory)/_final
+                - script: |
+                    echo "TODO" > $(Build.ArtifactStagingDirectory)/_final/placeholder.txt
+
+      - stage: release
+        displayName: 'Release'
+        dependsOn: [prereqs, build]
+        jobs:
+          - job: github
+            displayName: 'Publish GitHub release'
+            condition: and(succeeded(), eq('${{ parameters.github }}', true))
+            pool:
+              name: GitClientPME-1ESHostedPool-intel-pc
+              image: ubuntu-x86_64-ado1es
+              os: linux
+            variables:
+              tag_name: $[stageDependencies.prereqs.prebuild.outputs['info.tag_name']]
+              tag_sha: $[stageDependencies.prereqs.prebuild.outputs['info.tag_sha']]
+              git_version: $[stageDependencies.prereqs.prebuild.outputs['info.git_version']]
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: 'windows_x64'
+                  targetPath: $(Pipeline.Workspace)/assets/windows_x64
+                - input: pipelineArtifact
+                  artifactName: 'windows_arm64'
+                  targetPath: $(Pipeline.Workspace)/assets/windows_arm64
+                - input: pipelineArtifact
+                  artifactName: 'macos_universal'
+                  targetPath: $(Pipeline.Workspace)/assets/macos_universal
+                - input: pipelineArtifact
+                  artifactName: 'linux_x64'
+                  targetPath: $(Pipeline.Workspace)/assets/linux_x64
+                - input: pipelineArtifact
+                  artifactName: 'linux_arm64'
+                  targetPath: $(Pipeline.Workspace)/assets/linux_arm64
+            steps:
+              - task: GitHubRelease@1
+                displayName: 'Create Draft GitHub Release'
+                inputs:
+                  gitHubConnection: $(githubConnectionName)
+                  repositoryName: microsoft/git
+                  tag: '$(tag_name)'
+                  tagSource: userSpecifiedTag
+                  target: '$(tag_sha)'
+                  title: '$(tag_name)'
+                  isDraft: true
+                  addChangeLog: true
+                  assets: |
+                    $(Pipeline.Workspace)/assets/windows_x64/*.exe
+                    $(Pipeline.Workspace)/assets/windows_x64/*.zip
+                    $(Pipeline.Workspace)/assets/windows_arm64/*.exe
+                    $(Pipeline.Workspace)/assets/windows_arm64/*.zip
+                    $(Pipeline.Workspace)/assets/macos_universal/*.pkg
+                    $(Pipeline.Workspace)/assets/macos_universal/*.dmg
+                    $(Pipeline.Workspace)/assets/macos_universal/*.tar.gz
+                    $(Pipeline.Workspace)/assets/linux_x64/*.deb
+                    $(Pipeline.Workspace)/assets/linux_x64/*.tar.gz
+                    $(Pipeline.Workspace)/assets/linux_arm64/*.deb
+                    $(Pipeline.Workspace)/assets/linux_arm64/*.tar.gz


### PR DESCRIPTION
Add a stub pipeline for releases using Azure Pipelines.

The pipeline runs on Microsoft internal images/runners across:
 * Windows x64
 * Windows ARM64
 * macOS
 * Ubuntu x64
 * Ubuntu ARM64

At the start of a run there is a prerequisite stage and pre-build validation. Today this does nothing, and should be updated to:
 * validate the current commit is tagged (annotated), and
 * capture the Git version, tag name and SHA.

Artifacts are uploaded from the build stage, and downloaded into the release stage later for uploading to a draft GitHub release.

ESRP signing to be added later.