### PR TITLE
Fix macOS dependency install for release builds

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -728,6 +728,9 @@ extends:
                         "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
                       arch -x86_64 /usr/local/bin/brew install gettext
 
+                      # Ensure native Homebrew (arm64) is up-to-date beforehand.
+                      HOMEBREW_NO_AUTO_UPDATE='' brew update
+
                       # Native (arm64) build dependencies.
                       brew install automake asciidoc xmlto docbook
                       brew link --force gettext


### PR DESCRIPTION
Ensure that the native (ARM64) Homebrew on the Mac build jobs is up-to-date before trying to install dependencies using it.
    
If we are very unlucky, we may have an older version of Homebrew installed on the Azure Pipelines image that has issues, or be trying to install a formula that makes use of new functions in the DSL which are not in this version of `brew`.

Since we always download and install the x86_64 Homebrew fresh we don't need to run `brew update` for the x86_64 install; only the native one.