### PR TITLE
azure-pipelines: port Linux build jobs from build-git-installers

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -384,11 +384,15 @@ extends:
                             "Parameters": {}
                           }
                         ]
-                # TODO: put final artifacts under $(Build.ArtifactStagingDirectory)/_final
-                - script: |
-                    mkdir -p $(Build.ArtifactStagingDirectory)/_final
-                    cp -R $(Build.ArtifactStagingDirectory)/app/* $(Build.ArtifactStagingDirectory)/_final/
-                  displayName: 'Dummy collect artifacts'
+                - task: Bash@3
+                  displayName: 'Stage Debian package for upload'
+                  inputs:
+                    targetType: inline
+                    script: |
+                      set -euo pipefail
+                      mkdir -p "$(Build.ArtifactStagingDirectory)/_final"
+                      mv "$(Build.ArtifactStagingDirectory)/app/microsoft-git_$(git_version)_$(deb_arch).deb" \
+                        "$(Build.ArtifactStagingDirectory)/_final/"
 
       - stage: release
         displayName: 'Release'

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -315,22 +315,52 @@ extends:
                         tcl tk gettext asciidoc xmlto \
                         libcurl4-gnutls-dev libpcre2-dev zlib1g-dev libexpat-dev \
                         curl ca-certificates
-                # TODO: add tasks to build Git and installers
-                - script: |
-                    echo $(cc_arch)
-                    echo $(deb_arch)
-                    mkdir -p $(Build.ArtifactStagingDirectory)/app
-                    debroot=$(Build.ArtifactStagingDirectory)/pkgroot
-                    mkdir -p $debroot/DEBIAN
-                    cat > $debroot/DEBIAN/control <<CTRL
-                    Package: example
-                    Version: 1.0
-                    Architecture: $(deb_arch)
-                    Maintainer: test
-                    Description: dummy
-                    CTRL
-                    dpkg-deb --build $debroot $(Build.ArtifactStagingDirectory)/app/example_$(deb_arch).deb
-                  displayName: 'Dummy build'
+                - task: Bash@3
+                  displayName: 'Build microsoft-git Debian package'
+                  inputs:
+                    targetType: inline
+                    script: |
+                      set -euo pipefail
+
+                      VERSION="$(git_version)"
+                      # Git's GIT-VERSION-GEN expects .rc rather than -rc
+                      BUILD_VERSION="$(echo "$VERSION" | sed 's/-rc/.rc/g')"
+                      echo "$BUILD_VERSION" >version
+                      make GIT-VERSION-FILE
+
+                      PKGNAME="microsoft-git_${VERSION}_$(deb_arch)"
+                      PKGDIR="$(Build.ArtifactStagingDirectory)/pkgroot"
+                      rm -rf "$PKGDIR"
+                      mkdir -p "$PKGDIR/DEBIAN"
+
+                      DESTDIR="$PKGDIR" make -j"$(nproc)" V=1 DEVELOPER=1 \
+                        USE_LIBPCRE=1 \
+                        USE_CURL_FOR_IMAP_SEND=1 NO_OPENSSL=1 \
+                        NO_CROSS_DIRECTORY_HARDLINKS=1 \
+                        ASCIIDOC8=1 ASCIIDOC_NO_ROFF=1 \
+                        ASCIIDOC='TZ=UTC asciidoc' \
+                        prefix=/usr/local \
+                        gitexecdir=/usr/local/lib/git-core \
+                        libexecdir=/usr/local/lib/git-core \
+                        htmldir=/usr/local/share/doc/git/html \
+                        install install-doc install-html
+
+                      # Based on https://packages.ubuntu.com/xenial/vcs/git
+                      cat >"$PKGDIR/DEBIAN/control" <<CTRL
+                      Package: microsoft-git
+                      Version: $VERSION
+                      Section: vcs
+                      Priority: optional
+                      Architecture: $(deb_arch)
+                      Depends: libcurl3-gnutls, liberror-perl, libexpat1, libpcre2-8-0, perl, perl-modules, zlib1g
+                      Maintainer: GitClient <gitclient@microsoft.com>
+                      Description: Git client built from the https://github.com/microsoft/git repository,
+                        specialized in supporting monorepo scenarios. Includes the Scalar CLI.
+                      CTRL
+
+                      mkdir -p "$(Build.ArtifactStagingDirectory)/app"
+                      dpkg-deb -Zxz --build "$PKGDIR" \
+                        "$(Build.ArtifactStagingDirectory)/app/$PKGNAME.deb"
                 - ${{ if eq(parameters.esrp, true) }}:
                   # ESRP ADO tasks require .NET, so we install it here since the
                   # Linux images do not have it by default.

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -295,7 +295,26 @@ extends:
                     artifactName: '${{ dim.id }}'
               steps:
                 - checkout: self
-                # TODO: add tasks to set up build environment
+                - task: Bash@3
+                  displayName: 'Log build environment'
+                  inputs:
+                    targetType: inline
+                    script: |
+                      lsb_release -a || true
+                      uname -a
+                      id
+                - task: Bash@3
+                  displayName: 'Install build dependencies'
+                  inputs:
+                    targetType: inline
+                    script: |
+                      set -euo pipefail
+                      sudo apt-get update -q
+                      sudo apt-get install -y -q --no-install-recommends \
+                        build-essential \
+                        tcl tk gettext asciidoc xmlto \
+                        libcurl4-gnutls-dev libpcre2-dev zlib1g-dev libexpat-dev \
+                        curl ca-certificates
                 # TODO: add tasks to build Git and installers
                 - script: |
                     echo $(cc_arch)


### PR DESCRIPTION
Start porting the `build-git-installers` workflow from `.github/workflows/build-git-installers.yml` to the Azure Pipelines release pipeline at `.azure-pipelines/release.yml`, replacing the `debsigs` plus Key Vault GPG key flow with ESRP signing along the way. This first slice covers the Linux jobs only; Windows and macOS still ride the placeholder steps that landed earlier on `microsoft/azp`.

The series is small on purpose, four commits so each step can be reviewed in isolation:

1. Add a `container:` clause to the Linux jobs and a matching `container_image` field to each `linux_matrix` entry. The GitHub workflow deliberately builds inside `ubuntu:20.04` and `ubuntu:22.04` containers (the matrix comment about needing a `glibc-217` Node.js build for the older Ubuntu corroborates that the choice is intentional) so that the resulting `.deb` keeps a known glibc ABI floor. Building bare on the 1ES pool image would silently raise that floor, which is the kind of release regression that is hard to notice in CI but obvious to a downstream user on a slightly older Ubuntu.

2. Install the build dependencies, mirroring the package list from `create-linux-unsigned-artifacts`: `build-essential`, `tcl`, `tk`, `gettext`, `asciidoc`, `xmlto`, `libcurl4-gnutls-dev`, `libpcre2-dev`, `zlib1g-dev`, `libexpat-dev`, `curl`, `ca-certificates`. The container runs as root, so no `sudo`. The `DEBIAN_FRONTEND=noninteractive` and `TZ=Etc/UTC` env vars keep `tzdata` from blocking on its interactive timezone prompt. The Node.js shim workaround the GitHub workflow needs in order to satisfy `actions/checkout` does not apply here.

3. Replace the dummy build with the real `make install` plus `dpkg-deb --build`, reusing the same `DESTDIR` layout, the same Make flags (`USE_LIBPCRE`, `USE_CURL_FOR_IMAP_SEND`, `NO_OPENSSL`, `NO_CROSS_DIRECTORY_HARDLINKS`, `ASCIIDOC8`, `ASCIIDOC_NO_ROFF`, `ASCIIDOC='TZ=UTC asciidoc'`), the same `prefix` and `gitexecdir`/`libexecdir`/`htmldir`, the same install targets, and the same `Depends:` line and description. The only intentional content change is the version (now `$(git_version)` wired from `prereqs`) and the architecture (now `$(deb_arch)` from the matrix, dropping the workflow's `dpkg-architecture` round-trip). The workflow's `-j5` switches to `-j$(nproc)`, and `set -ex` to `set -euo pipefail` so an unbound variable or a failed pipeline aborts the job rather than silently producing a broken `.deb`.

4. Stage just `microsoft-git_<version>_<arch>.deb` into `$(Build.ArtifactStagingDirectory)/_final/`, naming the file precisely so that "ESRP signed something else" turns into a missing-file error rather than a silent wrong-artifact upload. The dummy collect step's `cp -R app/*` would have started silently shipping the `pkgroot/` staging tree alongside the `.deb` once the real build landed.

The `create-linux-artifacts` job from the GitHub workflow (the one that pulls a GPG key from Key Vault, imports it, monkey-patches `debsigs` to drop `--openpgp`, then signs the `.deb`) is intentionally not ported. ESRP's `LinuxSign` operation with key code `CP-453387-Pgp` is already wired into the dummy job and produces an equivalent signed `.deb` without the Key Vault round-trip; that is exactly the "ESRP instead of the custom sign tool based procedure" the conversion is supposed to deliver.

A few items deliberately out of scope here. Post-sign verification: the original workflow ran `debsigs --verify --check` after signing, and while ESRP `LinuxSign` is presumed equivalent, an actual install/runtime validation on a target Ubuntu should land before any release cutover. The release stage's `GitHubRelease@1` task still references `linux_*/.tar.gz` patterns we do not produce, so either the asset list needs to be trimmed or a tarball job needs to land alongside the `.deb` job. The `ubuntu:20.04` / `ubuntu:22.04` tags resolve to Docker Hub, and if 1ES SDL precludes that, swapping to the corresponding `mcr.microsoft.com` tags is a one-line follow-up. And of course the Windows and macOS jobs are still on the placeholder steps from `microsoft/azp`; porting those is the next slice.

Local validation: a small Node.js script (Microsoft's published `azure-pipelines-vscode/service-schema.json` plus `js-yaml` and `ajv`) confirms the YAML parses cleanly. The schema reports a fixed set of deviations around `extends:` 1ES Pipeline Templates and boolean parameter defaults that the schema does not currently model; none of them reflect real problems. Not run end-to-end on a 1ES pool yet.

Marked as draft for that reason: the YAML compiles, the logic mirrors a workflow that has been running in production for a long time, but the pipeline itself has not yet been triggered against the 1ES Linux pool.
