### PR TITLE
Fix performance regression in v2.55 related to having many packfiles

### DIFF
--- a/packfile.c
+++ b/packfile.c
@@ -103,11 +103,12 @@ void packfile_list_prepend(struct packfile_list *list, struct packed_git *pack)
 		list->tail = entry;
 }
 
-void packfile_list_append(struct packfile_list *list, struct packed_git *pack)
+void packfile_list_append(struct packfile_list *list, struct packed_git *pack,
+			  int is_new)
 {
 	struct packfile_list_entry *entry;
 
-	entry = packfile_list_remove_internal(list, pack);
+	entry = is_new ? NULL : packfile_list_remove_internal(list, pack);
 	if (!entry) {
 		entry = xmalloc(sizeof(*entry));
 		entry->pack = pack;
@@ -865,7 +866,7 @@ void packfile_store_add_pack(struct packfile_store *store,
 	if (pack->pack_fd != -1)
 		pack_open_fds++;
 
-	packfile_list_append(&store->packs, pack);
+	packfile_list_append(&store->packs, pack, 1);
 	strmap_put(&store->packs_by_path, pack->pack_name, pack);
 }
 

--- a/packfile.h
+++ b/packfile.h
@@ -66,7 +66,7 @@ struct packfile_list_entry {
 void packfile_list_clear(struct packfile_list *list);
 void packfile_list_remove(struct packfile_list *list, struct packed_git *pack);
 void packfile_list_prepend(struct packfile_list *list, struct packed_git *pack);
-void packfile_list_append(struct packfile_list *list, struct packed_git *pack);
+void packfile_list_append(struct packfile_list *list, struct packed_git *pack, int is_new);
 
 /*
  * Find the pack within the "packs" list whose index contains the object

--- a/t/perf/p5303-many-packs.sh
+++ b/t/perf/p5303-many-packs.sh
@@ -141,4 +141,8 @@ test_perf "load 10,000 packs" '
 	git rev-parse --verify "HEAD^{commit}"
 '
 
+test_perf "abbreviate with 10,000 packs" '
+	git rev-parse --short HEAD
+'
+
 test_done


### PR DESCRIPTION
When there are many packfiles in the repository (or in an alternate of it), a regression introduced into Git v2.53 introduced complexity quadratic in the number of the packfiles. In one instance, causing a slow-down of a simple `git rev-parse --short HEAD` (as used in `GIT_PS1`) from 0.4s to 4.5s. Let's fix that by avoiding the quadratic behavior in the most common case: loading the packfiles afresh.

In another (internally-reported) instance, clone times that increased to over 30 minutes were reported to reduce to under 2 minutes with this patch.

This closes #970.