### PR TITLE
release-winget: fix PR URL extraction in notice

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -80,6 +80,6 @@ jobs:
           $manifestDirectory = "$PWD\manifests\m\Microsoft\Git\$version"
           $output = & .\wingetcreate.exe submit $manifestDirectory
           Write-Host $output
-          $url = ($output | Select-String -Pattern 'https://github\.com/microsoft/winget-pkgs/pull/\S+' | ForEach-Object { $_.Matches.Value })[0]
+          $url = $output | Select-String -Pattern 'https://github\.com/microsoft/winget-pkgs/pull/\S+' | ForEach-Object { $_.Matches.Value }
           Write-Host "::notice::Submitted ${env:TAG_NAME} to winget as $url"
         shell: powershell


### PR DESCRIPTION
The notice at the end of a successful winget submission says `Submitted v2.53.0.vfs.0.7 to winget as h` instead of the full PR URL. Visible in https://github.com/microsoft/git/actions/runs/24558034627 (run attempt 2).

The root cause is a PowerShell quirk: when `Select-String` produces exactly one match, `ForEach-Object { $_.Matches.Value }` emits a single string rather than a one-element array. The trailing `[0]` then indexes into that string's characters, returning `h` (the first char of `https://...`).

Fix by dropping the `[0]`, since the tightened regex (from PR #843) can only match the one URL we care about.