### PR TITLE
ci: bump debian-11 job to debian-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,9 +411,9 @@ jobs:
         # A RHEL 8 compatible distro.  Supported until 2029-05-31.
         - jobname: almalinux-8
           image: almalinux:8
-        # Supported until 2026-08-31.
-        - jobname: debian-11
-          image: debian:11
+        # Supported until 2028-06-30.
+        - jobname: debian-12
+          image: debian:12
     env:
       jobname: ${{matrix.vector.jobname}}
       CC: ${{matrix.vector.cc}}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,9 +71,9 @@ test:linux:
       # A RHEL 8 compatible distro.  Supported until 2029-05-31.
       - jobname: almalinux-8
         image: almalinux:8
-      # Supported until 2026-08-31.
-      - jobname: debian-11
-        image: debian:11
+      # Supported until 2028-06-30.
+      - jobname: debian-12
+        image: debian:12
   artifacts:
     paths:
       - t/failed-test-artifacts


### PR DESCRIPTION
Debian 11 just recently went out of its LTS period, and is unmaintained by the project (there is "Extended LTS", but it is a paid service provided by a third party).

The point of the debian-11 job was to cover older releases in the LTS state, per ac112fd4f0 (Add additional CI jobs to avoid accidental breakage, 2024-10-31). Bumping to debian-12 will cover us there for the next 2 years.

This fixes [this kind of error](https://github.com/microsoft/git/actions/runs/34140012025/job/102061159993#step:4:28):

> Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
> Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]
> Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
> Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
> Get:5 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
> Reading package lists...
> E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 15h 16min 10s). Updates for this repository will not be applied.
> Error: Process completed with exit code 100.

* [x] This is an early version of work already under review upstream.