### PR TITLE
More release script fixes

### DIFF
--- a/.github/release-homebrew.sh
+++ b/.github/release-homebrew.sh
@@ -100,7 +100,9 @@ sha256:*) sha256=${digest#sha256:} ;;
 esac
 
 # Enforce 64 lowercase hex chars without spawning grep.
-	*[!0-9a-f]*|"")
+case "$sha256" in
+*[!0-9a-f]*|"")
+       die "asset digest is not lowercase hex: $sha256" ;;
 esac
 test ${#sha256} -eq 64 ||
 	die "asset digest is not 64 chars long: $sha256"

--- a/.github/release-homebrew.sh
+++ b/.github/release-homebrew.sh
@@ -153,6 +153,7 @@ echo "==> Pushed:    $(git log -1 --format='%h %s')"
 pr_url=$(gh pr create \
 	--repo "$REPO" \
 	--head "$BRANCH" \
-	--title "$TITLE")
+	--title "$TITLE" \
+	--body "See https://github.com/microsoft/git/releases/tag/$TAG_NAME")
 
 echo "==> Created:   $pr_url"

--- a/.github/release-homebrew.sh
+++ b/.github/release-homebrew.sh
@@ -32,7 +32,7 @@ die () {
 	exit 1
 }
 
-case "$1" in
+case "${1-}" in
 --force) force=t; shift;;
 *) force=;;
 esac

--- a/.github/release-vfsforgit.sh
+++ b/.github/release-vfsforgit.sh
@@ -26,7 +26,7 @@ die () {
 	exit 1
 }
 
-case "$1" in
+case "${1-}" in
 --force) force=t; shift;;
 *) force=;;
 esac

--- a/.github/release-winget.sh
+++ b/.github/release-winget.sh
@@ -49,7 +49,7 @@ Linux)
 	;;
 esac
 
-case "$1" in
+case "${1-}" in
 --force) force=t; shift;;
 *) force=;;
 esac

--- a/.github/release-winget.sh
+++ b/.github/release-winget.sh
@@ -70,8 +70,10 @@ version=$(printf '%s' "${TAG_NAME#v}" | sed 's/vfs\.//')
 echo "==> Version:   $version"
 
 workdir=$(mktemp -d)
+origdir="$(pwd)"
 success=0
 cleanup () {
+	cd "$origdir"
 	if [ "$success" = 1 ]; then
 		rm -rf "$workdir"
 	else


### PR DESCRIPTION
After promoting v2.54.0.vfs.0.5 to a full release, I ran the scripts (which were formerly three convenient GitHub workflows, see #952), and they all failed, requiring these here fixes.