### PR TITLE
C23 `const` fixes

### DIFF
--- a/hook.c
+++ b/hook.c
@@ -130,20 +130,14 @@ static char *get_post_index_change_sentinel_name(struct repository *r)
 {
 	struct strbuf path = STRBUF_INIT;
 	const char *sid = tr2_sid_get();
-	char *slash = strchr(sid, '/');
-
-	/*
-	 * Name is based on top-level SID, so children can indicate that
-	 * the top-level process should run the post-command hook.
-	 */
-	if (slash)
-		*slash = 0;
+	const char *slash = strchrnul(sid, '/');
 
 	/*
 	 * Do not write to hooks directory, as it could be redirected
 	 * somewhere like the source tree.
 	 */
-	repo_git_path_replace(r, &path, "info/index-change-%s.snt", sid);
+	repo_git_path_replace(r, &path, "info/index-change-%.*s.snt",
+			      (int)(slash - sid), sid);
 
 	return strbuf_detach(&path, NULL);
 }

--- a/virtualfilesystem.c
+++ b/virtualfilesystem.c
@@ -148,7 +148,7 @@ int is_included_in_virtualfilesystem(const char *pathname, int pathlen)
 
 static void parent_directory_hashmap_add(struct hashmap *map, const char *pattern, const int patternlen)
 {
-	char *slash;
+	const char *slash;
 	struct virtualfilesystem *vfs;
 
 	/*


### PR DESCRIPTION
This ports the two patches from #900 that were _not_ backports to `vfs-2.54.0`, to appease the C23 `const` rules of `strchr()`/`strrchr()`/`memchr()` (which are now in effect due to Fedora 44 being used in `fedora-breaking-changes`.