### PR TITLE
builtin/add: enable fscache around repo_read_index_preload

### DIFF
--- a/builtin/add.c
+++ b/builtin/add.c
@@ -487,13 +487,13 @@ int cmd_add(int argc,
 		 (!(addremove || take_worktree_changes)
 		  ? ADD_CACHE_IGNORE_REMOVAL : 0));
 
+	enable_fscache(0);
 	if (repo_read_index_preload(repo, &pathspec, 0) < 0)
 		die(_("index file corrupt"));
 
 	die_in_unpopulated_submodule(repo->index, prefix);
 	die_path_inside_submodule(repo->index, &pathspec);
 
-	enable_fscache(0);
 	/* We do not really re-read the index but update the up-to-date flags */
 	preload_index(repo->index, &pathspec, 0);
 

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -609,6 +609,6 @@ finish:
 	free(ps_matched);
 	dir_clear(&dir);
 	clear_pathspec(&pathspec);
-	enable_fscache(0);
+	disable_fscache();
 	return exit_status;
 }


### PR DESCRIPTION
Trace2 + GIT_TRACE_FSCACHE evidence on Windows ARM64 (Snapdragon X Elite, ReFS Dev Drive) shows that the heaviest lstat-bound work in `git add` happens inside repo_read_index_preload(), which currently runs *before* enable_fscache() is called. Moving the enable up so the preload phase is wrapped lets the existing batched NtQueryDirectoryFile cache cover the bulk of the lstat traffic. This patch gave me a ~30% performance improvement on a large git repo with a batched add.

Also at the end of cmd_add(): the cleanup site called enable_fscache(0) again instead of disable_fscache(), leaking the refcount. 
