### PR TITLE
release: drop Azure CLI install on Windows/ARM64

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -217,19 +217,6 @@ extends:
                   displayName: 'Add Git Bash to PATH'
                   inputs:
                     filename: ./.azure-pipelines/scripts/windows/setup-git-bash.cmd
-                # Install Azure CLI on arm64 (not pre-installed on these agents)
-                - ${{ if eq(dim.poolArch, 'arm64') }}:
-                  - powershell: |
-                      $ProgressPreference = 'SilentlyContinue'
-                      $msi = "$env:TEMP\AzureCLI.msi"
-                      Write-Host "Downloading Azure CLI (x64)..."
-                      Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile $msi
-                      Write-Host "Installing Azure CLI..."
-                      Start-Process msiexec.exe -ArgumentList "/i", $msi, "/quiet", "/norestart" -Wait
-                      $azPath = "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
-                      Write-Host "##vso[task.prependpath]$azPath"
-                      Write-Host "Azure CLI installed."
-                    displayName: 'Install Azure CLI (x64 on ARM64)'
                 # Install VS 2022 Build Tools on x64 so cv2pdb-strip can locate
                 # mspdb140.dll. We do not need to do this on ARM64 since we use
                 # clang's llvm-strip there instead.


### PR DESCRIPTION
The Windows ARM64 images now include the Azure CLI so we do not need to install it manually on each run. This brings ARM64 in line with x86_64, and saves 1-2 mins per run.

Port of https://github.com/microsoft/git/pull/930 into `vfs-2.54.0`