### PR TITLE
vfs-2.55.0: port PRs recently merged into vfs-2.54.0

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -1192,13 +1192,13 @@ extends:
                       version: '8.x'
                   - template: .azure-pipelines/esrp/sign.yml@self
                     parameters:
-                      displayName: 'Example sign Debian package'
+                      displayName: 'Sign Debian package'
                       folderPath: '$(Build.ArtifactStagingDirectory)/app'
                       pattern: '**/*.deb'
                       inlineOperation: |
                         [
                           {
-                            "KeyCode": "CP-453387-Pgp",
+                            "KeyCode": "CP-500207-Pgp",
                             "OperationCode": "LinuxSign",
                             "ToolName": "sign",
                             "ToolVersion": "1.0",

--- a/README.md
+++ b/README.md
@@ -122,44 +122,40 @@ To download and validate the signature of this package, run the following:
 sudo apt-get install -y curl debsig-verify
 
 # Download public key signature file
-curl -s https://api.github.com/repos/microsoft/git/releases/latest \
-| grep -E 'browser_download_url.*msft-git-public.asc' \
-| cut -d : -f 2,3 \
-| tr -d \" \
-| xargs -I 'url' curl -L -o msft-git-public.asc 'url'
+curl -Os https://packages.microsoft.com/keys/microsoft-2025.asc
 
 # De-armor public key signature file
-gpg --output msft-git-public.gpg --dearmor msft-git-public.asc
+gpg --output microsoft-2025.gpg --dearmor microsoft-2025.asc
 
-# Note that the fingerprint of this key is "B8F12E25441124E1", which you can
+# Note that the fingerprint of this key is "EE4D7792F748182B", which you can
 # determine by running:
-gpg --show-keys msft-git-public.asc | head -n 2 | tail -n 1 | tail -c 17
+gpg --show-keys microsoft-2025.asc | head -n 2 | tail -n 1 | tail -c 17
 
 # Copy de-armored public key to debsig keyring folder
-sudo mkdir /usr/share/debsig/keyrings/B8F12E25441124E1
-sudo mv msft-git-public.gpg /usr/share/debsig/keyrings/B8F12E25441124E1/
+sudo mkdir /usr/share/debsig/keyrings/EE4D7792F748182B
+sudo mv microsoft-2025.gpg /usr/share/debsig/keyrings/EE4D7792F748182B/
 
 # Create an appropriate policy file
-sudo mkdir /etc/debsig/policies/B8F12E25441124E1
+sudo mkdir /etc/debsig/policies/EE4D7792F748182B
 cat > generic.pol << EOL
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "https://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
-  <Origin Name="Microsoft Git" id="B8F12E25441124E1" Description="Microsoft Git public key"/>
+  <Origin Name="Microsoft Git" id="EE4D7792F748182B" Description="Microsoft Git public key"/>
   <Selection>
-    <Required Type="origin" File="msft-git-public.gpg" id="B8F12E25441124E1"/>
+    <Required Type="origin" File="microsoft-2025.gpg" id="EE4D7792F748182B"/>
   </Selection>
   <Verification MinOptional="0">
-    <Required Type="origin" File="msft-git-public.gpg" id="B8F12E25441124E1"/>
+    <Required Type="origin" File="microsoft-2025.gpg" id="EE4D7792F748182B"/>
   </Verification>
 </Policy>
 EOL
 
-sudo mv generic.pol /etc/debsig/policies/B8F12E25441124E1/generic.pol
+sudo mv generic.pol /etc/debsig/policies/EE4D7792F748182B/generic.pol
 
-# Download Debian package
+# Download Debian package (substitute `amd64` with `arm64` on ARM machines)
 curl -s https://api.github.com/repos/microsoft/git/releases/latest \
-| grep "browser_download_url.*deb" \
+| grep "browser_download_url.*amd64.deb" \
 | cut -d : -f 2,3 \
 | tr -d \" \
 | xargs -I 'url' curl -L -o msft-git.deb 'url'

--- a/gvfs-helper.c
+++ b/gvfs-helper.c
@@ -2447,6 +2447,7 @@ static int prefetch_get_next_task(struct child_process *cp,
 	strvec_pushl(&cp->args, "-o", entry->temp_path_idx.buf, NULL);
 	strvec_push(&cp->args, entry->temp_path_pack.buf);
 	cp->no_stdin = 1;
+	cp->no_stdout = 1;
 
 	return 1;
 }

--- a/t/t5797-gvfs-helper-prefetch-threads.sh
+++ b/t/t5797-gvfs-helper-prefetch-threads.sh
@@ -21,6 +21,7 @@ do_prefetch_all () {
 		--no-progress \
 		prefetch >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 3 &&
 	verify_prefetch_keeps 1200000000
 }
@@ -34,6 +35,7 @@ do_prefetch_since () {
 		--no-progress \
 		prefetch --since="1000000000" >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 2 &&
 	verify_prefetch_keeps 1200000000
 }
@@ -47,6 +49,7 @@ do_prefetch_up_to_date () {
 		--no-progress \
 		prefetch --since="1000000000" >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 2 &&
 	verify_prefetch_keeps 1200000000 &&
 
@@ -57,6 +60,7 @@ do_prefetch_up_to_date () {
 		--no-progress \
 		prefetch >OUT.output 2>OUT.stderr &&
 
+	test_must_be_empty OUT.stderr &&
 	verify_received_packfile_count 0 &&
 	verify_prefetch_keeps 1200000000
 }


### PR DESCRIPTION
This ports the PRs #941 and #946 to vfs-2.55.0.

The [v2.54.0.vfs.0.4 release](https://github.com/microsoft/git/releases/tag/v2.54.0.vfs.0.4) also included #932, #934 and #947, whose changes were already integrated into the `vfs-2.55.0` branch.