### PR TITLE
reset --mixed: clear skip-worktree for all changed entries in VFS mode

### DIFF
--- a/builtin/reset.c
+++ b/builtin/reset.c
@@ -173,18 +173,24 @@ static void update_index_from_diff(struct diff_queue_struct *q,
 		struct checkout state = CHECKOUT_INIT;
 
 		/*
-		 * When using the virtual filesystem feature, the cache entries that are
-		 * added here will not have the skip-worktree bit set.
+		 * When using the virtual filesystem feature, all entries
+		 * being reset should have skip-worktree cleared so that
+		 * refresh_index will compare them against the working tree
+		 * and report them as modified.
 		 *
-		 * Without this code there is data that is lost because the files that
-		 * would normally be in the working directory are not there and show as
-		 * deleted for the next status or in the case of added files just disappear.
-		 * We need to create the previous version of the files in the working
-		 * directory so that they will have the right content and the next
-		 * status call will show modified or untracked files correctly.
+		 * For files that don't exist on disk (virtual/placeholder),
+		 * we also need to write the pre-reset content to disk so
+		 * that they show as modified rather than deleted.
+		 *
+		 * For files that already exist on disk (hydrated), the
+		 * on-disk content is the pre-reset version, so no write
+		 * is needed — just clearing skip-worktree is sufficient.
 		 */
-		if (core_virtualfilesystem && !file_exists(two->path))
-		{
+		if (!core_virtualfilesystem)
+			; /* not in virtual filesystem mode; nothing to special-case */
+		else if (file_exists(two->path))
+			respect_skip_worktree = 0; /* hydrated: on-disk content is already the pre-reset version */
+		else {
 			respect_skip_worktree = 0;
 			pos = index_name_pos(the_repository->index, two->path, strlen(two->path));
 

--- a/t/t1093-virtualfilesystem.sh
+++ b/t/t1093-virtualfilesystem.sh
@@ -483,4 +483,101 @@ test_expect_success MINGW,FSMONITOR_DAEMON 'virtualfilesystem hook disables buil
 	test_must_fail git fsmonitor--daemon status
 '
 
+# reset --mixed tests for virtual filesystem mode
+#
+# Background: reset --mixed moves HEAD and updates the index to match the
+# target commit, but leaves the working tree untouched. In a normal repo,
+# files whose index entry changed show as "unstaged changes" because the
+# working tree still has the pre-reset content.
+#
+# In VFS mode, most files have skip-worktree set and don't exist on disk.
+# The VFS-specific code in update_index_from_diff() handles this:
+#
+#   - Files NOT on disk (virtual/placeholder): git writes the pre-reset
+#     content to disk via checkout_entry() and clears skip-worktree, so
+#     they correctly appear as "modified" in status.
+#
+#   - Files already on disk (hydrated by a previous read): their on-disk
+#     content is still the pre-reset version. Skip-worktree must also be
+#     cleared for these so refresh_index() compares them against the new
+#     index entry and reports them as modified.
+#
+# A bug existed where hydrated files (file_exists returns true) kept
+# skip-worktree set after the reset, making them invisible to status.
+
+test_expect_success 'reset --mixed reports hydrated files as modified in VFS mode' '
+	clean_repo &&
+
+	# Create a second commit that modifies dir1/file1.txt
+	git -c core.virtualfilesystem= checkout -b reset-hydrated-test &&
+	echo "modified content" >dir1/file1.txt &&
+	git -c core.virtualfilesystem= add dir1/file1.txt &&
+	git -c core.virtualfilesystem= commit -m "modify dir1/file1.txt" &&
+
+	# VFS hook: nothing in ModifiedPaths — all files get skip-worktree
+	write_script .git/hooks/virtualfilesystem <<-\EOF &&
+		printf ""
+	EOF
+
+	# dir1/file1.txt is on disk with the new commit content (simulates
+	# a hydrated file that was read but never written to ModifiedPaths).
+	# file_exists() will return true for it.
+	test_path_is_file dir1/file1.txt &&
+
+	# reset --mixed to parent: index moves to old content, working tree
+	# keeps new content. dir1/file1.txt should show as modified in
+	# the reset output because skip-worktree is cleared during the
+	# reset so refresh_index detects the mismatch.
+	git reset HEAD~1 >actual_stdout &&
+	grep "dir1/file1.txt" actual_stdout
+'
+
+test_expect_success 'reset --mixed reports non-hydrated files as modified in VFS mode' '
+	clean_repo &&
+
+	# Create a second commit that modifies dir1/file1.txt
+	git -c core.virtualfilesystem= checkout -b reset-virtual-test &&
+	echo "modified content" >dir1/file1.txt &&
+	git -c core.virtualfilesystem= add dir1/file1.txt &&
+	git -c core.virtualfilesystem= commit -m "modify dir1/file1.txt" &&
+
+	# VFS hook: nothing in ModifiedPaths
+	write_script .git/hooks/virtualfilesystem <<-\EOF &&
+		printf ""
+	EOF
+
+	# Remove the file from disk to simulate a non-hydrated virtual file.
+	# file_exists() will return false for it.
+	rm -f dir1/file1.txt &&
+
+	# reset --mixed to parent: git should write pre-reset content to
+	# disk and clear skip-worktree, reporting the file as modified.
+	git reset HEAD~1 >actual_stdout &&
+	grep "dir1/file1.txt" actual_stdout &&
+
+	# The pre-reset content should have been written to disk
+	test_path_is_file dir1/file1.txt
+'
+
+test_expect_success 'reset --mixed with hydrated file leaves other skip-worktree intact' '
+	clean_repo &&
+
+	# Create a commit that modifies dir1/file1.txt but NOT dir2/file1.txt
+	git -c core.virtualfilesystem= checkout -b reset-partial-test &&
+	echo "modified content" >dir1/file1.txt &&
+	git -c core.virtualfilesystem= add dir1/file1.txt &&
+	git -c core.virtualfilesystem= commit -m "modify dir1/file1.txt only" &&
+
+	# VFS hook: nothing in ModifiedPaths
+	write_script .git/hooks/virtualfilesystem <<-\EOF &&
+		printf ""
+	EOF
+
+	# Reset: only dir1/file1.txt changed between HEAD and HEAD~1.
+	# dir2/file1.txt should not appear in the output at all.
+	git reset HEAD~1 >actual_stdout &&
+	grep "dir1/file1.txt" actual_stdout &&
+	! grep "dir2/file1.txt" actual_stdout
+'
+
 test_done


### PR DESCRIPTION
This is a companion of #935, porting the changes from vfs-2.54.0 to vfs-2.55.0.

## Problem

In virtual filesystem (VFS/GVFS) mode, `reset --mixed` fails to report hydrated files as modified.

A **hydrated file** is one that has been read (e.g., via `blame` or `cat-file`) and materialized on disk by ProjFS, but not modified — so it is not in GVFS's ModifiedPaths database and retains the `skip-worktree` bit in the index.

### Reproduction

1. `gvfs clone` a repo
2. `git blame Readme.md` — hydrates the file (ProjFS materializes content on disk)
3. `git reset --mixed HEAD~1` (where `Readme.md` differs between HEAD and HEAD~1)
4. **Expected:** `Readme.md` appears in reset output and `git status` shows it as modified
5. **Actual:** `Readme.md` is missing from output; `git status` reports clean

### Root cause

The VFS-specific code in `update_index_from_diff()` uses `file_exists()` to decide whether to clear `skip-worktree`:

- **Files NOT on disk** (virtual/placeholder): `file_exists()` returns false → `skip-worktree` cleared, pre-reset content written to disk via `checkout_entry()` → correctly reported as modified ✓
- **Files on disk** (hydrated): `file_exists()` returns true → `skip-worktree` left set → `refresh_index()` skips the entry → invisible to status ✗

The original code assumed that if a file exists on disk, it must already be tracked properly. But hydrated-but-not-modified files exist on disk with stale content and are NOT in ModifiedPaths.

## Fix

Always clear `skip-worktree` (`respect_skip_worktree = 0`) for all entries processed by `update_index_from_diff()` when VFS mode is active. The `file_exists()` check now only controls whether pre-reset content needs to be written to disk — it no longer gates the skip-worktree decision.

After the reset, GVFS's `GitIndexParser` detects the cleared skip-worktree bits via the `post-index-change` hook and adds affected paths to ModifiedPaths, so subsequent git commands also see them correctly.

### Before (buggy)
```c
if (core_virtualfilesystem && !file_exists(two->path))
{
    respect_skip_worktree = 0;      // only for missing files
    // ... write content to disk ...
}
```

### After (fixed)
```c
if (core_virtualfilesystem)
{
    respect_skip_worktree = 0;      // for ALL changed entries

    if (!file_exists(two->path))    // only write content for missing files
    {
        // ... write content to disk ...
    }
}
```

## Testing

- 3 new tests in `t1093-virtualfilesystem.sh`:
  - **Hydrated file**: file exists on disk, should appear in reset output
  - **Non-hydrated file**: file missing from disk, should be written and appear in output
  - **Partial reset**: unchanged files retain skip-worktree
- Verified manually against a real GVFS enlistment: GVFS and control repo now produce identical output (224 modified files including `Readme.md`)
- All 25 existing `t1093` tests pass
