### PR TITLE
Integrate fix that was needed to release v2.54.0.vfs.0.4

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -290,6 +290,8 @@ extends:
                 - task: Bash@3
                   displayName: 'Build mingw-w64-git package'
                   env:
+                    # Git v2.55 still builds without Rust.
+                    NO_RUST: ForNow
                     # The mingw-w64-git build is heavy on parallel work
                     # that the underlying compile (and especially the
                     # contrib + doc + i18n + perl-script generation


### PR DESCRIPTION
Since Git for Windows/MSYS2 changed their `mingw-w64-git/PKGBUILD`, we now need to be explicit about not building the Rust bits.