### PR TITLE
build: tolerate use of _Generic from glibc 2.43 with Clang

### DIFF
--- a/config.mak.dev
+++ b/config.mak.dev
@@ -21,7 +21,7 @@ endif
 endif
 
 ifneq ($(uname_S),FreeBSD)
-ifneq ($(or $(filter gcc6,$(COMPILER_FEATURES)),$(filter clang7,$(COMPILER_FEATURES))),)
+ifneq ($(filter gcc6,$(COMPILER_FEATURES)),)
 ifndef USE_MIMALLOC
 DEVELOPER_CFLAGS += -std=gnu99
 endif
@@ -29,6 +29,9 @@ endif
 else
 # FreeBSD cannot limit to C99 because its system headers unconditionally
 # rely on C11 features.
+#
+# Clang cannot limit to C99 when using glibc 2.43 because its system headers
+# depend on the _Generic C11 feature. This works with GCC though.
 endif
 
 DEVELOPER_CFLAGS += -Wdeclaration-after-statement

--- a/meson.build
+++ b/meson.build
@@ -873,6 +873,12 @@ if get_option('warning_level') in ['2','3', 'everything'] and compiler.get_argum
       libgit_c_args += cflag
     endif
   endforeach
+
+  # Clang generates warnings when compiling glibc 2.43 because of the use of
+  # _Generic.
+  if compiler.get_id() == 'clang'
+    libgit_c_args += '-Wno-c11-extensions'
+  endif
 endif
 
 if get_option('breaking_changes')


### PR DESCRIPTION
Same fix as #6233 in `git-for-windows/git`, cherry-picked here so the corresponding `microsoft/git` branch builds again on Ubuntu 26.04. The `ubuntu:rolling` containers used by `linux-{asan-ubsan,sha256,reftable}` now ship glibc 2.43, which puts `_Generic` into `<sys/cdefs.h>`; Clang under `-std=gnu99 -Werror` flags it as a C11 extension.

Picking up Patrick Steinhardt's upstream-bound fix from https://lore.kernel.org/git/20260505-b4-pks-ci-tolerate-glibc-generic-v1-1-5786386fe512@pks.im/ ahead of its eventual merge (no list movement so far, not yet in `seen`). The diff conflicts with the `ifndef USE_MIMALLOC` wrap that this fork inherits from `git-for-windows/git`'s `fe5704a3695c "mimalloc: offer a build-time option to enable it"`; the resolution preserves that wrap on the `gcc6`-only branch surviving Patrick's patch. `meson.build` auto-merged.
