### PR TITLE
fixup! gvfs-helper: run prefetch index-pack in parallel

### DIFF
--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2447,6 +2447,7 @@ static int prefetch_get_next_task(struct child_process *cp,
 	strvec_pushl(&cp->args, "-o", entry->temp_path_idx.buf, NULL);
 	strvec_push(&cp->args, entry->temp_path_pack.buf);
 	cp->no_stdin = 1;
+	cp->no_stdout = 1;
 
 	return 1;
 }

--- a/t/t5797-gvfs-helper-prefetch-threads.sh
+++ b/t/t5797-gvfs-helper-prefetch-threads.sh
@@ -21,6 +21,7 @@ do_prefetch_all () {
 		--no-progress \
 		prefetch >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 3 &&
 	verify_prefetch_keeps 1200000000
 }
@@ -34,6 +35,7 @@ do_prefetch_since () {
 		--no-progress \
 		prefetch --since="1000000000" >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 2 &&
 	verify_prefetch_keeps 1200000000
 }
@@ -47,6 +49,7 @@ do_prefetch_up_to_date () {
 		--no-progress \
 		prefetch --since="1000000000" >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 2 &&
 	verify_prefetch_keeps 1200000000 &&
 
@@ -57,6 +60,7 @@ do_prefetch_up_to_date () {
 		--no-progress \
 		prefetch >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 0 &&
 	verify_prefetch_keeps 1200000000
 }


### PR DESCRIPTION
When adding the `gvfs.prefetchThreads` config option in #876, I didn't realize that the child `git index-pack` processes would output the hashes of the pack contents.

This makes the output quiet. It's committed as a `fixup!` so it can be squashed in the `vfs-2.55.0` release (or this PR can be repeated on that branch and squashed in 2.56.0).

The tests check stderr because the parallel process runner sets `stdout_to_stderr` so the previous behavior showed up over `stderr` from the top level process.

* [X] This change only applies to interactions with Azure DevOps and the
      GVFS Protocol.
