### PR TITLE
Update to latest EsrpClientTool task and allow version override for testing

### DIFF
--- a/.azure-pipelines/esrp/windows/setup.yml
+++ b/.azure-pipelines/esrp/windows/setup.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
 
 steps:
-  - task: EsrpClientTool@4
+  - task: EsrpClientTool@5
     name: esrpinstall
     displayName: 'Install ESRP client'
   - task: AzureCLI@2

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -18,6 +18,10 @@ parameters:
     type: boolean
     default: false # TODO: change default to true after testing
     displayName: 'Enable GitHub release publishing'
+  - name: 'versionOverride'
+    type: string
+    default: '-'
+    displayName: 'Version override (release publishing is skipped if set)'
 
 #
 # 1ES Pipeline Templates do not allow using a matrix strategy so we create
@@ -121,12 +125,29 @@ extends:
               - checkout: self
                 fetchDepth: 0
                 fetchTags: true
-              - task: Bash@3
-                displayName: 'Resolve version and tag information'
-                name: info
-                inputs:
-                  targetType: filePath
-                  filePath: .azure-pipelines/scripts/resolve-version.sh
+              - ${{ if or(eq(parameters.versionOverride, ''), eq(parameters.versionOverride, '-')) }}:
+                - task: Bash@3
+                  displayName: 'Resolve version and tag information'
+                  name: info
+                  inputs:
+                    targetType: filePath
+                    filePath: .azure-pipelines/scripts/resolve-version.sh
+              - ${{ if and(ne(parameters.versionOverride, ''), ne(parameters.versionOverride, '-')) }}:
+                - task: Bash@3
+                  displayName: 'Set version override information'
+                  name: info
+                  inputs:
+                    targetType: inline
+                    script: |
+                      tag_sha=$(git rev-parse HEAD)
+                      echo "##vso[task.logissue type=warning]Using version override: ${{ parameters.versionOverride }}. Release publishing will be skipped."
+                      echo "Git version: ${{ parameters.versionOverride }}"
+                      echo "Tag name: untagged"
+                      echo "Tag SHA: ${tag_sha}"
+                      echo "##vso[task.setvariable variable=git_version;isOutput=true;isReadOnly=true]${{ parameters.versionOverride }}"
+                      echo "##vso[task.setvariable variable=tag_name;isOutput=true;isReadOnly=true]untagged"
+                      echo "##vso[task.setvariable variable=tag_sha;isOutput=true;isReadOnly=true]${tag_sha}"
+                      echo "##vso[build.updatebuildnumber][UNTAGGED] ${tag_sha} (${BUILD_BUILDNUMBER:-unknown})"
 
       - stage: build
         displayName: 'Build'
@@ -956,7 +977,7 @@ extends:
               - ${{ each dim in parameters.linux_matrix }}:
                 - validate_${{ dim.id }}
             displayName: 'Publish GitHub release'
-            condition: and(succeeded(), eq('${{ parameters.github }}', true))
+            condition: and(succeeded(), eq('${{ parameters.github }}', true), or(eq('${{ parameters.versionOverride }}', ''), eq('${{ parameters.versionOverride }}', '-')))
             pool:
               name: GitClientPME-1ESHostedPool-intel-pc
               image: ubuntu-x86_64-ado1es


### PR DESCRIPTION
Task version 4 was using an out of date Node.JS version. Version 5 is the latest.
[Test run](https://dev.azure.com/mseng/1ES/_build/results?buildId=31507290) of the pipeline works.

Whilst we're at it, let's add a way to override the Git version so we can test without pushing an annotated tag. Untagged builds cannot publish to GitHub.

Builds with the override show like this:
<img width="786" height="62" alt="image" src="https://github.com/user-attachments/assets/4a3b3774-d108-4d17-b4bf-e4d8bca8677c" />
<img width="543" height="84" alt="image" src="https://github.com/user-attachments/assets/acb1acf3-6462-4a9a-9f96-182beed681db" />
<img width="831" height="227" alt="image" src="https://github.com/user-attachments/assets/1f4d5150-84b2-4a11-8aae-0eecbf7f9ed8" />
