### PR TITLE
Add SDL Baseline from release build

### DIFF
--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -1,0 +1,19 @@
+## DO NOT MODIFY THIS FILE MANUALLY. This is part of auto-baselining from 1ES Pipeline Templates. Go to [https://aka.ms/1espt-autobaselining] for more details.
+
+pipelines:
+  22503:
+    retail:
+      source:
+        eslint:
+          lastModifiedDate: 2026-05-29
+        psscriptanalyzer:
+          lastModifiedDate: 2026-05-29
+        armory:
+          lastModifiedDate: 2026-05-29
+        accessibilityinsights:
+          lastModifiedDate: 2026-05-29
+      binary:
+        binskim:
+          lastModifiedDate: 2026-05-29
+        spotbugs:
+          lastModifiedDate: 2026-05-29


### PR DESCRIPTION
Updated for https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_build?definitionId=22503 by using baselines generated in https://dev.azure.com/mseng/708e929f-6bd5-415a-8daf-25b1dac08dd8/_build/results?buildId=31571809

Note: the Merlin-bot failed to create this PR. We had closed the [previous PR](https://github.com/microsoft/git/pull/926) that had incorrectly generated a bad baseline. The bot managed to push this branch however.